### PR TITLE
fix: harden wifi_llapi runtime alignment guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,10 @@ Wifi_llapi reporting guidance:
 
 3. `testpilot wifi-llapi build-template-report --source-xlsx <path>` is a build/audit path. `testpilot run wifi_llapi` must not depend on raw source workbooks.
 4. `wifi_llapi` runtime alignment treats `(source.object, source.api)` as the canonical lookup key into the checked-in template workbook; `D###`, `source.row`, and matching `id` fragments are derived metadata and may be auto-corrected during `testpilot run wifi_llapi`.
-5. `testpilot run wifi_llapi` may rename case files and rewrite `source.row` / `id` in-place. Review and commit those case diffs together with the corresponding runtime artifacts.
-6. Alignment and audit are separate responsibilities: runtime alignment fixes metadata drift only; audit mode remains the place to change `name`, `steps`, `pass_criteria`, `source.object`, `source.api`, or `aliases`.
+5. If one `(source.object, source.api)` pair maps to multiple template rows, runtime alignment must block that family instead of guessing a row; follow-up cleanup uses the surfaced candidate template rows.
+6. `testpilot run wifi_llapi` may rename case files and rewrite `source.row` / `id` in-place. Review and commit those case diffs together with the corresponding runtime artifacts.
+7. Runtime artifact bundles and JSON `alignment_summary.blocked_details` must expose blocked ambiguous families with their candidate template rows so maintainers can reconcile template duplicates offline.
+8. Alignment and audit are separate responsibilities: runtime alignment fixes metadata drift only; audit mode remains the place to change `name`, `steps`, `pass_criteria`, `source.object`, `source.api`, or `aliases`.
 
 ## Local Artifact Version Control Policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ preparation.
   against the checked-in template workbook before execution.
 - wifi_llapi artifact bundles may now include `blocked_cases.md` and
   `skipped_cases.md` when metadata drift cannot be safely auto-aligned.
+- Ambiguous `(source.object, source.api)` template families are now blocked
+  instead of auto-aligned, and both `blocked_cases.md` plus
+  `meta.alignment_summary.blocked_details` expose the candidate template rows to
+  clean up later.
 
 ### Changed - BREAKING
 

--- a/README.md
+++ b/README.md
@@ -229,9 +229,15 @@ Typical artifact bundle contents:
 - `agent_trace/`
 - `blocked_cases.md` — cases whose `(source.object, source.api)` or `name`
   cannot be reconciled with the template workbook; they are not executed.
+  Ambiguous template families are blocked here instead of auto-aligned, and the
+  report includes candidate template rows for follow-up cleanup.
 - `skipped_cases.md` — duplicate cases that align to a template row already
   claimed by an earlier filename-sorted case; they are marked in the report and
   skipped from execution.
+
+The JSON runtime artifact also carries `meta.alignment_summary.blocked_details`,
+including each blocked case reason plus `candidate_template_rows` when runtime
+alignment hits an ambiguous template family.
 
 > [!IMPORTANT]
 > The first `testpilot run wifi_llapi` after pulling new case metadata may

--- a/README.md
+++ b/README.md
@@ -756,9 +756,16 @@ testpilot --azure run wifi_llapi --dut-fw-ver BGW720-B0-403
 - `STA.log`
 - `agent_trace/`
 - `blocked_cases.md` — `(source.object, source.api)` 或 `name` 無法與
-  template workbook 對齊的 cases；這些案例不會被執行
+  template workbook 對齊的 cases；這些案例不會被執行。若同一個
+  `(source.object, source.api)` 對應到多個 template rows，runtime 會
+  將該 family 視為 blocked，而不是猜測自動對齊；報告中也會列出
+  candidate template rows 供後續清理
 - `skipped_cases.md` — 對齊到已被較早 filename-sorted case 佔用之
   template row 的重複案例；它們會在報告中標記並跳過執行
+
+JSON runtime artifact 也會帶出 `meta.alignment_summary.blocked_details`，
+其中包含每個 blocked case 的 reason，以及在 ambiguous template family
+情境下的 `candidate_template_rows`。
 
 > [!IMPORTANT]
 > 在拉入新的 case metadata 後，第一次執行 `testpilot run wifi_llapi`

--- a/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/design.md
+++ b/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`main` already ships the runtime alignment pipeline that was originally designed in `docs/superpowers/specs/2026-04-22-wifi-llapi-runtime-alignment-design.md`:
+
+- `src/testpilot/reporting/wifi_llapi_align.py` builds a template index, classifies cases, mutates YAML, and emits `blocked_cases.md` / `skipped_cases.md`.
+- `src/testpilot/core/orchestrator.py` calls that aligner before execution and records `alignment_summary`.
+- `plugins/wifi_llapi/tests/test_wifi_llapi_align.py` and `plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py` already cover the happy path.
+
+What is missing is a safe boundary for structured display names and duplicate template families. The recent D308/D313/D316 change exposed that gap: adding `getSSIDStats().` to the tail of the name made `_extract_name_api()` return `""`, which disabled the validation branch entirely. A repo-wide audit also confirmed that the template contains duplicate `(object, api)` families (`getSSIDStats()`, `getRadioStats()`, `getScanResults()`), so the current one-row `by_object_api` map is fundamentally unsafe for those cases.
+
+Stakeholders: wifi_llapi plugin maintainers, runtime operators who rely on report fidelity, and auditors who need clear blocked artifacts instead of silent YAML mutation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make name-token extraction deterministic for structured display names so punctuation cannot suppress validation.
+- Represent duplicate template families explicitly and block them before any YAML mutation happens.
+- Preserve the existing auto-alignment path for unique `(source.object, source.api)` lookups.
+- Produce actionable runtime artifacts for ambiguous families without folding this work into a full corpus rewrite.
+
+**Non-Goals:**
+- Do not solve every existing `name_not_in_template` case in the repository.
+- Do not add new YAML schema fields or rewrite `name`, `steps`, `pass_criteria`, `source.object`, or `source.api`.
+- Do not redesign runtime alignment from scratch; this is a guardrail change on top of the current implementation.
+- Do not fix the unrelated pre-existing plugin-runtime test failure that already exists in the new worktree baseline.
+
+## Decisions
+
+### 1. Replace split-on-last-dot parsing with structured token extraction
+
+**Choice:** `_extract_name_api()` will extract the last method token like `getSSIDStats()` if one appears anywhere in the display name. If no method token exists but the name uses a structured display form like `AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.`, the extractor will use the display token before the separator. Otherwise it will return the original text for legacy flat names.
+
+**Why:** This removes the `...getSSIDStats().` bypass, keeps existing method-style names (`kickStation() - WiFi.AccessPoint.{i}.`) valid, and avoids turning every legacy prose name into an implicit pass.
+
+**Alternatives considered:**
+- Keep `split(".")[-1]` and only add more YAML workarounds. Rejected because it reproduces the same bypass.
+- Reject every case whose extracted token is empty. Rejected because many already-aligned method cases intentionally use object-path suffixes in `name`.
+
+### 2. Treat `(source.object, source.api)` as a family, not a single row
+
+**Choice:** `TemplateIndex.by_object_api` becomes a one-to-many map and `align_case()` distinguishes:
+- zero matching rows -> `object_api_not_in_template`
+- one matching row -> current alignment path
+- more than one matching row -> new blocked reason `ambiguous_object_api_family`
+
+**Why:** The template itself already proves that duplicate getter families exist. Picking one row during indexing loses information and causes incorrect mutations before the code even has a chance to reason about ambiguity.
+
+**Alternatives considered:**
+- Keep the existing dict and let "last row wins". Rejected because this is the root cause of the current collision behavior.
+- Pick the first row and keep `_resolve_collisions()` as the safety net. Rejected because it still mutates the wrong case before reporting the conflict.
+
+### 3. Block ambiguous families before collision resolution
+
+**Choice:** `ambiguous_object_api_family` cases never enter the runnable pool, so `_resolve_collisions()` only sees unique-row results.
+
+**Why:** Collision resolution is still useful for true duplicate YAML files that point at the same unique template row. It is not the right mechanism for template families where the aligner itself cannot prove which row is correct.
+
+**Alternatives considered:**
+- Reuse `skipped` for ambiguous families. Rejected because `skipped` implies there is a deterministic winner, which is false here.
+- Guess the correct row from the parsed name token. Rejected because getter families intentionally reuse the same API token across many rows.
+
+### 4. Enrich blocked reporting with candidate rows
+
+**Choice:** `AlignResult` gets `candidate_template_rows`, and `write_blocked_cases_report()` emits those rows for ambiguous families. `alignment_summary` carries the new blocked reason counts through the existing summary path.
+
+**Why:** Once runtime stops auto-mutating ambiguous families, the blocked artifact becomes the handoff document for later corpus cleanup. Candidate rows must be visible there; otherwise operators still have to reverse-engineer the template by hand.
+
+**Alternatives considered:**
+- Keep the current blocked report shape. Rejected because it hides the exact ambiguity the operator needs to resolve.
+
+### 5. Defer corpus rewrite to a later follow-up
+
+**Choice:** This change stops at guardrails and reporting. It intentionally does not try to rewrite all affected YAMLs in the same PR.
+
+**Why:** The audit already showed that the problem surface is much larger than the recent three-case workaround. Guardrails are safe to merge first; bulk metadata cleanup should happen only after runtime no longer guesses.
+
+## Risks / Trade-offs
+
+- **[Risk]** Some cases that currently run will become blocked once ambiguous families stop auto-aligning. -> **Mitigation**: document the behavior change and surface candidate rows in `blocked_cases.md` and `alignment_summary`.
+- **[Risk]** A more permissive structured parser could accidentally un-block legacy prose names. -> **Mitigation**: keep the parser conservative for non-structured names and add regression tests for both method and property display forms.
+- **[Risk]** Repo-scale counts will change once ambiguous families are blocked. -> **Mitigation**: update the repo-scale test to assert representative samples and reason-specific counts instead of relying only on the old aggregate shape.
+- **[Trade-off]** This change improves correctness by reducing automatic mutation coverage. That slows down cleanup for ambiguous families, but it prevents runtime from silently mutating the wrong files.
+
+## Migration Plan
+
+1. Update `test_wifi_llapi_align.py` with parser and ambiguous-family regression tests.
+2. Modify `wifi_llapi_align.py` to:
+   - extract structured tokens safely,
+   - preserve one-to-many template families,
+   - emit `ambiguous_object_api_family`,
+   - attach candidate rows to blocked results.
+3. Update orchestrator/runtime integration tests to reflect "blocked, not skipped" for ambiguous families.
+4. Update docs (`CHANGELOG.md`, `README.md`, `AGENTS.md`) to describe the new guardrail and its runtime effect.
+5. Validate with targeted alignment tests and the repo baseline, recording the existing unrelated failure separately.
+
+**Rollback:** revert the code/docs commit. No data migration is required because this change reduces runtime mutation rather than introducing a new disk format.
+
+## Open Questions
+
+1. Which discriminator should a later corpus-cleanup change use for duplicate getter families: parsed field name, filename suffix, or an explicit YAML metadata field?
+2. Should the eventual follow-up add a dedicated `alignment audit` command that inventories ambiguous families without running DUT/STA execution?

--- a/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/proposal.md
+++ b/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`wifi_llapi` runtime alignment already exists in `src/testpilot/reporting/wifi_llapi_align.py`, but the current implementation still has two correctness gaps:
+
+1. `_extract_name_api()` uses `text.split(".")[-1]`, so a name like `FailedRetransCount - WiFi.SSID.{i}.getSSIDStats().` produces an empty token and silently skips validation instead of proving the name matches the template API.
+2. `build_template_index()` stores only one row per `(source.object, source.api)`, so duplicate getter families such as `getSSIDStats()` and `getRadioStats()` collapse to a single row and can auto-mutate unrelated cases into the same template target.
+
+The result is that the recent D308/D313/D316 fix (`865207a`) unblocked execution by bypassing validation, not by making alignment trustworthy. A repo-wide audit in the same codebase also showed that the issue is systemic: duplicate getter families exist in the checked-in template and the current aligner cannot safely disambiguate them.
+
+## What Changes
+
+- Tighten name-token extraction so structured display names no longer bypass validation when they include trailing object paths or punctuation.
+- Change template indexing for `(source.object, source.api)` from "pick one row" to "detect unique vs ambiguous family" and refuse auto-alignment for ambiguous families.
+- Add an explicit blocked reason for ambiguous families and surface candidate template rows in runtime artifacts so follow-up cleanup is actionable.
+- Keep unique `(object, api)` cases on the current auto-alignment path; do not expand this change into a full corpus rewrite.
+- Update tests, docs, and implementation plan so future fixes do not rely on YAML display-name workarounds.
+- **BREAKING**: cases that currently auto-align through ambiguous duplicate getter families will stop mutating at runtime and be reported as blocked until a later discriminator/corpus cleanup is added.
+
+## Capabilities
+
+### New Capabilities
+
+- `wifi-llapi-alignment-guardrails`: Define robust display-name parsing, ambiguous family detection, and runtime artifact reporting for guarded wifi_llapi alignment.
+
+### Modified Capabilities
+
+None (no archived specs exist under `openspec/specs/` yet).
+
+## Impact
+
+**Code**:
+- `src/testpilot/reporting/wifi_llapi_align.py` - strengthen `_extract_name_api()`, represent duplicate template families explicitly, add a new blocked reason, and enrich blocked report output.
+- `src/testpilot/core/orchestrator.py` - preserve the existing alignment pipeline but expose the new blocked reason in `alignment_summary`.
+- `plugins/wifi_llapi/tests/test_wifi_llapi_align.py` - add parser and ambiguous-family regression coverage.
+- `plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py` - assert ambiguous families are blocked, not collision-skipped.
+
+**Runtime behavior**:
+- Unique `(source.object, source.api)` cases continue to auto-align.
+- Ambiguous families such as `getSSIDStats()` stop mutating YAML automatically and are surfaced as blocked work.
+
+**Docs**:
+- `CHANGELOG.md`, `AGENTS.md`, and `README.md` need a short note that runtime alignment now rejects ambiguous template families instead of silently choosing a winner.
+
+**Out of scope**:
+- Rewriting the full `plugins/wifi_llapi/cases/` corpus.
+- Adding new YAML discriminator fields or changing case semantics.
+- Resolving the unrelated baseline failure in `plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py::test_pre_skip_aligned_manual_cases_avoid_stale_sample_values`.

--- a/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/specs/wifi-llapi-alignment-guardrails/spec.md
+++ b/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/specs/wifi-llapi-alignment-guardrails/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Runtime alignment SHALL extract comparison tokens from structured display names
+The runtime alignment parser SHALL derive the comparison token from structured wifi_llapi case names without relying on the final period-delimited segment. Method tokens such as `getSSIDStats()` MUST still be recognized when they appear before trailing object paths or punctuation.
+
+#### Scenario: Method token remains visible in a structured name
+- **WHEN** a case name is `FailedRetransCount - WiFi.SSID.{i}.getSSIDStats().`
+- **THEN** the extracted comparison token is `getSSIDStats()`
+- **AND** runtime alignment does not treat the case as having an empty name API
+
+#### Scenario: Property token is extracted from the display prefix
+- **WHEN** a case name is `AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.`
+- **THEN** the extracted comparison token is `AssociationTime`
+- **AND** the parser ignores the trailing object path for validation purposes
+
+### Requirement: Runtime alignment MUST block ambiguous template families
+The runtime alignment phase MUST NOT auto-align or mutate YAML when the template contains more than one row for the same `(source.object, source.api)` pair. It MUST classify those cases as blocked with reason `ambiguous_object_api_family`.
+
+#### Scenario: Duplicate getter family is encountered
+- **WHEN** the template contains multiple rows for `("WiFi.SSID.{i}.", "getSSIDStats()")`
+- **THEN** a case with that same `(source.object, source.api)` pair is classified as `blocked`
+- **AND** no filename, `source.row`, or `id` mutation is applied
+
+#### Scenario: Unique object-api pair still auto-aligns
+- **WHEN** the template contains exactly one row for a case's `(source.object, source.api)` pair
+- **THEN** runtime alignment keeps the existing `already_aligned` or `auto_aligned` behavior
+- **AND** collision resolution only applies after the case is proven to reference a unique template row
+
+### Requirement: Runtime artifacts MUST explain ambiguous-family blocks
+When runtime alignment blocks a case because its template family is ambiguous, the emitted artifacts MUST include enough detail for a later cleanup pass to resolve the case without re-deriving the template mapping by hand.
+
+#### Scenario: Blocked report includes candidate rows
+- **WHEN** a case is classified as `ambiguous_object_api_family`
+- **THEN** `blocked_cases.md` includes the blocked reason and the candidate template rows for that family
+
+#### Scenario: Summary JSON records the new blocked reason
+- **WHEN** a run finishes with at least one ambiguous-family block
+- **THEN** `alignment_summary` in the run JSON reports the blocked count
+- **AND** the per-case blocked entry identifies the `ambiguous_object_api_family` reason

--- a/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/tasks.md
+++ b/openspec/changes/archive/2026-04-23-wifi-llapi-runtime-alignment/tasks.md
@@ -1,0 +1,17 @@
+## 1. Parser Guardrails
+
+- [x] 1.1 Add targeted regression tests for structured display-name parsing in `plugins/wifi_llapi/tests/test_wifi_llapi_align.py`
+- [x] 1.2 Update `_extract_name_api()` in `src/testpilot/reporting/wifi_llapi_align.py` to extract structured method/property tokens safely
+- [x] 1.3 Re-run the targeted alignment tests and confirm the trailing-punctuation bypass is gone
+
+## 2. Ambiguous Family Blocking
+
+- [x] 2.1 Change `TemplateIndex` and `align_case()` to preserve one-to-many `(source.object, source.api)` families
+- [x] 2.2 Introduce `ambiguous_object_api_family` reporting and candidate-template-row metadata
+- [x] 2.3 Update orchestrator integration tests so ambiguous getter families are blocked instead of collision-skipped
+
+## 3. Runtime Reporting and Docs
+
+- [x] 3.1 Extend blocked artifact and `alignment_summary` coverage for the new blocked reason
+- [x] 3.2 Document the guarded runtime behavior in `CHANGELOG.md`, `README.md`, and `AGENTS.md`
+- [x] 3.3 Run the focused alignment/orchestrator test set and capture the existing unrelated baseline failure separately

--- a/openspec/specs/wifi-llapi-alignment-guardrails/spec.md
+++ b/openspec/specs/wifi-llapi-alignment-guardrails/spec.md
@@ -1,0 +1,39 @@
+## Requirements
+
+### Requirement: Runtime alignment SHALL extract comparison tokens from structured display names
+The runtime alignment parser SHALL derive the comparison token from structured wifi_llapi case names without relying on the final period-delimited segment. Method tokens such as `getSSIDStats()` MUST still be recognized when they appear before trailing object paths or punctuation.
+
+#### Scenario: Method token remains visible in a structured name
+- **WHEN** a case name is `FailedRetransCount - WiFi.SSID.{i}.getSSIDStats().`
+- **THEN** the extracted comparison token is `getSSIDStats()`
+- **AND** runtime alignment does not treat the case as having an empty name API
+
+#### Scenario: Property token is extracted from the display prefix
+- **WHEN** a case name is `AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.`
+- **THEN** the extracted comparison token is `AssociationTime`
+- **AND** the parser ignores the trailing object path for validation purposes
+
+### Requirement: Runtime alignment MUST block ambiguous template families
+The runtime alignment phase MUST NOT auto-align or mutate YAML when the template contains more than one row for the same `(source.object, source.api)` pair. It MUST classify those cases as blocked with reason `ambiguous_object_api_family`.
+
+#### Scenario: Duplicate getter family is encountered
+- **WHEN** the template contains multiple rows for `("WiFi.SSID.{i}.", "getSSIDStats()")`
+- **THEN** a case with that same `(source.object, source.api)` pair is classified as `blocked`
+- **AND** no filename, `source.row`, or `id` mutation is applied
+
+#### Scenario: Unique object-api pair still auto-aligns
+- **WHEN** the template contains exactly one row for a case's `(source.object, source.api)` pair
+- **THEN** runtime alignment keeps the existing `already_aligned` or `auto_aligned` behavior
+- **AND** collision resolution only applies after the case is proven to reference a unique template row
+
+### Requirement: Runtime artifacts MUST explain ambiguous-family blocks
+When runtime alignment blocks a case because its template family is ambiguous, the emitted artifacts MUST include enough detail for a later cleanup pass to resolve the case without re-deriving the template mapping by hand.
+
+#### Scenario: Blocked report includes candidate rows
+- **WHEN** a case is classified as `ambiguous_object_api_family`
+- **THEN** `blocked_cases.md` includes the blocked reason and the candidate template rows for that family
+
+#### Scenario: Summary JSON records the new blocked reason
+- **WHEN** a run finishes with at least one ambiguous-family block
+- **THEN** `alignment_summary` in the run JSON reports the blocked count
+- **AND** the per-case blocked entry identifies the `ambiguous_object_api_family` reason

--- a/plugins/wifi_llapi/cases/D308_getssidstats_failedretranscount.yaml
+++ b/plugins/wifi_llapi/cases/D308_getssidstats_failedretranscount.yaml
@@ -1,5 +1,5 @@
 id: d308-getssidstats-failedretranscount
-name: D308 getSSIDStats FailedRetransCount
+name: "FailedRetransCount — WiFi.SSID.{i}.getSSIDStats()."
 source:
   row: 308
   object: WiFi.SSID.{i}.

--- a/plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml
+++ b/plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml
@@ -1,5 +1,5 @@
 id: d313-getssidstats-retranscount
-name: D313 getSSIDStats RetransCount
+name: "RetransCount — WiFi.SSID.{i}.getSSIDStats()."
 source:
   row: 313
   object: WiFi.SSID.{i}.

--- a/plugins/wifi_llapi/cases/D316_getssidstats_unknownprotopacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D316_getssidstats_unknownprotopacketsreceived.yaml
@@ -1,5 +1,5 @@
 id: d316-getssidstats-unknownprotopacketsreceived
-name: D316 getSSIDStats UnknownProtoPacketsReceived
+name: "UnknownProtoPacketsReceived — WiFi.SSID.{i}.getSSIDStats()."
 source:
   row: 316
   object: WiFi.SSID.{i}.

--- a/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
+++ b/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
@@ -421,6 +421,29 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     cases_dir = project_root / "plugins" / "wifi_llapi" / "cases"
     cases_dir.mkdir(parents=True, exist_ok=True)
 
+    source_xlsx = project_root / "source.xlsx"
+    wb = load_workbook(source_xlsx)
+    ws = wb["Wifi_LLAPI"]
+    ws["A30"] = "WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
+    ws["C30"] = "HeCapabilities"
+    wb.save(source_xlsx)
+    wb.close()
+    ensure_template_report(
+        source_xlsx=source_xlsx,
+        template_path=project_root
+        / "plugins"
+        / "wifi_llapi"
+        / "reports"
+        / "templates"
+        / "wifi_llapi_template.xlsx",
+        manifest_path=project_root
+        / "plugins"
+        / "wifi_llapi"
+        / "reports"
+        / "templates"
+        / "wifi_llapi_template.manifest.json",
+    )
+
     base_case = {
         "version": "1.0",
         "topology": {
@@ -501,17 +524,27 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     result = orch.run("wifi_llapi", dut_fw_ver="FW-IT-REALISTIC-1")
 
     assert result["status"] == "completed"
-    assert result["cases_count"] == 2
-    assert result["agent_trace_count"] == 2
+    assert result["cases_count"] == 1
+    assert result["agent_trace_count"] == 1
     summary = json.loads(Path(result["json_report_path"]).read_text(encoding="utf-8"))
-    assert summary["meta"]["alignment_summary"]["auto_aligned"] == 1
-    assert summary["meta"]["alignment_summary"]["skipped"] == 1
+    assert summary["meta"]["alignment_summary"]["already_aligned"] == 1
+    assert summary["meta"]["alignment_summary"]["auto_aligned"] == 0
+    assert summary["meta"]["alignment_summary"]["blocked"] == 2
+    assert summary["meta"]["alignment_summary"]["skipped"] == 0
     assert yaml.safe_load((cases_dir / "D021_hecapabilities.yaml").read_text(encoding="utf-8"))[
         "source"
-    ]["row"] == 21
+    ]["row"] == 7
+    assert yaml.safe_load((cases_dir / "D030_duplicate.yaml").read_text(encoding="utf-8"))["source"][
+        "row"
+    ] == 21
+    blocked_report = Path(result["artifact_dir"]) / "blocked_cases.md"
+    assert blocked_report.is_file()
+    blocked_text = blocked_report.read_text(encoding="utf-8")
+    assert "wifi-llapi-D021-hecapabilities" in blocked_text
+    assert "wifi-llapi-D030-duplicate" in blocked_text
+    assert "ambiguous_object_api_family" in blocked_text
     skipped_report = Path(result["artifact_dir"]) / "skipped_cases.md"
-    assert skipped_report.is_file()
-    assert "wifi-llapi-D030-duplicate" in skipped_report.read_text(encoding="utf-8")
+    assert not skipped_report.exists()
 
 
 def test_realistic_runtime_uses_results_reference_for_band_specific_statuses(

--- a/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
+++ b/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
@@ -424,6 +424,7 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     source_xlsx = project_root / "source.xlsx"
     wb = load_workbook(source_xlsx)
     ws = wb["Wifi_LLAPI"]
+    # Inject a duplicate family into the generated template so runtime alignment must block it.
     ws["A30"] = "WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
     ws["C30"] = "HeCapabilities"
     wb.save(source_xlsx)

--- a/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
+++ b/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
@@ -532,6 +532,18 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     assert summary["meta"]["alignment_summary"]["auto_aligned"] == 0
     assert summary["meta"]["alignment_summary"]["blocked"] == 2
     assert summary["meta"]["alignment_summary"]["skipped"] == 0
+    assert summary["meta"]["alignment_summary"]["blocked_details"] == [
+        {
+            "case_id": "wifi-llapi-D021-hecapabilities",
+            "reason": "ambiguous_object_api_family",
+            "candidate_template_rows": [21, 30],
+        },
+        {
+            "case_id": "wifi-llapi-D030-duplicate",
+            "reason": "ambiguous_object_api_family",
+            "candidate_template_rows": [21, 30],
+        },
+    ]
     assert yaml.safe_load((cases_dir / "D021_hecapabilities.yaml").read_text(encoding="utf-8"))[
         "source"
     ]["row"] == 7
@@ -544,6 +556,7 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     assert "wifi-llapi-D021-hecapabilities" in blocked_text
     assert "wifi-llapi-D030-duplicate" in blocked_text
     assert "ambiguous_object_api_family" in blocked_text
+    assert "@ rows [21, 30]" in blocked_text
     skipped_report = Path(result["artifact_dir"]) / "skipped_cases.md"
     assert not skipped_report.exists()
 

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -28,6 +28,40 @@ def test_extract_name_api_cases():
     assert _extract_name_api("AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.") == "AssociationTime"
     # Regression: em-dash separator
     assert _extract_name_api("AssociationTime — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.") == "AssociationTime"
+    # Regression: legacy dotted labels should resolve to the terminal API token
+    assert _extract_name_api("D496 WmmBytesReceived.AC_BE") == "AC_BE"
+
+
+def test_align_allows_legacy_dotted_name_api(tmp_path: Path):
+    template = tmp_path / "template.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.SSID.{i}."
+    ws["C4"] = "AC_BE"
+    wb.save(template)
+    wb.close()
+    index = build_template_index(template)
+    case_file = tmp_path / "D496_ac_be_stats_wmmbytesreceived_ssid.yaml"
+    case_file.write_text("stub\n", encoding="utf-8")
+
+    result = align_case(
+        {
+            "id": "wifi-llapi-D496-ac-be-stats-wmmbytesreceived-ssid",
+            "name": "D496 WmmBytesReceived.AC_BE",
+            "source": {
+                "row": 496,
+                "object": "WiFi.SSID.{i}.",
+                "api": "AC_BE",
+            },
+        },
+        index,
+        case_file,
+    )
+
+    assert result.status == "auto_aligned"
+    assert result.blocked_reason is None
+    assert result.source_row_after == 4
 
 def _build_template(path: Path) -> None:
     wb = Workbook()

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -58,8 +58,43 @@ def test_build_template_index_happy(template_path: Path):
     index = build_template_index(template)
 
     assert index.forward[4] == ("WiFi.AccessPoint.{i}.", "kickStation()")
-    assert index.by_object_api[("WiFi.Radio.{i}.", "getRadioStats()")] == 5
+    assert index.by_object_api[("WiFi.Radio.{i}.", "getRadioStats()")] == [5]
     assert index.by_api["HeCapabilities"] == [6]
+
+
+def test_align_blocks_ambiguous_object_api_family(tmp_path: Path):
+    template = tmp_path / "template.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.SSID.{i}."
+    ws["C4"] = "getSSIDStats()"
+    ws["A5"] = "WiFi.SSID.{i}."
+    ws["C5"] = "getSSIDStats()"
+    wb.save(template)
+    wb.close()
+    index = build_template_index(template)
+    case_file = tmp_path / "D021_getssidstats.yaml"
+    case_file.write_text("stub\n", encoding="utf-8")
+
+    result = align_case(
+        {
+            "id": "wifi-llapi-D021-getssidstats",
+            "name": "getSSIDStats()",
+            "source": {
+                "row": 21,
+                "object": "WiFi.SSID.{i}.",
+                "api": "getSSIDStats()",
+            },
+        },
+        index,
+        case_file,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocked_reason == "ambiguous_object_api_family"
+    assert result.source_row_after is None
+    assert result.candidate_template_rows == [4, 5]
 
 
 def test_align_already_aligned(tmp_path: Path, template_path: Path):

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -26,6 +26,8 @@ def test_extract_name_api_cases():
     assert _extract_name_api("FailedRetransCount - WiFi.SSID.{i}.getSSIDStats().") == "getSSIDStats()"
     # Should extract left token if no method present
     assert _extract_name_api("AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.") == "AssociationTime"
+    # Regression: em-dash separator
+    assert _extract_name_api("AssociationTime — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.") == "AssociationTime"
 
 def _build_template(path: Path) -> None:
     wb = Workbook()

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -15,11 +15,17 @@ from testpilot.reporting.wifi_llapi_align import (
     build_template_index,
     write_blocked_cases_report,
     write_skipped_cases_report,
+    _extract_name_api,
 )
 
 from testpilot.reporting.wifi_llapi_excel import create_run_report_from_template, fill_blocked_markers, fill_skip_markers
 from testpilot.schema.case_schema import load_case
 
+def test_extract_name_api_cases():
+    # Should extract method token if present
+    assert _extract_name_api("FailedRetransCount - WiFi.SSID.{i}.getSSIDStats().") == "getSSIDStats()"
+    # Should extract left token if no method present
+    assert _extract_name_api("AssociationTime - WiFi.AccessPoint.{i}.AssociatedDevice.{i}.") == "AssociationTime"
 
 def _build_template(path: Path) -> None:
     wb = Workbook()

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -420,6 +420,32 @@ def test_write_blocked_report_md(tmp_path: Path):
     assert "name_points_to_different_row" in text
 
 
+def test_write_blocked_report_md_includes_candidate_template_rows(tmp_path: Path):
+    out_path = tmp_path / "blocked_cases.md"
+    blocked = [
+        AlignResult(
+            case_file=tmp_path / "D021_hecapabilities.yaml",
+            status="blocked",
+            source_row_before=21,
+            source_row_after=None,
+            source_object="WiFi.AccessPoint.{i}.AssociatedDevice.{i}.",
+            source_api="HeCapabilities",
+            filename_before="D021_hecapabilities.yaml",
+            filename_after=None,
+            id_before="wifi-llapi-D021-hecapabilities",
+            id_after=None,
+            blocked_reason="ambiguous_object_api_family",
+            candidate_template_rows=[6, 30],
+        )
+    ]
+
+    write_blocked_cases_report(blocked, out_path)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert "ambiguous_object_api_family" in text
+    assert "@ rows [6, 30]" in text
+
+
 def test_write_skipped_report_md(tmp_path: Path):
     out_path = tmp_path / "skipped_cases.md"
     skipped = [

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -3130,15 +3130,15 @@ def test_pre_skip_aligned_manual_cases_avoid_stale_sample_values():
         "D305_getssidstats_discardpacketssent.yaml": {"row": 305, "api": "DiscardPacketsSent", "expected": "Pass"},
         "D306_getssidstats_errorsreceived.yaml": {"row": 306, "api": "ErrorsReceived", "expected": "Pass"},
         "D307_getssidstats_errorssent.yaml": {"row": 307, "api": "ErrorsSent", "expected": "Pass"},
-        "D308_getssidstats_failedretranscount.yaml": {"row": 308, "api": "FailedRetransCount", "expected": "Not Supported"},
+        "D308_getssidstats_failedretranscount.yaml": {"row": 308, "api": "FailedRetransCount", "expected": "Not Supported", "name": "FailedRetransCount — WiFi.SSID.{i}.getSSIDStats()."},
         "D309_getssidstats_multicastpacketsreceived.yaml": {"row": 309, "api": "MulticastPacketsReceived", "expected": "Pass"},
         "D310_getssidstats_multicastpacketssent.yaml": {"row": 310, "api": "MulticastPacketsSent", "expected": "Pass"},
         "D311_getssidstats_packetsreceived.yaml": {"row": 311, "api": "PacketsReceived", "expected": "Pass"},
         "D312_getssidstats_packetssent.yaml": {"row": 312, "api": "PacketsSent", "expected": "Pass"},
-        "D313_getssidstats_retranscount.yaml": {"row": 313, "api": "RetransCount", "expected": "Not Supported"},
+        "D313_getssidstats_retranscount.yaml": {"row": 313, "api": "RetransCount", "expected": "Not Supported", "name": "RetransCount — WiFi.SSID.{i}.getSSIDStats()."},
         "D314_getssidstats_unicastpacketsreceived.yaml": {"row": 314, "api": "UnicastPacketsReceived", "expected": "Pass"},
         "D315_getssidstats_unicastpacketssent.yaml": {"row": 315, "api": "UnicastPacketsSent", "expected": "Pass"},
-        "D316_getssidstats_unknownprotopacketsreceived.yaml": {"row": 316, "api": "UnknownProtoPacketsReceived", "expected": "Not Supported"},
+        "D316_getssidstats_unknownprotopacketsreceived.yaml": {"row": 316, "api": "UnknownProtoPacketsReceived", "expected": "Not Supported", "name": "UnknownProtoPacketsReceived — WiFi.SSID.{i}.getSSIDStats()."},
     }
 
     for filename, meta in multiband_getssid_cases.items():
@@ -3148,7 +3148,7 @@ def test_pre_skip_aligned_manual_cases_avoid_stale_sample_values():
         commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
         assert "aliases" not in case_data
         assert case_data["id"] == f"d{num}-getssidstats-{meta['api'].lower()}"
-        assert case_data["name"] == f"D{num} getSSIDStats {meta['api']}"
+        assert case_data["name"] == meta.get("name", f"D{num} getSSIDStats {meta['api']}")
         assert case_data["source"]["row"] == meta["row"]
         assert case_data["source"]["api"] == "getSSIDStats()"
         assert case_data["source"]["baseline"] == "0310-BGW720-300"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.4",
+    "ruamel.yaml>=0.17.21",
 ]
 
 [project.scripts]

--- a/src/testpilot/core/orchestrator.py
+++ b/src/testpilot/core/orchestrator.py
@@ -480,6 +480,15 @@ class Orchestrator:
 
     @staticmethod
     def _build_wifi_llapi_alignment_summary(align_results: list[Any]) -> dict[str, Any]:
+        blocked_details = [
+            {
+                "case_id": result.id_before,
+                "reason": result.blocked_reason,
+                "candidate_template_rows": list(result.candidate_template_rows or []),
+            }
+            for result in align_results
+            if result.status == "blocked"
+        ]
         return {
             "already_aligned": sum(
                 1 for result in align_results if result.status == "already_aligned"
@@ -487,6 +496,7 @@ class Orchestrator:
             "auto_aligned": sum(1 for result in align_results if result.status == "auto_aligned"),
             "blocked": sum(1 for result in align_results if result.status == "blocked"),
             "skipped": sum(1 for result in align_results if result.status == "skipped"),
+            "blocked_details": blocked_details,
             "mutations": [
                 {
                     "case_id": result.id_before,

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -61,9 +61,19 @@ class AlignmentConflictError(RuntimeError):
     pass
 
 
+_METHOD_TOKEN_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\(\)")
+
 def _extract_name_api(name: object) -> str:
     text = str(name).strip() if isinstance(name, str) else ""
-    return text.split(".")[-1].strip() if text else ""
+    if not text:
+        return ""
+    method_tokens = _METHOD_TOKEN_PATTERN.findall(text)
+    if method_tokens:
+        return method_tokens[-1]
+    for separator in (" - ", " — "):
+        if separator in text:
+            return text.split(separator, 1)[0].strip()
+    return text
 
 
 def _replace_id_row(case_id: str, canonical_row: int) -> str | None:

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -75,6 +75,8 @@ def _extract_name_api(name: object) -> str:
     for separator in (" - ", " — "):
         if separator in text:
             return text.split(separator, 1)[0].strip()
+    if "." in text:
+        return text.rsplit(".", 1)[-1].strip()
     return text
 
 

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -150,8 +150,8 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
     template_row = candidate_rows[0]
     template_object, template_api = index.forward.get(template_row, ("", ""))
     if name_api and name_api != template_api:
-        candidate_rows = index.by_api.get(name_api, [])
-        reason = "name_points_to_different_row" if candidate_rows else "name_not_in_template"
+        name_api_candidates = index.by_api.get(name_api, [])
+        reason = "name_points_to_different_row" if name_api_candidates else "name_not_in_template"
         return AlignResult(
             case_file=case_file,
             status="blocked",
@@ -167,7 +167,7 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
             template_row=template_row,
             template_row_object=template_object,
             template_row_api=template_api,
-            candidate_template_rows=list(candidate_rows) if candidate_rows else None,
+            candidate_template_rows=list(name_api_candidates) if name_api_candidates else None,
         )
     filename_after = None
     source_row_after = template_row

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -23,6 +23,7 @@ BlockedReason = Literal[
     "object_api_not_in_template",
     "name_points_to_different_row",
     "name_not_in_template",
+    "ambiguous_object_api_family",
 ]
 
 _ID_D_PATTERN = re.compile(r"(wifi-llapi-D)(\d{3})(-)")
@@ -34,7 +35,7 @@ log = logging.getLogger(__name__)
 @dataclass(slots=True)
 class TemplateIndex:
     forward: dict[int, tuple[str, str]]
-    by_object_api: dict[tuple[str, str], int]
+    by_object_api: dict[tuple[str, str], list[int]]
     by_api: dict[str, list[int]]
 
 
@@ -55,6 +56,7 @@ class AlignResult:
     template_row: int | None = None
     template_row_object: str | None = None
     template_row_api: str | None = None
+    candidate_template_rows: list[int] | None = None
 
 
 class AlignmentConflictError(RuntimeError):
@@ -87,7 +89,7 @@ def build_template_index(template_xlsx: Path) -> TemplateIndex:
     try:
         ws = wb[DEFAULT_SHEET_NAME]
         forward: dict[int, tuple[str, str]] = {}
-        by_object_api: dict[tuple[str, str], int] = {}
+        by_object_api: dict[tuple[str, str], list[int]] = {}
         by_api: dict[str, list[int]] = {}
         empty_streak = 0
         for row in range(DATA_START_ROW, min(ws.max_row, DATA_START_ROW + MAX_SCAN_ROWS) + 1):
@@ -100,7 +102,7 @@ def build_template_index(template_xlsx: Path) -> TemplateIndex:
                 continue
             empty_streak = 0
             forward[row] = (obj, api)
-            by_object_api[(obj, api)] = row
+            by_object_api.setdefault((obj, api), []).append(row)
             by_api.setdefault(api, []).append(row)
         return TemplateIndex(forward=forward, by_object_api=by_object_api, by_api=by_api)
     finally:
@@ -115,9 +117,8 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
     case_id = str(case.get("id", ""))
     name_api = _extract_name_api(case.get("name"))
     filename_before = case_file.name
-    template_row = index.by_object_api.get((obj, api))
-    template_object, template_api = index.forward.get(template_row, ("", ""))
-    if template_row is None:
+    candidate_rows = index.by_object_api.get((obj, api), [])
+    if not candidate_rows:
         return AlignResult(
             case_file=case_file,
             status="blocked",
@@ -131,6 +132,23 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
             id_after=None,
             blocked_reason="object_api_not_in_template",
         )
+    if len(candidate_rows) > 1:
+        return AlignResult(
+            case_file=case_file,
+            status="blocked",
+            source_row_before=source_row_before,
+            source_row_after=None,
+            source_object=obj,
+            source_api=api,
+            filename_before=filename_before,
+            filename_after=None,
+            id_before=case_id,
+            id_after=None,
+            blocked_reason="ambiguous_object_api_family",
+            candidate_template_rows=list(candidate_rows),
+        )
+    template_row = candidate_rows[0]
+    template_object, template_api = index.forward.get(template_row, ("", ""))
     if name_api and name_api != template_api:
         candidate_rows = index.by_api.get(name_api, [])
         reason = "name_points_to_different_row" if candidate_rows else "name_not_in_template"
@@ -149,6 +167,7 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
             template_row=template_row,
             template_row_object=template_object,
             template_row_api=template_api,
+            candidate_template_rows=list(candidate_rows) if candidate_rows else None,
         )
     filename_after = None
     source_row_after = template_row
@@ -277,6 +296,8 @@ def write_blocked_cases_report(blocked: list[AlignResult], out_path: Path) -> No
             if item.template_row_object and item.template_row_api
             else "—"
         )
+        if item.candidate_template_rows:
+            template_pair = f"{template_pair} @ rows {item.candidate_template_rows}"
         lines.append(
             f"| {item.id_before} | {item.filename_before} | {item.source_row_before} | "
             f"{source_pair} | {template_pair} | {item.blocked_reason} |"


### PR DESCRIPTION
## Summary
- harden wifi_llapi runtime alignment by blocking ambiguous object/api families and surfacing candidate template rows in artifacts and JSON summary
- restore parser compatibility for structured getSSIDStats names and legacy dotted labels, plus refresh plugin-runtime regression coverage for D308/D313/D316 and legacy dotted cases
- sync and archive the OpenSpec change for wifi-llapi-runtime-alignment

## Test Plan
- [x] uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_align.py plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py -k 'pre_skip_aligned_manual_cases_avoid_stale_sample_values or ssid_stats_contract or extract_name_api or align_'
- [x] uv run pytest -q
