### PR TITLE
feat: 修復 wifi_llapi inventory 與 runtime alignment

### DIFF
--- a/docs/superpowers/specs/2026-04-24-wifi-llapi-inventory-runtime-repair-design.md
+++ b/docs/superpowers/specs/2026-04-24-wifi-llapi-inventory-runtime-repair-design.md
@@ -1,0 +1,228 @@
+# wifi_llapi inventory + runtime repair design
+
+## Problem
+
+`wifi_llapi` official case inventory has drifted away from the current checked-in template workbook. The current `main` branch shows three related failures:
+
+1. some official workbook rows no longer have a canonical discoverable YAML (for example `D407`)
+2. some discoverable YAML files still carry stale canonical metadata (for example `D495_retrycount_ssid_stats_verified.yaml` keeping a stale `source.row`)
+3. runtime alignment blocks on `(source.object, source.api)` families with multiple workbook rows because it does not use `source.row` to disambiguate
+
+This creates a broken state where:
+
+- docs can claim a row is aligned while the repo inventory no longer contains the canonical case file
+- reruns of row-correct cases can still be blocked by `ambiguous_object_api_family`
+- duplicate or stale historical YAML can remain discoverable and pollute official inventory
+
+The repair must use the **current template workbook** as the only authoritative source and must restore a strict discoverable inventory: **one discoverable official YAML per workbook row**.
+
+## Goals
+
+1. rebuild canonical discoverable inventory from the current template workbook
+2. restore any missing official case YAML required by the workbook
+3. remove discoverable duplicates and drifted historical leftovers from official inventory
+4. update runtime alignment so multi-row object/api families use `source.row` before blocking
+5. resync repo documentation and handoff records to match the repaired inventory
+6. re-check all blockers that can cause rows to be skipped, blocked, or silently omitted before claiming completion
+
+## Non-goals
+
+- changing workbook contents
+- changing live calibration semantics, step commands, or pass criteria unless required to preserve the canonical row's existing meaning
+- redesigning the broader wifi_llapi reporting pipeline
+
+## Authoritative rules
+
+### Workbook authority
+
+The checked-in template workbook defines the canonical official row set. Historical repo state is reference material only; it is not authoritative when it conflicts with the current workbook.
+
+### Canonical inventory invariant
+
+For every official workbook row:
+
+- exactly one discoverable YAML must exist
+- that YAML must use the canonical row in `source.row`
+- filename `D###_*.yaml` must match the canonical row
+- any row-bearing official `id` must match the canonical row
+
+Historical or duplicate YAML may exist only if they are explicitly demoted out of discoverable official inventory. They must not remain discoverable.
+
+### Runtime disambiguation invariant
+
+When `(source.object, source.api)` maps to multiple workbook rows, runtime alignment must:
+
+1. inspect `source.row`
+2. choose that row if it is one of the candidate rows
+3. block only when `source.row` is missing or not part of the candidate family
+
+This keeps runtime deterministic while preserving workbook-driven inventory repair.
+
+## Proposed approach
+
+Use a two-layer repair:
+
+1. **inventory-first canonicalization**
+2. **runtime row-based disambiguation**
+
+This addresses both root causes:
+
+- broken or incomplete official inventory
+- runtime family ambiguity even when a case already has the correct canonical row
+
+## Design
+
+### 1. Inventory audit layer
+
+Add a workbook-driven audit pass that compares the current official workbook row set with discoverable YAML under `plugins/wifi_llapi/cases/`.
+
+The audit output must classify each item into:
+
+- `canonical_rows`: workbook rows already represented by one correct discoverable YAML
+- `missing_rows`: workbook rows with no canonical discoverable YAML
+- `drifted_cases`: discoverable YAML whose row, filename, id, or object/api metadata does not match the canonical workbook row they should represent
+- `extra_cases`: discoverable YAML that do not belong in the canonical official inventory
+- `duplicate_rows`: more than one discoverable YAML trying to represent the same workbook row
+
+The audit result must be machine-checkable so tests can assert inventory completeness and uniqueness.
+
+### 2. Canonicalization rules
+
+#### Missing rows
+
+If a workbook row is official but missing from discoverable inventory, create or restore a canonical YAML for that row.
+
+Preferred reconstruction order:
+
+1. reuse the closest historical YAML that already represents the same workbook row semantics
+2. if no exact historical YAML exists, reuse the nearest drifted YAML for that row family and normalize its row-bearing metadata
+3. only if neither exists, synthesize a canonical YAML from workbook/template metadata plus existing repo conventions
+
+The result must land as a canonical discoverable file for the exact workbook row.
+
+#### Drifted rows
+
+If a discoverable YAML should represent a canonical workbook row but carries stale metadata, rewrite:
+
+- filename
+- `source.row`
+- row-bearing `id`
+
+Any non-row-bearing metadata should stay unchanged unless required to preserve canonical workbook identity.
+
+#### Extra or duplicate rows
+
+If a discoverable YAML is not part of the canonical workbook inventory, it must exit discoverable official inventory.
+
+If its contents are still useful for tests or historical reference, demote it to an underscore-prefixed fixture-style file so `load_cases_dir()` no longer discovers it.
+
+### 3. Runtime alignment changes
+
+Update `align_case()` so `ambiguous_object_api_family` is not emitted immediately when multiple template rows share the same `(source.object, source.api)`.
+
+New behavior:
+
+1. read candidate rows from `TemplateIndex.by_object_api[(obj, api)]`
+2. if there is exactly one candidate row, keep current behavior
+3. if there are multiple candidates:
+   - if `source.row_before` is a member of that candidate set, select it as the canonical row
+   - otherwise block with `ambiguous_object_api_family` and include candidate rows
+4. keep the later `name`-vs-template API checks unchanged after a single target row has been chosen
+
+This preserves guardrails while allowing deterministic execution for row-correct cases such as:
+
+- `D308`
+- `D313`
+- `D316`
+- `D495 basic`
+
+Cases such as stale `D495 verified` should still be surfaced as drift/blocker candidates until their canonical row is repaired.
+
+### 4. Blocker re-audit before completion
+
+Before declaring the repair complete, run a full blocker sweep over the repaired inventory and runtime path.
+
+The sweep must explicitly account for anything that can cause a case to be:
+
+- skipped
+- blocked
+- silently excluded from discoverable inventory
+- shadowed by a duplicate canonical row
+
+Completion requires proving that all workbook-authoritative official rows are either:
+
+- present as canonical discoverable YAML, or
+- explicitly listed as a blocker with a concrete reason
+
+No row may disappear implicitly.
+
+### 5. Documentation sync
+
+Update repo handoff documents that describe official inventory status so they match the repaired inventory exactly.
+
+At minimum, reconcile:
+
+- `README.md`
+- `docs/plan.md`
+- `docs/todos.md`
+- any active audit or handoff doc that references the repaired rows
+
+The key rule is simple: documentation must not claim an official row exists or is aligned unless the canonical discoverable YAML is actually present in the repo.
+
+## Components affected
+
+- `src/testpilot/reporting/wifi_llapi_align.py`
+- inventory audit / normalization helpers in the existing wifi_llapi case-loading and reporting area
+- `plugins/wifi_llapi/cases/`
+- runtime and regression tests covering alignment and inventory integrity
+- repo handoff docs that describe official inventory state
+
+## Validation plan
+
+### Inventory validation
+
+- assert official workbook rows and discoverable YAML are in 1:1 correspondence
+- assert each canonical row appears exactly once in discoverable inventory
+- assert no extra discoverable YAML claims an official canonical row outside the workbook-defined set
+
+### Runtime validation
+
+- add regression coverage for multi-row object/api family disambiguation using `source.row`
+- verify row-correct cases no longer block with `ambiguous_object_api_family`
+- verify stale-row cases still surface as blockers until repaired
+
+### Integration validation
+
+- rerun representative problematic rows, including the currently affected families around `D308/D313/D316/D407/D495`
+- confirm they are executed or explicitly blocked for a concrete remaining reason, never silently skipped
+
+### Documentation validation
+
+- compare repaired inventory against official-row claims in repo docs
+- remove or fix any stale claim that references rows no longer present in discoverable inventory
+
+## Risks and controls
+
+### Risk: wrong historical YAML chosen as canonical source
+
+Control: workbook row remains authoritative; history is only a reconstruction aid.
+
+### Risk: runtime fix masks inventory bugs
+
+Control: keep inventory audit and runtime disambiguation as separate checks. Runtime may use `source.row`, but inventory still must prove one canonical YAML per workbook row.
+
+### Risk: silent omission of rows during cleanup
+
+Control: blocker re-audit is a required gate before completion. Missing rows must be explicit.
+
+## Definition of done
+
+The change is complete only when all of the following are true:
+
+1. every official workbook row has exactly one canonical discoverable YAML
+2. discoverable inventory contains no duplicate canonical rows
+3. drifted historical files no longer pollute discoverable official inventory
+4. runtime uses `source.row` to disambiguate multi-row object/api families
+5. representative reruns are no longer blocked only because of family ambiguity when the case already has the correct row
+6. all remaining skip/block conditions have been re-audited and explicitly accounted for
+7. documentation matches the actual repaired inventory

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/.openspec.yaml
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/design.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`wifi_llapi` runtime alignment and official case inventory have diverged in two ways.
+
+First, the repo no longer guarantees that every official workbook row has exactly one discoverable YAML. Some rows are missing entirely, while other historical YAML remain discoverable with stale row-bearing metadata.
+
+Second, runtime alignment currently treats any duplicate `(source.object, source.api)` template family as an unconditional block. That guardrail was useful for surfacing ambiguity, but it now blocks row-correct cases that already carry the canonical `source.row`.
+
+The change has to repair both layers together. If only runtime changes, broken inventory remains in the repo. If only inventory changes, future family collisions still block valid reruns.
+
+## Goals / Non-Goals
+
+**Goals:**
+- make the current checked-in template workbook the authoritative source for official inventory
+- ensure every official workbook row maps to exactly one discoverable YAML
+- restore missing official rows and remove duplicate discoverable leftovers from canonical inventory
+- allow runtime alignment to use `source.row` to resolve ambiguous template families before blocking
+- keep blocked/skip states explicit so no official row disappears silently
+
+**Non-Goals:**
+- changing workbook contents
+- changing live case semantics, pass criteria, or calibration intent beyond row/inventory repair
+- redesigning the broader reporting pipeline or non-`wifi_llapi` plugins
+
+## Decisions
+
+### Decision: Introduce a workbook-driven inventory audit/reconcile layer
+
+The repair will add a dedicated inventory helper that audits discoverable YAML against workbook rows and classifies cases as canonical, missing, drifted, duplicate, or extra.
+
+This is preferred over ad hoc manual cleanup because the problem has already drifted over multiple days and needs a machine-checkable invariant. A formal audit also gives tests a stable API for asserting 1:1 inventory.
+
+Alternative considered: repair the current case set manually and rely on runtime checks only. Rejected because it would not prevent future silent drift and would provide no reusable repo-scale validation.
+
+### Decision: Keep runtime guardrails, but let `source.row` break family ties
+
+`align_case()` will still treat duplicate `(source.object, source.api)` families as special handling, but it will first inspect `source.row`. If that row is one of the candidate rows, runtime will choose it deterministically. Only unresolved family collisions remain blocked as `ambiguous_object_api_family`.
+
+This preserves the guardrail's purpose while unblocking row-correct cases such as the current `D308/D313/D316/D495` family.
+
+Alternative considered: always block any duplicate family and force inventory cleanup first. Rejected because even after inventory repair the workbook can still contain legitimate duplicate object/api families that require row-based selection.
+
+### Decision: Missing rows are restored from repo history before any synthesis
+
+When a workbook row is missing from discoverable inventory, the reconcile flow will first search git history for the latest matching canonical `D###_*.yaml` file. Only if no historical candidate exists should the repair stop with an explicit blocker.
+
+This minimizes semantic drift because historical YAML usually carry the closest row-specific content already validated in the project.
+
+Alternative considered: synthesize missing YAML directly from workbook metadata. Rejected as the default because workbook metadata alone may not preserve case-specific topology and step structure.
+
+### Decision: Non-canonical leftovers exit discoverable inventory
+
+Historical or duplicate YAML that are no longer canonical will be demoted out of discoverable inventory, preferably by underscore prefix when their contents still have fixture value.
+
+This follows the existing repo rule that underscore-prefixed YAML are excluded from `load_cases_dir()`.
+
+Alternative considered: leave extra YAML discoverable and rely on collision resolution. Rejected because it keeps official inventory ambiguous and allows docs to drift from the actual canonical set.
+
+## Risks / Trade-offs
+
+- **Wrong historical file restored for a missing row** → Use workbook row as the canonical key and fail explicitly if history lookup is ambiguous or absent.
+- **Runtime disambiguation masks broken inventory** → Keep inventory audit and runtime disambiguation as separate validations; runtime success alone is not enough.
+- **Repo-scale YAML rewrite causes noisy diffs** → Isolate the repair in a dedicated worktree and commit runtime logic separately from inventory/application diffs.
+- **Some rows remain blocked after repair** → Require a blocker re-audit pass and explicit reporting before claiming completion.
+
+## Migration Plan
+
+1. Add regression tests for row-based runtime disambiguation.
+2. Implement runtime disambiguation in `wifi_llapi_align.py`.
+3. Add inventory audit/reconcile helpers and tests.
+4. Run reconcile flow against `plugins/wifi_llapi/cases/` to restore missing rows and demote non-canonical leftovers.
+5. Re-run targeted runtime tests and the problematic case set.
+6. Sync README / handoff docs to the repaired canonical inventory.
+
+Rollback is straightforward:
+
+- revert the runtime alignment commit if row disambiguation proves unsafe
+- revert the inventory reconcile commit if the applied YAML repair is incorrect
+
+Because inventory and runtime changes are separated, rollback can be targeted.
+
+## Open Questions
+
+- Whether any workbook-official row lacks a recoverable historical YAML and will need a follow-up manual blocker resolution
+- Whether any repo docs outside `README.md`, `docs/plan.md`, and `docs/todos.md` still claim canonical rows that do not exist after reconciliation

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/proposal.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`wifi_llapi` official case inventory has drifted away from the current checked-in template workbook. The repo can now claim that some rows are aligned even when the canonical discoverable YAML is missing, and runtime reruns can still be blocked on ambiguous `(source.object, source.api)` families even when the case already carries the correct `source.row`.
+
+This needs to be fixed now because the current state makes reruns unreliable, hides missing official rows behind historical leftovers, and lets documentation drift away from the actual repo inventory.
+
+## What Changes
+
+- Introduce a workbook-authoritative official inventory rule for `wifi_llapi`: every official workbook row must map to exactly one discoverable YAML.
+- Add inventory audit and reconcile behavior to detect missing, drifted, duplicate, and extra discoverable official cases.
+- Restore missing official case YAML rows from repo history or explicit repair flows, and demote non-canonical historical leftovers out of discoverable inventory.
+- **BREAKING**: change runtime ambiguous-family handling so `(source.object, source.api)` collisions first use `source.row` to select the canonical row; only unresolved collisions remain blocked as `ambiguous_object_api_family`.
+- Sync runtime artifacts and repo handoff docs so they describe the repaired canonical inventory instead of stale historical state.
+
+## Capabilities
+
+### New Capabilities
+- `wifi-llapi-official-inventory`: Define workbook-authoritative official inventory, including one discoverable YAML per official workbook row plus explicit handling for missing, drifted, duplicate, and extra cases.
+
+### Modified Capabilities
+- `wifi-llapi-alignment-guardrails`: Change ambiguous-family alignment behavior so runtime uses `source.row` to disambiguate before emitting `ambiguous_object_api_family`.
+
+## Impact
+
+- Affected code: `src/testpilot/reporting/wifi_llapi_align.py`, new inventory audit/reconcile helpers, reconcile script, `plugins/wifi_llapi/cases/*.yaml`, orchestrator integration tests, and repo handoff docs.
+- Affected runtime behavior: row-correct ambiguous-family cases become runnable instead of being blocked immediately.
+- Affected artifacts: alignment summaries, blocked-case reports, and repo documentation must match the repaired canonical official inventory.

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/specs/wifi-llapi-alignment-guardrails/spec.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/specs/wifi-llapi-alignment-guardrails/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime alignment MUST block unresolved ambiguous template families
+The runtime alignment phase MUST NOT auto-align or mutate YAML when the template contains more than one row for the same `(source.object, source.api)` pair unless the case's `source.row` resolves that family to a single canonical row. It MUST classify only unresolved collisions as blocked with reason `ambiguous_object_api_family`.
+
+#### Scenario: Duplicate getter family is resolved by source row
+- **WHEN** the template contains multiple rows for `("WiFi.SSID.{i}.", "getSSIDStats()")`
+- **AND** a case with that same `(source.object, source.api)` pair has `source.row` equal to one of those candidate rows
+- **THEN** runtime alignment selects that row as the canonical target
+- **AND** the case is not blocked only because the object-api family has multiple rows
+
+#### Scenario: Duplicate getter family remains unresolved
+- **WHEN** the template contains multiple rows for `("WiFi.SSID.{i}.", "getSSIDStats()")`
+- **AND** a case with that same `(source.object, source.api)` pair has no `source.row` match in that candidate family
+- **THEN** the case is classified as `blocked`
+- **AND** no filename, `source.row`, or `id` mutation is applied
+
+#### Scenario: Unique object-api pair still auto-aligns
+- **WHEN** the template contains exactly one row for a case's `(source.object, source.api)` pair
+- **THEN** runtime alignment keeps the existing `already_aligned` or `auto_aligned` behavior
+- **AND** collision resolution only applies after the case is proven to reference a unique template row

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/specs/wifi-llapi-official-inventory/spec.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/specs/wifi-llapi-official-inventory/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Official wifi_llapi inventory SHALL be workbook-authoritative
+The system SHALL treat the current checked-in wifi_llapi template workbook as the only authoritative source for official discoverable case inventory. Every official workbook row MUST map to exactly one discoverable YAML in `plugins/wifi_llapi/cases/`.
+
+#### Scenario: Workbook row has exactly one canonical discoverable YAML
+- **WHEN** the inventory audit evaluates an official workbook row
+- **THEN** it finds exactly one discoverable YAML whose filename row and `source.row` both match that workbook row
+
+#### Scenario: Workbook row is missing from discoverable inventory
+- **WHEN** the inventory audit evaluates an official workbook row and no canonical discoverable YAML exists for it
+- **THEN** the row is reported as missing
+- **AND** the row is not silently skipped or treated as covered by a different discoverable case
+
+### Requirement: Non-canonical discoverable wifi_llapi cases MUST be classified explicitly
+The inventory repair flow MUST classify discoverable `wifi_llapi` YAML that do not satisfy canonical workbook inventory as drifted, duplicate, or extra before any reconcile is applied.
+
+#### Scenario: Discoverable case carries stale canonical metadata
+- **WHEN** a discoverable YAML has a `source.row` or filename row that does not match its canonical workbook row
+- **THEN** the inventory audit reports it as drifted
+
+#### Scenario: Multiple discoverable cases claim the same workbook row
+- **WHEN** more than one discoverable YAML maps to the same official workbook row
+- **THEN** the inventory audit reports the row as duplicated
+- **AND** the reconcile flow chooses at most one canonical discoverable case for that row
+
+#### Scenario: Discoverable case is not part of official workbook inventory
+- **WHEN** a discoverable YAML does not belong to the workbook-defined official inventory
+- **THEN** the inventory audit reports it as extra
+
+### Requirement: Inventory reconcile MUST make missing and extra rows explicit
+The inventory reconcile flow MUST restore or preserve canonical discoverable coverage for each official workbook row, and it MUST demote non-canonical leftovers out of discoverable inventory instead of leaving them as silent duplicates.
+
+#### Scenario: Missing official row is restorable from repo history
+- **WHEN** an official workbook row is missing and a historical canonical YAML exists in repo history
+- **THEN** the reconcile flow restores that row into discoverable inventory
+
+#### Scenario: Extra historical YAML still has fixture value
+- **WHEN** a non-canonical YAML should be kept for reference or testing
+- **THEN** the reconcile flow demotes it out of discoverable inventory
+- **AND** the file no longer participates in official case discovery
+
+#### Scenario: Missing row cannot be restored automatically
+- **WHEN** an official workbook row is missing and no safe restoration source exists
+- **THEN** the reconcile flow reports an explicit blocker
+- **AND** the row remains visible in blocker reporting until resolved

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/tasks.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/tasks.md
@@ -1,0 +1,27 @@
+## 1. Runtime alignment repair
+
+- [x] 1.1 Add regression tests proving `align_case()` uses `source.row` to resolve ambiguous `(source.object, source.api)` families when the row is one of the template candidates
+- [x] 1.2 Keep `ambiguous_object_api_family` blocking behavior for families that still cannot be resolved by `source.row`
+- [x] 1.3 Update `src/testpilot/reporting/wifi_llapi_align.py` to select the canonical row from `candidate_rows` when `source.row` is present and valid
+- [x] 1.4 Re-run targeted alignment tests and confirm the new row-disambiguation behavior stays green
+
+## 2. Official inventory audit
+
+- [x] 2.1 Create workbook-driven inventory audit helpers that classify discoverable `wifi_llapi` YAML as canonical, missing, drifted, duplicate, or extra
+- [x] 2.2 Add unit tests covering missing rows, stale row-bearing metadata, and duplicate/extra discoverable cases
+- [x] 2.3 Expose a machine-checkable audit result that can be used by repo-scale tests and reconcile tooling
+
+## 3. Inventory reconcile flow
+
+- [x] 3.1 Create a reconcile script that prints restore/rewrite/demote actions in dry-run mode
+- [x] 3.2 Restore missing canonical rows from repo history when a historical `D###_*.yaml` exists
+- [x] 3.3 Rewrite drifted cases to canonical row-bearing metadata and demote non-canonical leftovers out of discoverable inventory
+- [x] 3.4 Add repo-scale inventory tests asserting one discoverable YAML per official workbook row with no silent omissions
+
+## 4. Integration verification and docs sync
+
+- [x] 4.1 Add orchestrator/runtime regression coverage proving row-correct ambiguous-family cases are runnable instead of blocked
+- [ ] 4.2 Apply the reconcile flow to `plugins/wifi_llapi/cases/` and review the resulting canonical inventory diff
+- [ ] 4.3 Re-run the problematic case set to confirm rows are executed or explicitly blocked, never silently skipped
+- [ ] 4.4 Sync `README.md`, `docs/plan.md`, and `docs/todos.md` to the repaired canonical inventory
+- [ ] 4.5 Run full repo regression and archive any remaining blockers explicitly before claiming completion

--- a/openspec/changes/wifi-llapi-inventory-runtime-repair/tasks.md
+++ b/openspec/changes/wifi-llapi-inventory-runtime-repair/tasks.md
@@ -22,6 +22,22 @@
 
 - [x] 4.1 Add orchestrator/runtime regression coverage proving row-correct ambiguous-family cases are runnable instead of blocked
 - [ ] 4.2 Apply the reconcile flow to `plugins/wifi_llapi/cases/` and review the resulting canonical inventory diff
+  Blocked on the current real-repo reconcile dry-run: `376 actions / 344 blockers`
+  (`missing_history_candidate`: 280, `ambiguous_history_candidate`: 57, `unresolved_object_api_family`: 7).
+  The accepted Task 3 planner must stop on those blockers instead of guessing restore/apply behavior.
 - [ ] 4.3 Re-run the problematic case set to confirm rows are executed or explicitly blocked, never silently skipped
+  Current target-row accounting on the real repo is explicit, not silent:
+  `D034/D095/D096/D100` are canonical discoverable rows;
+  `D308/D313/D316/D327/D329/D337/D406/D495` are discoverable drifted rows scheduled for
+  `rewrite:canonical_row_bearing_metadata`;
+  `D407` remains missing behind `ambiguous_history_candidate`.
+  Repo-scale invariants currently hold (`missing_uncovered = 0`, `unresolved_uncovered = 0`),
+  but a full rerun of the repaired target set remains blocked until 4.2 can safely apply the
+  canonical inventory changes.
 - [ ] 4.4 Sync `README.md`, `docs/plan.md`, and `docs/todos.md` to the repaired canonical inventory
+  Blocked until 4.2 produces a safe canonical inventory diff to document.
 - [ ] 4.5 Run full repo regression and archive any remaining blockers explicitly before claiming completion
+  Partial verification is done (`mixed_alignment` runtime regression plus targeted wifi_llapi suites).
+  Full repo regression currently stops at the unrelated baseline failure
+  `tests/test_topology.py::test_variable_resolve`
+  (`SSID_5G` expected `testpilot5G`, got `TestPilot_5G`), so Task 4 cannot be closed yet.

--- a/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
+++ b/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
@@ -424,7 +424,8 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     source_xlsx = project_root / "source.xlsx"
     wb = load_workbook(source_xlsx)
     ws = wb["Wifi_LLAPI"]
-    # Inject a duplicate family into the generated template so runtime alignment must block it.
+    # Inject a duplicate family into the generated template so runtime alignment must
+    # still run the row-correct case and only block the row-mismatched one.
     ws["A30"] = "WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
     ws["C30"] = "HeCapabilities"
     wb.save(source_xlsx)
@@ -525,12 +526,12 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
     result = orch.run("wifi_llapi", dut_fw_ver="FW-IT-REALISTIC-1")
 
     assert result["status"] == "completed"
-    assert result["cases_count"] == 1
-    assert result["agent_trace_count"] == 1
+    assert result["cases_count"] == 2
+    assert result["agent_trace_count"] == 2
     summary = json.loads(Path(result["json_report_path"]).read_text(encoding="utf-8"))
     assert summary["meta"]["alignment_summary"]["already_aligned"] == 1
-    assert summary["meta"]["alignment_summary"]["auto_aligned"] == 0
-    assert summary["meta"]["alignment_summary"]["blocked"] == 2
+    assert summary["meta"]["alignment_summary"]["auto_aligned"] == 1
+    assert summary["meta"]["alignment_summary"]["blocked"] == 1
     assert summary["meta"]["alignment_summary"]["skipped"] == 0
     assert summary["meta"]["alignment_summary"]["blocked_details"] == [
         {
@@ -538,23 +539,23 @@ def test_run_with_mixed_alignment(tmp_path: Path, monkeypatch):
             "reason": "ambiguous_object_api_family",
             "candidate_template_rows": [21, 30],
         },
-        {
-            "case_id": "wifi-llapi-D030-duplicate",
-            "reason": "ambiguous_object_api_family",
-            "candidate_template_rows": [21, 30],
-        },
     ]
     assert yaml.safe_load((cases_dir / "D021_hecapabilities.yaml").read_text(encoding="utf-8"))[
         "source"
     ]["row"] == 7
-    assert yaml.safe_load((cases_dir / "D030_duplicate.yaml").read_text(encoding="utf-8"))["source"][
+    assert not (cases_dir / "D030_duplicate.yaml").exists()
+    assert yaml.safe_load((cases_dir / "D021_duplicate.yaml").read_text(encoding="utf-8"))["source"][
         "row"
     ] == 21
+    assert any(
+        mutation["case_id"] == "wifi-llapi-D030-duplicate" and mutation["status"] == "auto_aligned"
+        for mutation in summary["meta"]["alignment_summary"]["mutations"]
+    )
     blocked_report = Path(result["artifact_dir"]) / "blocked_cases.md"
     assert blocked_report.is_file()
     blocked_text = blocked_report.read_text(encoding="utf-8")
     assert "wifi-llapi-D021-hecapabilities" in blocked_text
-    assert "wifi-llapi-D030-duplicate" in blocked_text
+    assert "wifi-llapi-D030-duplicate" not in blocked_text
     assert "ambiguous_object_api_family" in blocked_text
     assert "@ rows [21, 30]" in blocked_text
     skipped_report = Path(result["artifact_dir"]) / "skipped_cases.md"

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -131,6 +131,75 @@ def test_align_blocks_ambiguous_object_api_family(tmp_path: Path):
     assert result.candidate_template_rows == [4, 5]
 
 
+def test_align_uses_source_row_to_break_ambiguous_object_api_family(tmp_path: Path):
+    template = tmp_path / "template.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.SSID.{i}."
+    ws["C4"] = "getSSIDStats()"
+    ws["A5"] = "WiFi.SSID.{i}."
+    ws["C5"] = "getSSIDStats()"
+    wb.save(template)
+    wb.close()
+    index = build_template_index(template)
+    case_file = tmp_path / "D005_getssidstats.yaml"
+    case_file.write_text("stub\n", encoding="utf-8")
+
+    result = align_case(
+        {
+            "id": "wifi-llapi-D005-getssidstats",
+            "name": "getSSIDStats()",
+            "source": {
+                "row": 5,
+                "object": "WiFi.SSID.{i}.",
+                "api": "getSSIDStats()",
+            },
+        },
+        index,
+        case_file,
+    )
+
+    assert result.status == "already_aligned"
+    assert result.template_row == 5
+    assert result.source_row_after == 5
+    assert result.blocked_reason is None
+
+
+def test_align_keeps_blocked_when_source_row_is_not_in_ambiguous_family(tmp_path: Path):
+    template = tmp_path / "template.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.SSID.{i}."
+    ws["C4"] = "getSSIDStats()"
+    ws["A5"] = "WiFi.SSID.{i}."
+    ws["C5"] = "getSSIDStats()"
+    wb.save(template)
+    wb.close()
+    index = build_template_index(template)
+    case_file = tmp_path / "D021_getssidstats.yaml"
+    case_file.write_text("stub\n", encoding="utf-8")
+
+    result = align_case(
+        {
+            "id": "wifi-llapi-D021-getssidstats",
+            "name": "getSSIDStats()",
+            "source": {
+                "row": 21,
+                "object": "WiFi.SSID.{i}.",
+                "api": "getSSIDStats()",
+            },
+        },
+        index,
+        case_file,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocked_reason == "ambiguous_object_api_family"
+    assert result.candidate_template_rows == [4, 5]
+
+
 def test_align_already_aligned(tmp_path: Path, template_path: Path):
     template = template_path
     index = build_template_index(template)

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -143,12 +143,12 @@ def test_align_uses_source_row_to_break_ambiguous_object_api_family(tmp_path: Pa
     wb.save(template)
     wb.close()
     index = build_template_index(template)
-    case_file = tmp_path / "D005_getssidstats.yaml"
+    case_file = tmp_path / "D021_getssidstats.yaml"
     case_file.write_text("stub\n", encoding="utf-8")
 
     result = align_case(
         {
-            "id": "wifi-llapi-D005-getssidstats",
+            "id": "wifi-llapi-D021-getssidstats",
             "name": "getSSIDStats()",
             "source": {
                 "row": 5,
@@ -160,9 +160,10 @@ def test_align_uses_source_row_to_break_ambiguous_object_api_family(tmp_path: Pa
         case_file,
     )
 
-    assert result.status == "already_aligned"
+    assert result.status == "auto_aligned"
     assert result.template_row == 5
     assert result.source_row_after == 5
+    assert result.filename_after == "D005_getssidstats.yaml"
     assert result.blocked_reason is None
 
 
@@ -175,6 +176,8 @@ def test_align_keeps_blocked_when_source_row_is_not_in_ambiguous_family(tmp_path
     ws["C4"] = "getSSIDStats()"
     ws["A5"] = "WiFi.SSID.{i}."
     ws["C5"] = "getSSIDStats()"
+    ws["A6"] = "WiFi.SSID.{i}."
+    ws["C6"] = "getRadioStats()"
     wb.save(template)
     wb.close()
     index = build_template_index(template)

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -164,6 +164,7 @@ def test_align_uses_source_row_to_break_ambiguous_object_api_family(tmp_path: Pa
     assert result.template_row == 5
     assert result.source_row_after == 5
     assert result.filename_after == "D005_getssidstats.yaml"
+    assert result.id_after == "wifi-llapi-D005-getssidstats"
     assert result.blocked_reason is None
 
 
@@ -172,26 +173,24 @@ def test_align_keeps_blocked_when_source_row_is_not_in_ambiguous_family(tmp_path
     wb = Workbook()
     ws = wb.active
     ws.title = "Wifi_LLAPI"
-    ws["A4"] = "WiFi.SSID.{i}."
-    ws["C4"] = "getSSIDStats()"
-    ws["A5"] = "WiFi.SSID.{i}."
-    ws["C5"] = "getSSIDStats()"
-    ws["A6"] = "WiFi.SSID.{i}."
-    ws["C6"] = "getRadioStats()"
+    ws["A8"] = "WiFi.Radio.{i}."
+    ws["C8"] = "getRadioStats()"
+    ws["A11"] = "WiFi.Radio.{i}."
+    ws["C11"] = "getRadioStats()"
     wb.save(template)
     wb.close()
     index = build_template_index(template)
-    case_file = tmp_path / "D021_getssidstats.yaml"
+    case_file = tmp_path / "D010_getradiostats.yaml"
     case_file.write_text("stub\n", encoding="utf-8")
 
     result = align_case(
         {
-            "id": "wifi-llapi-D021-getssidstats",
-            "name": "getSSIDStats()",
+            "id": "wifi-llapi-D010-getradiostats",
+            "name": "getRadioStats()",
             "source": {
-                "row": 21,
-                "object": "WiFi.SSID.{i}.",
-                "api": "getSSIDStats()",
+                "row": 10,
+                "object": "WiFi.Radio.{i}.",
+                "api": "getRadioStats()",
             },
         },
         index,
@@ -200,7 +199,7 @@ def test_align_keeps_blocked_when_source_row_is_not_in_ambiguous_family(tmp_path
 
     assert result.status == "blocked"
     assert result.blocked_reason == "ambiguous_object_api_family"
-    assert result.candidate_template_rows == [4, 5]
+    assert result.candidate_template_rows == [8, 11]
 
 
 def test_align_already_aligned(tmp_path: Path, template_path: Path):

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_inventory.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_inventory.py
@@ -135,3 +135,53 @@ def test_audit_to_dict_is_machine_checkable(tmp_path: Path) -> None:
     assert payload["missing_rows"] == [5, 6, 7]
     assert payload["cases"]["D004_canonical.yaml"]["status"] == "canonical"
     assert payload["rows"]["4"]["canonical_case_file"] == "D004_canonical.yaml"
+
+
+def test_audit_marks_unresolved_in_template_family_as_drifted(tmp_path: Path) -> None:
+    template = tmp_path / "template.xlsx"
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+    _write_template(template)
+    from openpyxl import load_workbook
+
+    wb = load_workbook(template)
+    ws = wb["Wifi_LLAPI"]
+    ws["A8"] = "WiFi.SSID.{i}."
+    ws["C8"] = "getSSIDStats()"
+    wb.save(template)
+    wb.close()
+    _write_case(
+        cases_dir / "D099_family_drift.yaml",
+        case_id="wifi-llapi-D099-family-drift",
+        name="getSSIDStats()",
+        row=99,
+        obj="WiFi.SSID.{i}.",
+        api="getSSIDStats()",
+    )
+
+    audit = audit_wifi_llapi_inventory(template, cases_dir)
+
+    assert audit.cases["D099_family_drift.yaml"].status == "drifted"
+    assert audit.cases["D099_family_drift.yaml"].reason == "unresolved_object_api_family"
+
+
+def test_audit_treats_stale_id_fragment_as_drifted_metadata(tmp_path: Path) -> None:
+    template = tmp_path / "template.xlsx"
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+    _write_template(template)
+    _write_case(
+        cases_dir / "D004_stale_id.yaml",
+        case_id="wifi-llapi-D099-stale-id",
+        name="getRadioStats()",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+
+    audit = audit_wifi_llapi_inventory(template, cases_dir)
+
+    assert audit.rows[4].status == "drifted"
+    assert audit.rows[4].canonical_case_file is None
+    assert audit.cases["D004_stale_id.yaml"].status == "drifted"
+    assert audit.cases["D004_stale_id.yaml"].resolved_row == 4

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_inventory.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_inventory.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from openpyxl import Workbook
+
+from testpilot.reporting.wifi_llapi_inventory import audit_wifi_llapi_inventory
+
+
+def _write_template(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.Radio.{i}."
+    ws["C4"] = "getRadioStats()"
+    ws["A5"] = "WiFi.SSID.{i}."
+    ws["C5"] = "getSSIDStats()"
+    ws["A6"] = "WiFi.AccessPoint.{i}."
+    ws["C6"] = "getAPStats()"
+    ws["A7"] = "WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
+    ws["C7"] = "AssociatedDeviceNumberOfEntries"
+    wb.save(path)
+    wb.close()
+
+
+def _write_case(path: Path, *, case_id: str, name: str, row: int, obj: str, api: str) -> None:
+    payload = {
+        "id": case_id,
+        "name": name,
+        "topology": {"devices": {"DUT": {}, "STA": {}}},
+        "steps": [
+            {
+                "id": "step-1",
+                "action": "noop",
+                "target": "DUT",
+            }
+        ],
+        "pass_criteria": [{"field": "status", "operator": "equals", "expected": "Pass"}],
+        "source": {
+            "row": row,
+            "object": obj,
+            "api": api,
+        },
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+
+def test_audit_classifies_missing_drifted_duplicate_and_extra_cases(tmp_path: Path) -> None:
+    template = tmp_path / "template.xlsx"
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+    _write_template(template)
+
+    _write_case(
+        cases_dir / "D004_canonical.yaml",
+        case_id="wifi-llapi-D004-canonical",
+        name="getRadioStats()",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+    _write_case(
+        cases_dir / "D009_stale.yaml",
+        case_id="wifi-llapi-D009-stale",
+        name="getSSIDStats()",
+        row=9,
+        obj="WiFi.SSID.{i}.",
+        api="getSSIDStats()",
+    )
+    _write_case(
+        cases_dir / "D006_canonical.yaml",
+        case_id="wifi-llapi-D006-canonical",
+        name="getAPStats()",
+        row=6,
+        obj="WiFi.AccessPoint.{i}.",
+        api="getAPStats()",
+    )
+    _write_case(
+        cases_dir / "D006_duplicate.yaml",
+        case_id="wifi-llapi-D006-duplicate",
+        name="getAPStats()",
+        row=6,
+        obj="WiFi.AccessPoint.{i}.",
+        api="getAPStats()",
+    )
+    _write_case(
+        cases_dir / "D999_extra.yaml",
+        case_id="wifi-llapi-D999-extra",
+        name="not-in-template()",
+        row=999,
+        obj="WiFi.NotInTemplate.{i}.",
+        api="notInTemplate()",
+    )
+
+    audit = audit_wifi_llapi_inventory(template, cases_dir)
+
+    assert audit.missing_rows == (7,)
+    assert audit.case_status_counts == {
+        "canonical": 2,
+        "drifted": 1,
+        "duplicate": 1,
+        "extra": 1,
+    }
+    assert audit.rows[4].status == "canonical"
+    assert audit.rows[5].status == "drifted"
+    assert audit.rows[6].status == "duplicate"
+    assert audit.rows[7].status == "missing"
+    assert audit.rows[5].canonical_case_file is None
+    assert audit.rows[6].canonical_case_file == "D006_canonical.yaml"
+    assert audit.cases["D009_stale.yaml"].status == "drifted"
+    assert audit.cases["D009_stale.yaml"].resolved_row == 5
+    assert audit.cases["D006_duplicate.yaml"].status == "duplicate"
+    assert audit.cases["D006_duplicate.yaml"].resolved_row == 6
+    assert audit.cases["D999_extra.yaml"].status == "extra"
+
+
+def test_audit_to_dict_is_machine_checkable(tmp_path: Path) -> None:
+    template = tmp_path / "template.xlsx"
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+    _write_template(template)
+    _write_case(
+        cases_dir / "D004_canonical.yaml",
+        case_id="wifi-llapi-D004-canonical",
+        name="getRadioStats()",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+
+    audit = audit_wifi_llapi_inventory(template, cases_dir)
+    payload = audit.to_dict()
+
+    assert payload["missing_rows"] == [5, 6, 7]
+    assert payload["cases"]["D004_canonical.yaml"]["status"] == "canonical"
+    assert payload["rows"]["4"]["canonical_case_file"] == "D004_canonical.yaml"

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from openpyxl import Workbook
+
+from testpilot.reporting.wifi_llapi_inventory import (
+    audit_wifi_llapi_inventory,
+    build_wifi_llapi_inventory_reconcile_plan,
+    apply_wifi_llapi_inventory_reconcile_plan,
+)
+
+
+def _write_template(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Wifi_LLAPI"
+    ws["A4"] = "WiFi.Radio.{i}."
+    ws["C4"] = "getRadioStats()"
+    ws["A5"] = "WiFi.SSID.{i}."
+    ws["C5"] = "getSSIDStats()"
+    wb.save(path)
+    wb.close()
+
+
+def _write_case(path: Path, *, case_id: str, row: int, obj: str, api: str) -> None:
+    payload = {
+        "id": case_id,
+        "name": api,
+        "topology": {"devices": {"DUT": {}, "STA": {}}},
+        "steps": [{"id": "step-1", "action": "noop", "target": "DUT"}],
+        "pass_criteria": [{"field": "status", "operator": "equals", "expected": "Pass"}],
+        "source": {"row": row, "object": obj, "api": api},
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+
+def test_reconcile_plan_reports_restore_rewrite_and_demote_actions(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    cases_dir = repo_root / "plugins" / "wifi_llapi" / "cases"
+    templates_dir = repo_root / "plugins" / "wifi_llapi" / "reports" / "templates"
+    cases_dir.mkdir(parents=True)
+    templates_dir.mkdir(parents=True)
+    _write_template(templates_dir / "wifi_llapi_template.xlsx")
+
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+
+    restored_case = cases_dir / "D004_restored.yaml"
+    _write_case(restored_case, case_id="wifi-llapi-D004-restored", row=4, obj="WiFi.Radio.{i}.", api="getRadioStats()")
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "seed history"], cwd=repo_root, check=True, capture_output=True)
+    restored_case.unlink()
+    subprocess.run(["git", "add", "-u"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "remove canonical row"], cwd=repo_root, check=True, capture_output=True)
+
+    _write_case(
+        cases_dir / "D999_drifted.yaml",
+        case_id="wifi-llapi-D999-drifted",
+        row=999,
+        obj="WiFi.SSID.{i}.",
+        api="getSSIDStats()",
+    )
+    _write_case(
+        cases_dir / "D777_extra.yaml",
+        case_id="wifi-llapi-D777-extra",
+        row=777,
+        obj="WiFi.Unknown.{i}.",
+        api="notInTemplate()",
+    )
+
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        templates_dir / "wifi_llapi_template.xlsx",
+        cases_dir,
+        repo_root=repo_root,
+    )
+
+    assert any(action.kind == "restore" and action.row == 4 for action in plan.actions)
+    assert any(action.kind == "rewrite" and action.row == 5 for action in plan.actions)
+    assert any(action.kind == "demote" for action in plan.actions)
+    assert not plan.blockers
+
+    dry_run = plan.to_lines()
+    assert any(line.startswith("restore ") for line in dry_run)
+    assert any(line.startswith("rewrite ") for line in dry_run)
+    assert any(line.startswith("demote ") for line in dry_run)
+
+    script = Path(__file__).resolve().parents[3] / "scripts" / "wifi_llapi_reconcile_inventory.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--repo-root",
+            str(repo_root),
+            "--template-xlsx",
+            str(templates_dir / "wifi_llapi_template.xlsx"),
+            "--cases-dir",
+            str(cases_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "dry-run:" in result.stdout
+    assert "restore " in result.stdout
+    assert "rewrite " in result.stdout
+    assert "demote " in result.stdout
+
+    apply_wifi_llapi_inventory_reconcile_plan(plan)
+    audit = audit_wifi_llapi_inventory(templates_dir / "wifi_llapi_template.xlsx", cases_dir)
+    assert audit.missing_rows == ()
+    assert audit.case_status_counts["extra"] == 0
+    assert audit.rows[4].status == "canonical"
+    assert audit.rows[5].status == "canonical"
+
+
+def test_repo_scale_inventory_has_no_silent_official_row_omissions() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    audit = audit_wifi_llapi_inventory(
+        repo_root / "plugins" / "wifi_llapi" / "reports" / "templates" / "wifi_llapi_template.xlsx",
+        repo_root / "plugins" / "wifi_llapi" / "cases",
+    )
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        repo_root / "plugins" / "wifi_llapi" / "reports" / "templates" / "wifi_llapi_template.xlsx",
+        repo_root / "plugins" / "wifi_llapi" / "cases",
+        repo_root=repo_root,
+    )
+
+    blocker_rows = {action.row for action in plan.blockers}
+    restore_rows = {action.row for action in plan.actions if action.kind == "restore"}
+    assert set(audit.missing_rows) == blocker_rows | restore_rows
+    assert any(action.kind == "restore" for action in plan.actions)
+    assert any(action.kind == "rewrite" for action in plan.actions)
+    assert any(action.kind == "demote" for action in plan.actions)

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
@@ -39,6 +39,27 @@ def _write_case(path: Path, *, case_id: str, row: int, obj: str, api: str) -> No
     path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
 
 
+def _write_history_case(
+    path: Path,
+    *,
+    case_id: str,
+    row: int,
+    obj: str,
+    api: str,
+    marker: str,
+) -> None:
+    payload = {
+        "id": case_id,
+        "name": api,
+        "marker": marker,
+        "topology": {"devices": {"DUT": {}, "STA": {}}},
+        "steps": [{"id": "step-1", "action": "noop", "target": "DUT"}],
+        "pass_criteria": [{"field": "status", "operator": "equals", "expected": "Pass"}],
+        "source": {"row": row, "object": obj, "api": api},
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+
 def _init_repo(repo_root: Path) -> None:
     subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
@@ -176,6 +197,16 @@ def test_restore_target_occupied_by_demoted_file_is_applied_safely(tmp_path: Pat
     _write_template(templates_dir / "wifi_llapi_template.xlsx")
     _init_repo(repo_root)
 
+    _write_history_case(
+        cases_dir / "D004_restoretarget.yaml",
+        case_id="wifi-llapi-D004-restoretarget",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+        marker="v2",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "seed history"], cwd=repo_root, check=True, capture_output=True)
     _write_case(
         cases_dir / "D004_restoretarget.yaml",
         case_id="wifi-llapi-D004-restoretarget",
@@ -184,7 +215,8 @@ def test_restore_target_occupied_by_demoted_file_is_applied_safely(tmp_path: Pat
         api="getRadioStats()",
     )
     subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
-    subprocess.run(["git", "commit", "-m", "seed history"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "history v2"], cwd=repo_root, check=True, capture_output=True)
+    (cases_dir / "D004_restoretarget.yaml").unlink()
     _write_case(
         cases_dir / "D004_restoretarget.yaml",
         case_id="wifi-llapi-D004-restoretarget",
@@ -192,8 +224,6 @@ def test_restore_target_occupied_by_demoted_file_is_applied_safely(tmp_path: Pat
         obj="WiFi.Unknown.{i}.",
         api="notInTemplate()",
     )
-    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
-    subprocess.run(["git", "commit", "-m", "drift current file"], cwd=repo_root, check=True, capture_output=True)
     _write_case(
         cases_dir / "D005_canonical.yaml",
         case_id="wifi-llapi-D005-canonical",
@@ -217,6 +247,61 @@ def test_restore_target_occupied_by_demoted_file_is_applied_safely(tmp_path: Pat
     assert all(len(a.discoverable_case_files) == 1 for a in audit.rows.values())
 
 
+def test_history_restore_prefers_newest_revision_for_same_path(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    cases_dir = repo_root / "plugins" / "wifi_llapi" / "cases"
+    templates_dir = repo_root / "plugins" / "wifi_llapi" / "reports" / "templates"
+    cases_dir.mkdir(parents=True)
+    templates_dir.mkdir(parents=True)
+    _write_template(templates_dir / "wifi_llapi_template.xlsx")
+    _init_repo(repo_root)
+
+    _write_case(
+        cases_dir / "D005_canonical.yaml",
+        case_id="wifi-llapi-D005-canonical",
+        row=5,
+        obj="WiFi.SSID.{i}.",
+        api="getSSIDStats()",
+    )
+    case_path = cases_dir / "D004_history.yaml"
+    _write_history_case(
+        case_path,
+        case_id="wifi-llapi-D004-history",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+        marker="v1",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "history v1"], cwd=repo_root, check=True, capture_output=True)
+
+    _write_history_case(
+        case_path,
+        case_id="wifi-llapi-D004-history",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+        marker="v2",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "history v2"], cwd=repo_root, check=True, capture_output=True)
+
+    case_path.unlink()
+    subprocess.run(["git", "add", "-u"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "delete history"], cwd=repo_root, check=True, capture_output=True)
+
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        templates_dir / "wifi_llapi_template.xlsx",
+        cases_dir,
+        repo_root=repo_root,
+    )
+
+    assert any(action.kind == "restore" and action.row == 4 for action in plan.actions)
+    apply_wifi_llapi_inventory_reconcile_plan(plan)
+    restored = yaml.safe_load((cases_dir / "D004_history.yaml").read_text(encoding="utf-8"))
+    assert restored["marker"] == "v2"
+
+
 def test_repo_scale_inventory_reports_drifted_cases_without_omission() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     audit = audit_wifi_llapi_inventory(
@@ -229,7 +314,13 @@ def test_repo_scale_inventory_reports_drifted_cases_without_omission() -> None:
         repo_root=repo_root,
     )
 
-    omitted = {"D068_discoverymethodenabled_accesspoint_rnr.yaml", "D495_retrycount_ssid_stats_verified.yaml"}
-    present = {action.case_file.name for action in plan.actions if action.case_file is not None}
-    present |= {action.case_file.name for action in plan.blockers if action.case_file is not None}
-    assert omitted <= present
+    blocker_rows = {action.row for action in plan.blockers if action.row is not None}
+    restore_rows = {action.row for action in plan.actions if action.kind == "restore"}
+    assert set(audit.missing_rows) == blocker_rows | restore_rows
+    unresolved_drifted = {
+        case_audit.case_file.name
+        for case_audit in audit.cases.values()
+        if case_audit.status == "drifted" and case_audit.resolved_row is None
+    }
+    blocker_case_names = {action.case_file.name for action in plan.blockers if action.case_file is not None}
+    assert unresolved_drifted <= blocker_case_names

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
+import pytest
 
 import yaml
 from openpyxl import Workbook
@@ -38,6 +39,12 @@ def _write_case(path: Path, *, case_id: str, row: int, obj: str, api: str) -> No
     path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True), encoding="utf-8")
 
 
+def _init_repo(repo_root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+
+
 def test_reconcile_plan_reports_restore_rewrite_and_demote_actions(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     cases_dir = repo_root / "plugins" / "wifi_llapi" / "cases"
@@ -46,9 +53,7 @@ def test_reconcile_plan_reports_restore_rewrite_and_demote_actions(tmp_path: Pat
     templates_dir.mkdir(parents=True)
     _write_template(templates_dir / "wifi_llapi_template.xlsx")
 
-    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo_root, check=True)
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo_root, check=True)
+    _init_repo(repo_root)
 
     restored_case = cases_dir / "D004_restored.yaml"
     _write_case(restored_case, case_id="wifi-llapi-D004-restored", row=4, obj="WiFi.Radio.{i}.", api="getRadioStats()")
@@ -118,7 +123,101 @@ def test_reconcile_plan_reports_restore_rewrite_and_demote_actions(tmp_path: Pat
     assert audit.rows[5].status == "canonical"
 
 
-def test_repo_scale_inventory_has_no_silent_official_row_omissions() -> None:
+def test_ambiguous_history_candidate_becomes_blocker(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    cases_dir = repo_root / "plugins" / "wifi_llapi" / "cases"
+    templates_dir = repo_root / "plugins" / "wifi_llapi" / "reports" / "templates"
+    cases_dir.mkdir(parents=True)
+    templates_dir.mkdir(parents=True)
+    _write_template(templates_dir / "wifi_llapi_template.xlsx")
+    _init_repo(repo_root)
+
+    _write_case(
+        cases_dir / "D004_alpha.yaml",
+        case_id="wifi-llapi-D004-alpha",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "alpha"], cwd=repo_root, check=True, capture_output=True)
+    (cases_dir / "D004_alpha.yaml").unlink()
+    _write_case(
+        cases_dir / "D004_beta.yaml",
+        case_id="wifi-llapi-D004-beta",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "beta"], cwd=repo_root, check=True, capture_output=True)
+    (cases_dir / "D004_beta.yaml").unlink()
+    subprocess.run(["git", "add", "-u"], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "remove row"], cwd=repo_root, check=True, capture_output=True)
+
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        templates_dir / "wifi_llapi_template.xlsx",
+        cases_dir,
+        repo_root=repo_root,
+    )
+
+    assert any(action.reason == "ambiguous_history_candidate" for action in plan.blockers)
+    assert not any(action.kind == "restore" and action.row == 4 for action in plan.actions)
+    with pytest.raises(ValueError):
+        apply_wifi_llapi_inventory_reconcile_plan(plan)
+
+
+def test_restore_target_occupied_by_demoted_file_is_applied_safely(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    cases_dir = repo_root / "plugins" / "wifi_llapi" / "cases"
+    templates_dir = repo_root / "plugins" / "wifi_llapi" / "reports" / "templates"
+    cases_dir.mkdir(parents=True)
+    templates_dir.mkdir(parents=True)
+    _write_template(templates_dir / "wifi_llapi_template.xlsx")
+    _init_repo(repo_root)
+
+    _write_case(
+        cases_dir / "D004_restoretarget.yaml",
+        case_id="wifi-llapi-D004-restoretarget",
+        row=4,
+        obj="WiFi.Radio.{i}.",
+        api="getRadioStats()",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "seed history"], cwd=repo_root, check=True, capture_output=True)
+    _write_case(
+        cases_dir / "D004_restoretarget.yaml",
+        case_id="wifi-llapi-D004-restoretarget",
+        row=999,
+        obj="WiFi.Unknown.{i}.",
+        api="notInTemplate()",
+    )
+    subprocess.run(["git", "add", "."], cwd=repo_root, check=True)
+    subprocess.run(["git", "commit", "-m", "drift current file"], cwd=repo_root, check=True, capture_output=True)
+    _write_case(
+        cases_dir / "D005_canonical.yaml",
+        case_id="wifi-llapi-D005-canonical",
+        row=5,
+        obj="WiFi.SSID.{i}.",
+        api="getSSIDStats()",
+    )
+
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        templates_dir / "wifi_llapi_template.xlsx",
+        cases_dir,
+        repo_root=repo_root,
+    )
+
+    assert any(action.kind == "restore" and action.row == 4 for action in plan.actions)
+    assert any(action.kind == "demote" and action.case_file.name == "D004_restoretarget.yaml" for action in plan.actions)
+    apply_wifi_llapi_inventory_reconcile_plan(plan)
+    audit = audit_wifi_llapi_inventory(templates_dir / "wifi_llapi_template.xlsx", cases_dir)
+    assert audit.rows[4].status == "canonical"
+    assert audit.rows[5].status == "canonical"
+    assert all(len(a.discoverable_case_files) == 1 for a in audit.rows.values())
+
+
+def test_repo_scale_inventory_reports_drifted_cases_without_omission() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     audit = audit_wifi_llapi_inventory(
         repo_root / "plugins" / "wifi_llapi" / "reports" / "templates" / "wifi_llapi_template.xlsx",
@@ -130,9 +229,7 @@ def test_repo_scale_inventory_has_no_silent_official_row_omissions() -> None:
         repo_root=repo_root,
     )
 
-    blocker_rows = {action.row for action in plan.blockers}
-    restore_rows = {action.row for action in plan.actions if action.kind == "restore"}
-    assert set(audit.missing_rows) == blocker_rows | restore_rows
-    assert any(action.kind == "restore" for action in plan.actions)
-    assert any(action.kind == "rewrite" for action in plan.actions)
-    assert any(action.kind == "demote" for action in plan.actions)
+    omitted = {"D068_discoverymethodenabled_accesspoint_rnr.yaml", "D495_retrycount_ssid_stats_verified.yaml"}
+    present = {action.case_file.name for action in plan.actions if action.case_file is not None}
+    present |= {action.case_file.name for action in plan.blockers if action.case_file is not None}
+    assert omitted <= present

--- a/scripts/wifi_llapi_reconcile_inventory.py
+++ b/scripts/wifi_llapi_reconcile_inventory.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from testpilot.reporting.wifi_llapi_inventory import (
+    apply_wifi_llapi_inventory_reconcile_plan,
+    build_wifi_llapi_inventory_reconcile_plan,
+)
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reconcile wifi_llapi inventory")
+    parser.add_argument(
+        "--template-xlsx",
+        type=Path,
+        default=_project_root() / "plugins" / "wifi_llapi" / "reports" / "templates" / "wifi_llapi_template.xlsx",
+        help="Workbook used as the official inventory source.",
+    )
+    parser.add_argument(
+        "--cases-dir",
+        type=Path,
+        default=_project_root() / "plugins" / "wifi_llapi" / "cases",
+        help="Discoverable wifi_llapi case directory.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_project_root(),
+        help="Repository root for git history lookups.",
+    )
+    parser.add_argument("--apply", action="store_true", help="Apply the reconcile plan in place.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    plan = build_wifi_llapi_inventory_reconcile_plan(
+        args.template_xlsx,
+        args.cases_dir,
+        repo_root=args.repo_root,
+    )
+
+    mode = "apply" if args.apply else "dry-run"
+    print(f"{mode}: {len(plan.actions)} actions, {len(plan.blockers)} blockers")
+    for line in plan.to_lines():
+        print(line)
+
+    if plan.blockers:
+        return 1
+    if args.apply:
+        apply_wifi_llapi_inventory_reconcile_plan(plan)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -134,22 +134,27 @@ def align_case(case: dict, index: TemplateIndex, case_file: Path) -> AlignResult
             id_after=None,
             blocked_reason="object_api_not_in_template",
         )
+    template_row: int | None = None
     if len(candidate_rows) > 1:
-        return AlignResult(
-            case_file=case_file,
-            status="blocked",
-            source_row_before=source_row_before,
-            source_row_after=None,
-            source_object=obj,
-            source_api=api,
-            filename_before=filename_before,
-            filename_after=None,
-            id_before=case_id,
-            id_after=None,
-            blocked_reason="ambiguous_object_api_family",
-            candidate_template_rows=list(candidate_rows),
-        )
-    template_row = candidate_rows[0]
+        if source_row_before in candidate_rows:
+            template_row = source_row_before
+        else:
+            return AlignResult(
+                case_file=case_file,
+                status="blocked",
+                source_row_before=source_row_before,
+                source_row_after=None,
+                source_object=obj,
+                source_api=api,
+                filename_before=filename_before,
+                filename_after=None,
+                id_before=case_id,
+                id_after=None,
+                blocked_reason="ambiguous_object_api_family",
+                candidate_template_rows=list(candidate_rows),
+            )
+    else:
+        template_row = candidate_rows[0]
     template_object, template_api = index.forward.get(template_row, ("", ""))
     if name_api and name_api != template_api:
         name_api_candidates = index.by_api.get(name_api, [])

--- a/src/testpilot/reporting/wifi_llapi_inventory.py
+++ b/src/testpilot/reporting/wifi_llapi_inventory.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+from typing import Any, Literal
+
+from testpilot.reporting.wifi_llapi_align import build_template_index
+from testpilot.reporting.wifi_llapi_excel import normalize_text
+from testpilot.schema.case_schema import load_case, validate_wifi_llapi_case
+
+_FILE_D_PATTERN = re.compile(r"^D(?P<row>\d{3})(?P<suffix>.*)$")
+_ID_D_PATTERN = re.compile(r"(wifi-llapi-D)(\d{3})(-)")
+
+CaseStatus = Literal["canonical", "drifted", "duplicate", "extra"]
+RowStatus = Literal["canonical", "missing", "drifted", "duplicate"]
+
+
+@dataclass(slots=True)
+class WifiLlapiInventoryCaseAudit:
+    case_file: Path
+    case_id: str
+    source_row: int | None
+    source_object: str
+    source_api: str
+    resolved_row: int | None
+    status: CaseStatus
+    reason: str
+    filename_row: int | None
+    id_row: int | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "case_file": str(self.case_file),
+            "case_id": self.case_id,
+            "source_row": self.source_row,
+            "source_object": self.source_object,
+            "source_api": self.source_api,
+            "resolved_row": self.resolved_row,
+            "status": self.status,
+            "reason": self.reason,
+            "filename_row": self.filename_row,
+            "id_row": self.id_row,
+        }
+
+
+@dataclass(slots=True)
+class WifiLlapiInventoryRowAudit:
+    row: int
+    source_object: str
+    source_api: str
+    status: RowStatus
+    discoverable_case_files: tuple[str, ...] = ()
+    canonical_case_file: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "row": self.row,
+            "source_object": self.source_object,
+            "source_api": self.source_api,
+            "status": self.status,
+            "discoverable_case_files": list(self.discoverable_case_files),
+            "canonical_case_file": self.canonical_case_file,
+        }
+
+
+@dataclass(slots=True)
+class WifiLlapiInventoryAudit:
+    template_xlsx: Path
+    cases_dir: Path
+    rows: dict[int, WifiLlapiInventoryRowAudit] = field(default_factory=dict)
+    cases: dict[str, WifiLlapiInventoryCaseAudit] = field(default_factory=dict)
+    case_status_counts: dict[str, int] = field(default_factory=dict)
+    missing_rows: tuple[int, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "template_xlsx": str(self.template_xlsx),
+            "cases_dir": str(self.cases_dir),
+            "rows": {str(row): audit.to_dict() for row, audit in sorted(self.rows.items())},
+            "cases": {name: audit.to_dict() for name, audit in sorted(self.cases.items())},
+            "case_status_counts": dict(sorted(self.case_status_counts.items())),
+            "missing_rows": list(self.missing_rows),
+        }
+
+
+def _extract_row_from_filename(case_file: Path) -> int | None:
+    match = _FILE_D_PATTERN.match(case_file.stem)
+    if not match:
+        return None
+    return int(match.group("row"))
+
+
+def _extract_row_from_case_id(case_id: str) -> int | None:
+    match = _ID_D_PATTERN.search(case_id)
+    if not match:
+        return None
+    return int(match.group(2))
+
+
+def _is_canonical_metadata(case: dict[str, Any], row: int, case_file: Path) -> bool:
+    source = case.get("source") if isinstance(case.get("source"), dict) else {}
+    source_row = source.get("row")
+    return (
+        int(source_row or 0) == row
+        and _extract_row_from_filename(case_file) == row
+        and _extract_row_from_case_id(str(case.get("id", ""))) == row
+    )
+
+
+def _load_discoverable_cases(cases_dir: Path) -> list[tuple[Path, dict[str, Any]]]:
+    if not cases_dir.is_dir():
+        return []
+    discovered: list[tuple[Path, dict[str, Any]]] = []
+    for case_file in sorted(cases_dir.glob("*.y*ml")):
+        if case_file.stem.startswith("_"):
+            continue
+        case = load_case(case_file, validator=validate_wifi_llapi_case)
+        discovered.append((case_file, case))
+    return discovered
+
+
+def _resolve_case_row(
+    case: dict[str, Any],
+    candidate_rows: list[int],
+) -> int | None:
+    source = case.get("source") if isinstance(case.get("source"), dict) else {}
+    source_row = int(source.get("row", 0) or 0)
+    if source_row in candidate_rows:
+        return source_row
+    if len(candidate_rows) == 1:
+        return candidate_rows[0]
+    return None
+
+
+def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str) -> WifiLlapiInventoryAudit:
+    template_xlsx = Path(template_xlsx)
+    cases_dir = Path(cases_dir)
+    index = build_template_index(template_xlsx)
+    official_rows = sorted(index.forward)
+
+    discovered_cases = _load_discoverable_cases(cases_dir)
+    row_groups: dict[int, list[tuple[Path, dict[str, Any]]]] = {row: [] for row in official_rows}
+    case_audits: dict[str, WifiLlapiInventoryCaseAudit] = {}
+    extra_rows: dict[str, WifiLlapiInventoryCaseAudit] = {}
+
+    for case_file, case in discovered_cases:
+        source = case.get("source") if isinstance(case.get("source"), dict) else {}
+        source_object = normalize_text(source.get("object"))
+        source_api = normalize_text(source.get("api"))
+        source_row = int(source.get("row", 0) or 0) or None
+        case_id = str(case.get("id", ""))
+        filename_row = _extract_row_from_filename(case_file)
+        id_row = _extract_row_from_case_id(case_id)
+        candidate_rows = index.by_object_api.get((source_object, source_api), [])
+        resolved_row = _resolve_case_row(case, candidate_rows)
+        if resolved_row is None:
+            audit = WifiLlapiInventoryCaseAudit(
+                case_file=case_file,
+                case_id=case_id,
+                source_row=source_row,
+                source_object=source_object,
+                source_api=source_api,
+                resolved_row=None,
+                status="extra",
+                reason="object_api_not_in_template" if not candidate_rows else "unresolved_object_api_family",
+                filename_row=filename_row,
+                id_row=id_row,
+            )
+            extra_rows[case_file.name] = audit
+            continue
+        row_groups.setdefault(resolved_row, []).append((case_file, case))
+        case_audits[case_file.name] = WifiLlapiInventoryCaseAudit(
+            case_file=case_file,
+            case_id=case_id,
+            source_row=source_row,
+            source_object=source_object,
+            source_api=source_api,
+            resolved_row=resolved_row,
+            status="canonical",  # provisional; refined below
+            reason="",
+            filename_row=filename_row,
+            id_row=id_row,
+        )
+
+    row_audits: dict[int, WifiLlapiInventoryRowAudit] = {}
+    missing_rows: list[int] = []
+    case_status_counts = {"canonical": 0, "drifted": 0, "duplicate": 0, "extra": 0}
+
+    for row in official_rows:
+        source_object, source_api = index.forward[row]
+        grouped = sorted(row_groups.get(row, []), key=lambda item: str(item[0]))
+        if not grouped:
+            row_audits[row] = WifiLlapiInventoryRowAudit(
+                row=row,
+                source_object=source_object,
+                source_api=source_api,
+                status="missing",
+            )
+            missing_rows.append(row)
+            continue
+
+        exact = [
+            case_file.name
+            for case_file, case in grouped
+            if _is_canonical_metadata(case, row, case_file)
+        ]
+        canonical_case_file = min(exact) if exact else None
+
+        row_status: RowStatus
+        if canonical_case_file is not None and len(grouped) == 1:
+            row_status = "canonical" if _is_canonical_metadata(grouped[0][1], row, grouped[0][0]) else "drifted"
+        elif canonical_case_file is not None:
+            row_status = "duplicate"
+        else:
+            row_status = "drifted" if len(grouped) == 1 else "duplicate"
+
+        row_audits[row] = WifiLlapiInventoryRowAudit(
+            row=row,
+            source_object=source_object,
+            source_api=source_api,
+            status=row_status,
+            discoverable_case_files=tuple(case_file.name for case_file, _case in grouped),
+            canonical_case_file=canonical_case_file,
+        )
+
+        if canonical_case_file is not None:
+            case_statuses = {
+                case_file.name: ("canonical" if case_file.name == canonical_case_file and _is_canonical_metadata(case, row, case_file) else "duplicate")
+                for case_file, case in grouped
+            }
+        else:
+            case_statuses = {
+                case_file.name: ("drifted" if len(grouped) == 1 else "duplicate")
+                for case_file, _case in grouped
+            }
+
+        if canonical_case_file is None and len(grouped) == 1:
+            only_case_file, only_case = grouped[0]
+            case_statuses[only_case_file.name] = "drifted"
+            case_audits[only_case_file.name] = WifiLlapiInventoryCaseAudit(
+                case_file=only_case_file,
+                case_id=str(only_case.get("id", "")),
+                source_row=int(only_case.get("source", {}).get("row", 0) or 0) or None,
+                source_object=normalize_text(only_case.get("source", {}).get("object")),
+                source_api=normalize_text(only_case.get("source", {}).get("api")),
+                resolved_row=row,
+                status="drifted",
+                reason="stale_row_bearing_metadata",
+                filename_row=_extract_row_from_filename(only_case_file),
+                id_row=_extract_row_from_case_id(str(only_case.get("id", ""))),
+            )
+        else:
+            for case_file, case in grouped:
+                status = case_statuses[case_file.name]
+                reason = "canonical_metadata" if status == "canonical" else "row_already_claimed"
+                if status == "duplicate" and not _is_canonical_metadata(case, row, case_file):
+                    reason = "stale_row_bearing_metadata" if len(grouped) == 1 else "duplicate_discoverable_row"
+                case_audits[case_file.name] = WifiLlapiInventoryCaseAudit(
+                    case_file=case_file,
+                    case_id=str(case.get("id", "")),
+                    source_row=int(case.get("source", {}).get("row", 0) or 0) or None,
+                    source_object=normalize_text(case.get("source", {}).get("object")),
+                    source_api=normalize_text(case.get("source", {}).get("api")),
+                    resolved_row=row,
+                    status=status,  # type: ignore[arg-type]
+                    reason=reason,
+                    filename_row=_extract_row_from_filename(case_file),
+                    id_row=_extract_row_from_case_id(str(case.get("id", ""))),
+                )
+
+        for status in case_statuses.values():
+            case_status_counts[status] += 1
+
+    for case_name, audit in extra_rows.items():
+        case_audits[case_name] = audit
+        case_status_counts["extra"] += 1
+
+    # Ensure canonical row selection is stable for duplicate rows with multiple exact matches.
+    for row, row_audit in row_audits.items():
+        if row_audit.status != "duplicate" or row_audit.canonical_case_file is None:
+            continue
+        exact_candidates = sorted(
+            name
+            for name, audit in case_audits.items()
+            if audit.resolved_row == row and audit.status == "canonical"
+        )
+        if exact_candidates:
+            row_audit.canonical_case_file = exact_candidates[0]
+
+    return WifiLlapiInventoryAudit(
+        template_xlsx=template_xlsx,
+        cases_dir=cases_dir,
+        rows=row_audits,
+        cases=case_audits,
+        case_status_counts=case_status_counts,
+        missing_rows=tuple(missing_rows),
+    )

--- a/src/testpilot/reporting/wifi_llapi_inventory.py
+++ b/src/testpilot/reporting/wifi_llapi_inventory.py
@@ -231,7 +231,7 @@ def _git_capture(repo_root: Path, *args: str) -> str:
     return completed.stdout
 
 
-def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, tuple[str, str]]:
+def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, dict[str, str]]:
     output = _git_capture(
         repo_root,
         "log",
@@ -242,7 +242,7 @@ def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, t
         "--",
         str(cases_dir.relative_to(repo_root)),
     )
-    candidates: dict[int, tuple[str, str]] = {}
+    candidates: dict[int, dict[str, str]] = {}
     current_sha = ""
     for raw_line in output.splitlines():
         line = raw_line.strip()
@@ -256,8 +256,7 @@ def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, t
         if not match:
             continue
         row = int(match.group("row"))
-        if row not in candidates:
-            candidates[row] = (current_sha, line)
+        candidates.setdefault(row, {})[line] = current_sha
     return candidates
 
 
@@ -323,8 +322,8 @@ def build_wifi_llapi_inventory_reconcile_plan(
         grouped_rows.setdefault(case_audit.resolved_row, []).append((case_audit.case_file, _load_case_yaml(case_audit.case_file)))
 
     for row in audit.missing_rows:
-        candidate = history_candidates.get(row)
-        if not candidate:
+        candidate_paths = history_candidates.get(row, {})
+        if not candidate_paths:
             blockers.append(
                 WifiLlapiInventoryReconcileAction(
                     kind="blocker",
@@ -335,7 +334,19 @@ def build_wifi_llapi_inventory_reconcile_plan(
                 )
             )
             continue
-        sha, relative_path = candidate
+        if len(candidate_paths) > 1:
+            blockers.append(
+                WifiLlapiInventoryReconcileAction(
+                    kind="blocker",
+                    row=row,
+                    case_file=None,
+                    target_file=None,
+                    reason="ambiguous_history_candidate",
+                    source_ref=",".join(sorted(candidate_paths)),
+                )
+            )
+            continue
+        relative_path, sha = next(iter(candidate_paths.items()))
         target_file = cases_dir / Path(relative_path).name
         actions.append(
             WifiLlapiInventoryReconcileAction(
@@ -392,6 +403,17 @@ def build_wifi_llapi_inventory_reconcile_plan(
             )
 
     for case_name, case_audit in sorted(audit.cases.items()):
+        if case_audit.status == "drifted" and case_audit.resolved_row is None:
+            blockers.append(
+                WifiLlapiInventoryReconcileAction(
+                    kind="blocker",
+                    row=None,
+                    case_file=case_audit.case_file,
+                    target_file=None,
+                    reason=case_audit.reason,
+                )
+            )
+            continue
         if case_audit.status != "extra":
             continue
         actions.append(
@@ -404,7 +426,7 @@ def build_wifi_llapi_inventory_reconcile_plan(
             )
         )
 
-    actions.sort(key=lambda action: ({"restore": 0, "rewrite": 1, "demote": 2, "blocker": 3}[action.kind], action.row or 0, action.case_file.name if action.case_file else ""))
+    actions.sort(key=lambda action: ({"demote": 0, "rewrite": 1, "restore": 2, "blocker": 3}[action.kind], action.row or 0, action.case_file.name if action.case_file else ""))
     blockers.sort(key=lambda action: (action.row or 0, action.reason))
     return WifiLlapiInventoryReconcilePlan(
         template_xlsx=template_xlsx,
@@ -417,7 +439,11 @@ def build_wifi_llapi_inventory_reconcile_plan(
 
 
 def apply_wifi_llapi_inventory_reconcile_plan(plan: WifiLlapiInventoryReconcilePlan) -> None:
-    for action in plan.actions:
+    if plan.blockers:
+        raise ValueError("cannot apply blocked wifi_llapi inventory reconcile plan")
+
+    phase_order = {"demote": 0, "rewrite": 1, "restore": 2}
+    for action in sorted(plan.actions, key=lambda item: (phase_order[item.kind], item.row or 0, item.case_file.name if item.case_file else "")):
         if action.kind == "restore":
             assert action.case_file is not None
             assert action.source_ref is not None

--- a/src/testpilot/reporting/wifi_llapi_inventory.py
+++ b/src/testpilot/reporting/wifi_llapi_inventory.py
@@ -143,6 +143,7 @@ def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str)
     row_groups: dict[int, list[tuple[Path, dict[str, Any]]]] = {row: [] for row in official_rows}
     case_audits: dict[str, WifiLlapiInventoryCaseAudit] = {}
     extra_rows: dict[str, WifiLlapiInventoryCaseAudit] = {}
+    case_status_counts = {"canonical": 0, "drifted": 0, "duplicate": 0, "extra": 0}
 
     for case_file, case in discovered_cases:
         source = case.get("source") if isinstance(case.get("source"), dict) else {}
@@ -155,6 +156,8 @@ def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str)
         candidate_rows = index.by_object_api.get((source_object, source_api), [])
         resolved_row = _resolve_case_row(case, candidate_rows)
         if resolved_row is None:
+            status: CaseStatus = "extra" if not candidate_rows else "drifted"
+            reason = "object_api_not_in_template" if not candidate_rows else "unresolved_object_api_family"
             audit = WifiLlapiInventoryCaseAudit(
                 case_file=case_file,
                 case_id=case_id,
@@ -162,12 +165,16 @@ def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str)
                 source_object=source_object,
                 source_api=source_api,
                 resolved_row=None,
-                status="extra",
-                reason="object_api_not_in_template" if not candidate_rows else "unresolved_object_api_family",
+                status=status,
+                reason=reason,
                 filename_row=filename_row,
                 id_row=id_row,
             )
-            extra_rows[case_file.name] = audit
+            if status == "extra":
+                extra_rows[case_file.name] = audit
+            else:
+                case_audits[case_file.name] = audit
+                case_status_counts["drifted"] += 1
             continue
         row_groups.setdefault(resolved_row, []).append((case_file, case))
         case_audits[case_file.name] = WifiLlapiInventoryCaseAudit(
@@ -185,7 +192,6 @@ def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str)
 
     row_audits: dict[int, WifiLlapiInventoryRowAudit] = {}
     missing_rows: list[int] = []
-    case_status_counts = {"canonical": 0, "drifted": 0, "duplicate": 0, "extra": 0}
 
     for row in official_rows:
         source_object, source_api = index.forward[row]

--- a/src/testpilot/reporting/wifi_llapi_inventory.py
+++ b/src/testpilot/reporting/wifi_llapi_inventory.py
@@ -256,7 +256,9 @@ def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, d
         if not match:
             continue
         row = int(match.group("row"))
-        candidates.setdefault(row, {})[line] = current_sha
+        row_candidates = candidates.setdefault(row, {})
+        if line not in row_candidates:
+            row_candidates[line] = current_sha
     return candidates
 
 

--- a/src/testpilot/reporting/wifi_llapi_inventory.py
+++ b/src/testpilot/reporting/wifi_llapi_inventory.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from copy import deepcopy
 from pathlib import Path
 import re
+import shutil
+import subprocess
 from typing import Any, Literal
 
 from testpilot.reporting.wifi_llapi_align import build_template_index
@@ -84,6 +87,55 @@ class WifiLlapiInventoryAudit:
         }
 
 
+@dataclass(slots=True)
+class WifiLlapiInventoryReconcileAction:
+    kind: Literal["restore", "rewrite", "demote", "blocker"]
+    row: int | None
+    case_file: Path | None
+    target_file: Path | None
+    reason: str
+    source_ref: str | None = None
+
+    def to_line(self) -> str:
+        parts = [self.kind]
+        if self.row is not None:
+            parts.append(f"row={self.row:03d}")
+        if self.case_file is not None:
+            parts.append(f"case={self.case_file.name}")
+        if self.target_file is not None and self.target_file != self.case_file:
+            parts.append(f"target={self.target_file.name}")
+        if self.source_ref:
+            parts.append(f"source={self.source_ref}")
+        if self.reason:
+            parts.append(f"reason={self.reason}")
+        return " ".join(parts)
+
+
+@dataclass(slots=True)
+class WifiLlapiInventoryReconcilePlan:
+    template_xlsx: Path
+    cases_dir: Path
+    repo_root: Path
+    audit: WifiLlapiInventoryAudit
+    actions: tuple[WifiLlapiInventoryReconcileAction, ...] = ()
+    blockers: tuple[WifiLlapiInventoryReconcileAction, ...] = ()
+
+    def to_lines(self) -> list[str]:
+        lines = [action.to_line() for action in self.actions]
+        lines.extend(action.to_line() for action in self.blockers)
+        return lines
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "template_xlsx": str(self.template_xlsx),
+            "cases_dir": str(self.cases_dir),
+            "repo_root": str(self.repo_root),
+            "audit": self.audit.to_dict(),
+            "actions": [action.to_line() for action in self.actions],
+            "blockers": [action.to_line() for action in self.blockers],
+        }
+
+
 def _extract_row_from_filename(case_file: Path) -> int | None:
     match = _FILE_D_PATTERN.match(case_file.stem)
     if not match:
@@ -96,6 +148,35 @@ def _extract_row_from_case_id(case_id: str) -> int | None:
     if not match:
         return None
     return int(match.group(2))
+
+
+def _replace_case_id_row(case_id: str, row: int) -> str:
+    return _ID_D_PATTERN.sub(lambda match: f"{match.group(1)}{row:03d}{match.group(3)}", case_id, count=1)
+
+
+def _sanitize_slug(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", normalize_text(text)).strip("_")
+    return slug or "case"
+
+
+def _case_slug(case: dict[str, Any], case_file: Path) -> str:
+    stem = case_file.stem
+    match = _FILE_D_PATTERN.match(stem)
+    if match and match.group("suffix"):
+        slug = match.group("suffix").lstrip("_")
+        if slug:
+            return slug
+    name = str(case.get("name", "")).strip()
+    if name:
+        return _sanitize_slug(name)
+    case_id = str(case.get("id", "")).strip()
+    if case_id:
+        return _sanitize_slug(case_id)
+    return "case"
+
+
+def _canonical_case_filename(case: dict[str, Any], row: int, case_file: Path) -> str:
+    return f"D{row:03d}_{_case_slug(case, case_file)}.yaml"
 
 
 def _is_canonical_metadata(case: dict[str, Any], row: int, case_file: Path) -> bool:
@@ -131,6 +212,257 @@ def _resolve_case_row(
     if len(candidate_rows) == 1:
         return candidate_rows[0]
     return None
+
+
+def _find_repo_root(path: Path) -> Path:
+    for parent in [path, *path.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return path
+
+
+def _git_capture(repo_root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _collect_history_candidates(repo_root: Path, cases_dir: Path) -> dict[int, tuple[str, str]]:
+    output = _git_capture(
+        repo_root,
+        "log",
+        "--all",
+        "--diff-filter=AMR",
+        "--name-only",
+        "--pretty=format:%H",
+        "--",
+        str(cases_dir.relative_to(repo_root)),
+    )
+    candidates: dict[int, tuple[str, str]] = {}
+    current_sha = ""
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if re.fullmatch(r"[0-9a-f]{40}", line):
+            current_sha = line
+            continue
+        path = Path(line)
+        match = _FILE_D_PATTERN.match(path.name)
+        if not match:
+            continue
+        row = int(match.group("row"))
+        if row not in candidates:
+            candidates[row] = (current_sha, line)
+    return candidates
+
+
+def _load_case_yaml(path: Path) -> dict[str, Any]:
+    return load_case(path, validator=validate_wifi_llapi_case)
+
+
+def _normalize_case_metadata(case: dict[str, Any], *, row: int, case_file: Path) -> dict[str, Any]:
+    normalized = deepcopy(case)
+    normalized["id"] = _replace_case_id_row(str(normalized.get("id", "")), row)
+    normalized["source"] = dict(normalized.get("source") or {})
+    normalized["source"]["row"] = row
+    normalized["source"]["object"] = normalized["source"].get("object", "")
+    normalized["source"]["api"] = normalized["source"].get("api", "")
+    return normalized
+
+
+def _write_case_yaml(path: Path, case: dict[str, Any]) -> None:
+    import yaml
+
+    path.write_text(yaml.safe_dump(case, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+
+def _demote_case_file(case_file: Path) -> Path:
+    if case_file.stem.startswith("_"):
+        return case_file
+    return case_file.with_name(f"_{case_file.name}")
+
+
+def _choose_survivor(row: int, grouped: list[tuple[Path, dict[str, Any]]]) -> tuple[Path, dict[str, Any]]:
+    def score(item: tuple[Path, dict[str, Any]]) -> tuple[int, int, int, str]:
+        case_file, case = item
+        source = case.get("source") if isinstance(case.get("source"), dict) else {}
+        return (
+            1 if int(source.get("row", 0) or 0) == row else 0,
+            1 if _extract_row_from_filename(case_file) == row else 0,
+            1 if _extract_row_from_case_id(str(case.get("id", ""))) == row else 0,
+            str(case_file),
+        )
+
+    return sorted(grouped, key=score, reverse=True)[0]
+
+
+def build_wifi_llapi_inventory_reconcile_plan(
+    template_xlsx: Path | str,
+    cases_dir: Path | str,
+    *,
+    repo_root: Path | str | None = None,
+) -> WifiLlapiInventoryReconcilePlan:
+    template_xlsx = Path(template_xlsx)
+    cases_dir = Path(cases_dir)
+    repo_root = _find_repo_root(Path(repo_root) if repo_root is not None else cases_dir)
+    audit = audit_wifi_llapi_inventory(template_xlsx, cases_dir)
+    history_candidates = _collect_history_candidates(repo_root, cases_dir)
+
+    actions: list[WifiLlapiInventoryReconcileAction] = []
+    blockers: list[WifiLlapiInventoryReconcileAction] = []
+
+    grouped_rows: dict[int, list[tuple[Path, dict[str, Any]]]] = {}
+    for case_audit in audit.cases.values():
+        if case_audit.resolved_row is None or case_audit.status == "extra":
+            continue
+        grouped_rows.setdefault(case_audit.resolved_row, []).append((case_audit.case_file, _load_case_yaml(case_audit.case_file)))
+
+    for row in audit.missing_rows:
+        candidate = history_candidates.get(row)
+        if not candidate:
+            blockers.append(
+                WifiLlapiInventoryReconcileAction(
+                    kind="blocker",
+                    row=row,
+                    case_file=None,
+                    target_file=None,
+                    reason="missing_history_candidate",
+                )
+            )
+            continue
+        sha, relative_path = candidate
+        target_file = cases_dir / Path(relative_path).name
+        actions.append(
+            WifiLlapiInventoryReconcileAction(
+                kind="restore",
+                row=row,
+                case_file=target_file,
+                target_file=target_file,
+                reason="restore_from_history",
+                source_ref=f"{sha}:{relative_path}",
+            )
+        )
+
+    for row, row_audit in sorted(audit.rows.items()):
+        grouped = sorted(grouped_rows.get(row, []), key=lambda item: str(item[0]))
+        if not grouped:
+            continue
+        survivor = None
+        if row_audit.canonical_case_file is not None:
+            for case_file, case in grouped:
+                if case_file.name == row_audit.canonical_case_file:
+                    survivor = (case_file, case)
+                    break
+        else:
+            survivor = _choose_survivor(row, grouped)
+
+        if survivor is None:
+            continue
+
+        survivor_file, survivor_case = survivor
+        canonical_name = _canonical_case_filename(survivor_case, row, survivor_file)
+        canonical_path = survivor_file.with_name(canonical_name)
+        if canonical_path != survivor_file or not _is_canonical_metadata(survivor_case, row, survivor_file):
+            actions.append(
+                WifiLlapiInventoryReconcileAction(
+                    kind="rewrite",
+                    row=row,
+                    case_file=survivor_file,
+                    target_file=canonical_path,
+                    reason="canonical_row_bearing_metadata",
+                )
+            )
+
+        for case_file, _case in grouped:
+            if case_file == survivor_file:
+                continue
+            actions.append(
+                WifiLlapiInventoryReconcileAction(
+                    kind="demote",
+                    row=row,
+                    case_file=case_file,
+                    target_file=_demote_case_file(case_file),
+                    reason="non_canonical_leftover",
+                )
+            )
+
+    for case_name, case_audit in sorted(audit.cases.items()):
+        if case_audit.status != "extra":
+            continue
+        actions.append(
+            WifiLlapiInventoryReconcileAction(
+                kind="demote",
+                row=case_audit.resolved_row,
+                case_file=case_audit.case_file,
+                target_file=_demote_case_file(case_audit.case_file),
+                reason="extra_outside_official_inventory",
+            )
+        )
+
+    actions.sort(key=lambda action: ({"restore": 0, "rewrite": 1, "demote": 2, "blocker": 3}[action.kind], action.row or 0, action.case_file.name if action.case_file else ""))
+    blockers.sort(key=lambda action: (action.row or 0, action.reason))
+    return WifiLlapiInventoryReconcilePlan(
+        template_xlsx=template_xlsx,
+        cases_dir=cases_dir,
+        repo_root=repo_root,
+        audit=audit,
+        actions=tuple(actions),
+        blockers=tuple(blockers),
+    )
+
+
+def apply_wifi_llapi_inventory_reconcile_plan(plan: WifiLlapiInventoryReconcilePlan) -> None:
+    for action in plan.actions:
+        if action.kind == "restore":
+            assert action.case_file is not None
+            assert action.source_ref is not None
+            sha, relative_path = action.source_ref.split(":", 1)
+            restored_text = _git_capture(plan.repo_root, "show", f"{sha}:{relative_path}")
+            case = _load_case_yaml_from_text(restored_text, action.case_file)
+            normalized = _normalize_case_metadata(case, row=action.row or 0, case_file=action.case_file)
+            action.case_file.parent.mkdir(parents=True, exist_ok=True)
+            if action.case_file.exists():
+                raise FileExistsError(f"restore target already exists: {action.case_file}")
+            _write_case_yaml(action.case_file, normalized)
+        elif action.kind == "rewrite":
+            assert action.case_file is not None
+            assert action.target_file is not None
+            case = _load_case_yaml(action.case_file)
+            normalized = _normalize_case_metadata(case, row=action.row or 0, case_file=action.target_file)
+            if action.target_file != action.case_file:
+                action.target_file.parent.mkdir(parents=True, exist_ok=True)
+                if action.target_file.exists():
+                    raise FileExistsError(f"rewrite target already exists: {action.target_file}")
+                _write_case_yaml(action.target_file, normalized)
+                action.case_file.unlink()
+            else:
+                _write_case_yaml(action.case_file, normalized)
+        elif action.kind == "demote":
+            assert action.case_file is not None
+            assert action.target_file is not None
+            action.target_file.parent.mkdir(parents=True, exist_ok=True)
+            if action.target_file == action.case_file:
+                continue
+            if action.target_file.exists():
+                raise FileExistsError(f"demote target already exists: {action.target_file}")
+            shutil.move(str(action.case_file), str(action.target_file))
+        elif action.kind == "blocker":
+            continue
+
+
+def _load_case_yaml_from_text(text: str, source: Path) -> dict[str, Any]:
+    import yaml
+
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise TypeError(f"{source}: restored case must be a mapping")
+    validate_wifi_llapi_case(data, source)
+    return data
 
 
 def audit_wifi_llapi_inventory(template_xlsx: Path | str, cases_dir: Path | str) -> WifiLlapiInventoryAudit:


### PR DESCRIPTION
## 摘要
- 修正 wifi_llapi runtime alignment，讓 ambiguous family 可用 `source.row` 消歧
- 新增 workbook-driven inventory audit / reconcile 工具與回歸測試
- 補上 orchestrator realistic runtime regression，驗證 row-correct ambiguous family 不會被 silent skip
- 將 OpenSpec change artifacts 與 Task 4 blocker 狀態納入版本控制

## 已完成
- Task 1: runtime `source.row` disambiguation
- Task 2: official inventory audit helper
- Task 3: reconcile planner/apply 與 blocker-safe flow（complete with blockers）
- Task 4.1: runtime/orchestrator regression coverage

## 目前 blocker
- real-repo reconcile dry-run 仍為 `376 actions / 344 blockers`
- blocker 類型：`missing_history_candidate`、`ambiguous_history_candidate`、`unresolved_object_api_family`
- full repo regression 另有既有/無關基線失敗：`tests/test_topology.py::test_variable_resolve`

## 驗證
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_align.py plugins/wifi_llapi/tests/test_wifi_llapi_inventory.py plugins/wifi_llapi/tests/test_wifi_llapi_inventory_reconcile.py plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py`
- real-repo planner invariants：`missing_uncovered = 0`、`unresolved_uncovered = 0`

## 備註
這個 PR 目前先以 draft 送出，因為 canonical inventory apply / docs sync / full rerun 仍受 real-repo blockers 影響。