### PR TITLE
feat: 完成 wifi_llapi counter delta validation Wave 1

### DIFF
--- a/docs/superpowers/plans/2026-04-27-wifi-llapi-counter-delta-validation-wave1.md
+++ b/docs/superpowers/plans/2026-04-27-wifi-llapi-counter-delta-validation-wave1.md
@@ -1,0 +1,2482 @@
+# wifi_llapi Counter Delta Validation — Wave 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the runtime + reporter foundation for delta-based counter validation in `wifi_llapi`, plus migrate two sample cases (D037 / D313) that prove the new format end-to-end.
+
+**Architecture:** Add a `phase: baseline | trigger | verify` step label, two new pass_criteria operators (`delta_nonzero`, `delta_match`), a load-time phase ordering validator that marks violators BLOCKED, a new `Comment` column M in the xlsx report carrying evaluate-failure notes. Existing `field+value`/`field+reference` evaluation paths remain unchanged.
+
+**Tech Stack:** Python 3.11+, `openpyxl` for xlsx writing, `pytest` for tests, `PyYAML` for case files.
+
+**Reference:** Spec at `docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md`; OpenSpec change at `openspec/changes/wifi-llapi-counter-delta-validation/`.
+
+**Out of scope (Wave 2/3):** ~30 Stage A case migrations and ~50 Stage B case migrations. They each get their own plan after Wave 1 ships.
+
+---
+
+## File Structure
+
+**Modified files:**
+- `plugins/wifi_llapi/plugin.py` — add `ZERO_DELTA_COMMENT` constant, `_validate_phase_ordering()`, `_evaluate_delta_criterion()`, evaluate dispatch refactor, `discover_cases` hook
+- `src/testpilot/reporting/wifi_llapi_excel.py` — bump `DEFAULT_TEMPLATE_MAX_COLUMN` to `"M"`, add `COMMENT_HEADER`, `_truncate_comment()` helper, write M column in `fill_case_results()`
+- `src/testpilot/core/orchestrator.py` — merge `plugin._phase_blocked` (new attr) into `prep.blocked_results` during `_prepare_wifi_llapi_alignment`
+- `tests/test_wifi_llapi_excel.py` — extend with M column / truncate / regression tests
+- `plugins/wifi_llapi/cases/D037_retransmissions.yaml` — migrated to delta range
+- `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` — migrated to delta range
+
+**New files:**
+- `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` — long-lived yaml syntax reference
+- `tests/test_wifi_llapi_delta.py` — unit tests for delta operators + phase validator
+- `tests/test_wifi_llapi_delta_integration.py` — end-to-end test: discover → execute (mocked) → evaluate → reporter
+- `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml`
+- `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml`
+- `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml`
+- `tests/fixtures/wifi_llapi_delta/phase_invalid.yaml`
+
+Each file has one clear responsibility — runtime decisions live in `plugin.py`; xlsx layout in `wifi_llapi_excel.py`; orchestration glue in `orchestrator.py`; documentation in `CASE_YAML_SYNTAX.md`.
+
+---
+
+## Task 1: Reporter — Add `COMMENT_HEADER` constant and bump max column to M
+
+**Files:**
+- Modify: `src/testpilot/reporting/wifi_llapi_excel.py:27-44`
+- Test: `tests/test_wifi_llapi_excel.py`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `tests/test_wifi_llapi_excel.py`:
+
+```python
+def test_default_template_max_column_is_M():
+    from testpilot.reporting.wifi_llapi_excel import DEFAULT_TEMPLATE_MAX_COLUMN
+    assert DEFAULT_TEMPLATE_MAX_COLUMN == "M"
+
+
+def test_comment_header_constant_exists():
+    from testpilot.reporting.wifi_llapi_excel import COMMENT_HEADER
+    assert COMMENT_HEADER == "Comment"
+
+
+def test_default_clear_columns_includes_M():
+    from testpilot.reporting.wifi_llapi_excel import DEFAULT_CLEAR_COLUMNS
+    assert "M" in DEFAULT_CLEAR_COLUMNS
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_excel.py::test_default_template_max_column_is_M tests/test_wifi_llapi_excel.py::test_comment_header_constant_exists tests/test_wifi_llapi_excel.py::test_default_clear_columns_includes_M -v`
+Expected: 3 failures (`assert "L" == "M"`, `ImportError: cannot import name 'COMMENT_HEADER'`, `assert "M" in (...)` false)
+
+- [ ] **Step 1.3: Apply minimal change**
+
+Edit `src/testpilot/reporting/wifi_llapi_excel.py` lines 29-44:
+
+```python
+DEFAULT_TEMPLATE_MAX_COLUMN = "M"
+RESULT_GROUP_HEADER = "Result"
+RESULT_HEADERS_BY_COLUMN = {
+    "I": "WiFi 5G",
+    "J": "WiFi 6G",
+    "K": "WiFi 2.4G",
+}
+TESTER_HEADER = "Tester"
+COMMENT_HEADER = "Comment"
+DEFAULT_CLEAR_COLUMNS = (
+    "G",   # Test steps
+    "H",   # Driver-level verified command output
+    "I",   # ARC 5g result
+    "J",   # ARC 6g result
+    "K",   # ARC 2.4g result
+    "L",   # ARC tester
+    "M",   # Evaluate-failure comment
+)
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -v`
+Expected: previously failing 3 tests pass; existing tests still pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/testpilot/reporting/wifi_llapi_excel.py tests/test_wifi_llapi_excel.py
+git commit -m "reporter(wifi_llapi): bump template max column to M, add COMMENT_HEADER"
+```
+
+---
+
+## Task 2: Reporter — Header normalization writes "Comment" at row 3 column 13
+
+**Files:**
+- Modify: `src/testpilot/reporting/wifi_llapi_excel.py:_normalize_template_headers`
+- Test: `tests/test_wifi_llapi_excel.py`
+
+- [ ] **Step 2.1: Write the failing test**
+
+Append to `tests/test_wifi_llapi_excel.py`:
+
+```python
+def test_normalize_template_headers_writes_comment_in_M(tmp_path):
+    """Row 3 column 13 must contain COMMENT_HEADER after header normalization."""
+    from openpyxl import Workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        _normalize_template_headers,
+        COMMENT_HEADER,
+        DEFAULT_SHEET_NAME,
+    )
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    assert ws.cell(row=3, column=13).value == COMMENT_HEADER
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `pytest tests/test_wifi_llapi_excel.py::test_normalize_template_headers_writes_comment_in_M -v`
+Expected: FAIL with `assert None == "Comment"`.
+
+- [ ] **Step 2.3: Modify `_normalize_template_headers()`**
+
+In `src/testpilot/reporting/wifi_llapi_excel.py`, locate the function (around line 304) and add the comment header line at the end:
+
+```python
+def _normalize_template_headers(ws) -> None:
+    """Normalize Wifi_LLAPI result/tester header semantics for columns I~M."""
+    for merged in list(ws.merged_cells.ranges):
+        if merged.max_row < 2 or merged.min_row > 2:
+            continue
+        if merged.max_col < 9 or merged.min_col > 13:
+            continue
+        ws.unmerge_cells(str(merged))
+
+    ws.merge_cells(start_row=2, end_row=2, start_column=9, end_column=11)
+    ws.cell(row=2, column=9).value = RESULT_GROUP_HEADER
+    ws.cell(row=2, column=12).value = TESTER_HEADER
+    ws.cell(row=3, column=9).value = RESULT_HEADERS_BY_COLUMN["I"]
+    ws.cell(row=3, column=10).value = RESULT_HEADERS_BY_COLUMN["J"]
+    ws.cell(row=3, column=11).value = RESULT_HEADERS_BY_COLUMN["K"]
+    ws.cell(row=3, column=12).value = TESTER_HEADER
+    ws.cell(row=3, column=13).value = COMMENT_HEADER
+```
+
+(Note: also bumped `merged.min_col > 12` to `> 13` so any future M-column merges aren't accidentally preserved.)
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -v`
+Expected: previously failing test passes; existing tests still pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/testpilot/reporting/wifi_llapi_excel.py tests/test_wifi_llapi_excel.py
+git commit -m "reporter(wifi_llapi): write Comment header in column M during template normalization"
+```
+
+---
+
+## Task 3: Reporter — `_truncate_comment()` helper
+
+**Files:**
+- Modify: `src/testpilot/reporting/wifi_llapi_excel.py` (add helper near other small utilities, e.g. after `normalize_command_block`)
+- Test: `tests/test_wifi_llapi_excel.py`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append to `tests/test_wifi_llapi_excel.py`:
+
+```python
+def test_truncate_comment_short_text_unchanged():
+    from testpilot.reporting.wifi_llapi_excel import _truncate_comment
+    assert _truncate_comment("hello") == "hello"
+
+
+def test_truncate_comment_exactly_200_unchanged():
+    from testpilot.reporting.wifi_llapi_excel import _truncate_comment
+    text = "a" * 200
+    assert _truncate_comment(text) == text
+
+
+def test_truncate_comment_201_chars_truncates():
+    from testpilot.reporting.wifi_llapi_excel import _truncate_comment
+    text = "a" * 201
+    out = _truncate_comment(text)
+    assert len(out) == 203  # 200 + "..."
+    assert out.endswith("...")
+    assert out.startswith("a" * 200)
+
+
+def test_truncate_comment_empty_returns_empty():
+    from testpilot.reporting.wifi_llapi_excel import _truncate_comment
+    assert _truncate_comment("") == ""
+
+
+def test_truncate_comment_none_returns_empty():
+    from testpilot.reporting.wifi_llapi_excel import _truncate_comment
+    assert _truncate_comment(None) == ""
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -k truncate_comment -v`
+Expected: 5 failures (`ImportError: cannot import name '_truncate_comment'`).
+
+- [ ] **Step 3.3: Add the helper**
+
+In `src/testpilot/reporting/wifi_llapi_excel.py`, after the `normalize_command_block` function (around line 154), insert:
+
+```python
+def _truncate_comment(text: str | None, *, limit: int = 200) -> str:
+    """Truncate evaluate-failure comments to fit M column display.
+
+    Returns "" for None / empty input. Appends '...' when the source string
+    exceeds `limit` characters; otherwise returns the input unchanged.
+    """
+    if text is None:
+        return ""
+    s = str(text)
+    if len(s) <= limit:
+        return s
+    return s[:limit] + "..."
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -k truncate_comment -v`
+Expected: 5 PASS.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/testpilot/reporting/wifi_llapi_excel.py tests/test_wifi_llapi_excel.py
+git commit -m "reporter(wifi_llapi): add _truncate_comment helper for M column"
+```
+
+---
+
+## Task 4: Reporter — `fill_case_results()` writes `comment` to M column
+
+**Files:**
+- Modify: `src/testpilot/reporting/wifi_llapi_excel.py:fill_case_results` (~line 434-458)
+- Test: `tests/test_wifi_llapi_excel.py`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append to `tests/test_wifi_llapi_excel.py`:
+
+```python
+def test_fill_case_results_writes_M_column(tmp_path):
+    """fill_case_results writes WifiLlapiCaseResult.comment to column M."""
+    from openpyxl import Workbook, load_workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        WifiLlapiCaseResult,
+        fill_case_results,
+        _normalize_template_headers,
+    )
+
+    # Build a minimal report with one data row at row 4.
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    wb.save(report)
+
+    item = WifiLlapiCaseResult(
+        case_id="D037",
+        source_row=4,
+        executed_test_command="echo cmd",
+        command_output="output",
+        result_5g="FAIL",
+        result_6g="N/A",
+        result_24g="N/A",
+        comment="fail 原因為 0，數值無變化",
+    )
+    fill_case_results(report, [item])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    assert ws2.cell(row=4, column=13).value == "fail 原因為 0，數值無變化"
+
+
+def test_fill_case_results_empty_comment_leaves_M_empty(tmp_path):
+    from openpyxl import Workbook, load_workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        WifiLlapiCaseResult,
+        fill_case_results,
+        _normalize_template_headers,
+    )
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    wb.save(report)
+
+    item = WifiLlapiCaseResult(
+        case_id="D200",
+        source_row=4,
+        executed_test_command="echo cmd",
+        command_output="output",
+        result_5g="PASS",
+        result_6g="PASS",
+        result_24g="PASS",
+        comment="",
+    )
+    fill_case_results(report, [item])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    assert ws2.cell(row=4, column=13).value in (None, "")  # not "None" string
+
+
+def test_fill_case_results_truncates_long_comment(tmp_path):
+    from openpyxl import Workbook, load_workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        WifiLlapiCaseResult,
+        fill_case_results,
+        _normalize_template_headers,
+    )
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    wb.save(report)
+
+    long_comment = "x" * 250
+    item = WifiLlapiCaseResult(
+        case_id="D300",
+        source_row=4,
+        executed_test_command="echo cmd",
+        command_output="output",
+        result_5g="FAIL",
+        result_6g="N/A",
+        result_24g="N/A",
+        comment=long_comment,
+    )
+    fill_case_results(report, [item])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    cell = ws2.cell(row=4, column=13).value
+    assert isinstance(cell, str)
+    assert len(cell) == 203
+    assert cell.endswith("...")
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -k fill_case_results -v`
+Expected: 3 new tests fail (M column is None for all because writer not yet writing it).
+
+- [ ] **Step 4.3: Modify `fill_case_results()`**
+
+In `src/testpilot/reporting/wifi_llapi_excel.py`, locate `fill_case_results` (~line 434) and add the M write after the L write:
+
+```python
+def fill_case_results(
+    report_xlsx: Path | str,
+    case_results: Iterable[WifiLlapiCaseResult],
+    *,
+    sheet_name: str = DEFAULT_SHEET_NAME,
+) -> Path:
+    """Batch fill test command and result columns by source row."""
+    path = Path(report_xlsx)
+    wb = load_workbook(path)
+    ws = _get_sheet(wb, sheet_name)
+
+    for item in case_results:
+        if item.source_row <= 0:
+            continue
+        row = item.source_row
+        _set_cell_value_safe(ws, row, "G", normalize_command_block(item.executed_test_command))
+        _set_cell_value_safe(ws, row, "H", sanitize_report_output(item.command_output))
+        _set_cell_value_safe(ws, row, "I", item.result_5g)
+        _set_cell_value_safe(ws, row, "J", item.result_6g)
+        _set_cell_value_safe(ws, row, "K", item.result_24g)
+        _set_cell_value_safe(ws, row, "L", item.tester)
+        _set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment) or None)
+
+    wb.save(path)
+    wb.close()
+    return path
+```
+
+(Note: `or None` keeps cell empty when comment is "" rather than writing the empty string — matches `test_fill_case_results_empty_comment_leaves_M_empty`.)
+
+- [ ] **Step 4.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -k fill_case_results -v`
+Expected: all 3 new tests + any existing fill_case_results tests PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/testpilot/reporting/wifi_llapi_excel.py tests/test_wifi_llapi_excel.py
+git commit -m "reporter(wifi_llapi): write WifiLlapiCaseResult.comment to M column with truncation"
+```
+
+---
+
+## Task 5: Reporter — Regression guard: BLOCKED / SKIP markers don't touch M
+
+**Files:**
+- Test only: `tests/test_wifi_llapi_excel.py`
+
+- [ ] **Step 5.1: Write the regression tests**
+
+Append to `tests/test_wifi_llapi_excel.py`:
+
+```python
+def test_blocked_marker_writes_H_not_M(tmp_path):
+    """fill_blocked_markers must not write to column M."""
+    from dataclasses import dataclass
+    from openpyxl import Workbook, load_workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        fill_blocked_markers,
+        _normalize_template_headers,
+    )
+
+    @dataclass
+    class _BlockedStub:
+        source_row_before: int
+        blocked_reason: str
+
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    # extend rows so row=4 is addressable
+    ws.cell(row=4, column=1).value = "anchor"
+    wb.save(report)
+
+    fill_blocked_markers(report, [_BlockedStub(source_row_before=4, blocked_reason="some_reason")])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    assert ws2.cell(row=4, column=8).value == "BLOCKED: some_reason"  # H
+    assert ws2.cell(row=4, column=13).value in (None, "")               # M empty
+
+
+def test_skip_marker_writes_H_not_M(tmp_path):
+    """fill_skip_markers must not write to column M."""
+    from dataclasses import dataclass
+    from openpyxl import Workbook, load_workbook
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        fill_skip_markers,
+        _normalize_template_headers,
+    )
+
+    @dataclass
+    class _SkipStub:
+        source_row_before: int
+        template_row: int
+
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    ws.cell(row=4, column=1).value = "anchor"
+    ws.cell(row=10, column=1).value = "anchor10"
+    wb.save(report)
+
+    fill_skip_markers(report, [_SkipStub(source_row_before=4, template_row=10)])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    assert ws2.cell(row=4, column=8).value == "SKIP: duplicate with D010"   # H
+    assert ws2.cell(row=4, column=13).value in (None, "")                   # M empty
+```
+
+- [ ] **Step 5.2: Run tests — they should already pass without code change**
+
+Run: `pytest tests/test_wifi_llapi_excel.py -k "blocked_marker or skip_marker" -v`
+Expected: both PASS without any source change (regression guard against future drift).
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add tests/test_wifi_llapi_excel.py
+git commit -m "test(wifi_llapi_excel): regression guards that BLOCKED/SKIP markers do not touch M column"
+```
+
+---
+
+## Task 6: Plugin — Add `ZERO_DELTA_COMMENT` constant
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py` (module-level, near other constants)
+- Test: `tests/test_wifi_llapi_delta.py` (new file)
+
+- [ ] **Step 6.1: Write the failing test**
+
+Create `tests/test_wifi_llapi_delta.py` with:
+
+```python
+"""Unit tests for wifi_llapi delta-validation runtime (Wave 1 of #38/#13)."""
+
+from __future__ import annotations
+
+
+def test_zero_delta_comment_constant():
+    from plugins.wifi_llapi.plugin import ZERO_DELTA_COMMENT
+    assert ZERO_DELTA_COMMENT == "fail 原因為 0，數值無變化"
+```
+
+- [ ] **Step 6.2: Run test to verify it fails**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_zero_delta_comment_constant -v`
+Expected: `ImportError: cannot import name 'ZERO_DELTA_COMMENT'`.
+
+- [ ] **Step 6.3: Add the constant**
+
+In `plugins/wifi_llapi/plugin.py`, immediately after the imports / module docstring (look for the first non-import line near the top, e.g. before `class Plugin`), add:
+
+```python
+ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"
+DELTA_VALUE_NOT_NUMERIC_COMMENT = "fail 原因為 delta 端點非數值"
+DELTA_MISMATCH_COMMENT_TEMPLATE = "fail 原因為 delta 不一致：api={a} drv={b} tol={t}%"
+```
+
+- [ ] **Step 6.4: Run test to verify it passes**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_zero_delta_comment_constant -v`
+Expected: PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): add ZERO_DELTA_COMMENT and related comment constants"
+```
+
+---
+
+## Task 7: Plugin — `_evaluate_delta_criterion()` for `delta_nonzero`
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py` (add method to `Plugin` class)
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 7.1: Write the failing tests**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+import pytest
+
+from plugins.wifi_llapi.plugin import Plugin
+
+
+def _build_context(values: dict[str, dict[str, object]]) -> dict[str, object]:
+    """Build an eval_context shape matching what _build_eval_context returns:
+
+    For each capture name, store as both `context[name]` (a dict) and an entry
+    under `context["steps"]` so _resolve_field can find it via dotted lookup.
+    """
+    ctx: dict[str, object] = {"steps": {}, "_aggregate_output": "", "_capture_raw": {}}
+    for cap, payload in values.items():
+        ctx[cap] = payload
+        ctx["steps"][cap] = {"success": True, "output": "", "captured": payload, "returncode": 0}
+    return ctx
+
+
+def _make_plugin() -> Plugin:
+    return Plugin()
+
+
+def test_delta_nonzero_pass():
+    plugin = _make_plugin()
+    ctx = _build_context({"before_5g": {"X": 10}, "after_5g": {"X": 42}})
+    case = {"id": "T1", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_5g.X", "verify": "after_5g.X"},
+        "operator": "delta_nonzero",
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is True
+    assert "_last_failure" not in case
+
+
+def test_delta_nonzero_fail_zero():
+    plugin = _make_plugin()
+    ctx = _build_context({"before_5g": {"X": 10}, "after_5g": {"X": 10}})
+    case = {"id": "T2", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_5g.X", "verify": "after_5g.X"},
+        "operator": "delta_nonzero",
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+    assert case["_last_failure"]["comment"] == "fail 原因為 0，數值無變化"
+
+
+def test_delta_nonzero_fail_negative():
+    plugin = _make_plugin()
+    ctx = _build_context({"before_5g": {"X": 10}, "after_5g": {"X": 5}})
+    case = {"id": "T3", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_5g.X", "verify": "after_5g.X"},
+        "operator": "delta_nonzero",
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+
+
+def test_delta_nonzero_baseline_missing():
+    plugin = _make_plugin()
+    ctx = _build_context({"after_5g": {"X": 5}})
+    case = {"id": "T4", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_5g.X", "verify": "after_5g.X"},
+        "operator": "delta_nonzero",
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_value_not_numeric"
+    assert case["_last_failure"]["comment"] == "fail 原因為 delta 端點非數值"
+
+
+def test_delta_nonzero_non_numeric():
+    plugin = _make_plugin()
+    ctx = _build_context({"before_5g": {"X": 10}, "after_5g": {"X": "N/A"}})
+    case = {"id": "T5", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_5g.X", "verify": "after_5g.X"},
+        "operator": "delta_nonzero",
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_value_not_numeric"
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k delta_nonzero -v`
+Expected: 5 failures (`AttributeError: 'Plugin' object has no attribute '_evaluate_delta_criterion'`).
+
+- [ ] **Step 7.3: Implement `_evaluate_delta_criterion()` (delta_nonzero only first)**
+
+In `plugins/wifi_llapi/plugin.py`, add this method to the `Plugin` class (place it near `_compare`, around line 1046):
+
+```python
+def _evaluate_delta_criterion(
+    self,
+    case: dict[str, Any],
+    context: dict[str, Any],
+    criterion: dict[str, Any],
+    idx: int,
+) -> bool:
+    """Evaluate a delta-shaped pass_criteria entry.
+
+    Supported operators: delta_nonzero, delta_match.
+    """
+    operator = str(criterion.get("operator", "")).strip().lower()
+    delta_spec = criterion.get("delta")
+    if not isinstance(delta_spec, dict):
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+            category="test",
+            reason_code="delta_value_not_numeric",
+            metadata={"idx": idx, "issue": "missing_delta_block"},
+        )
+        return False
+
+    baseline_a = self._resolve_field(context, str(delta_spec.get("baseline", "")))
+    verify_a = self._resolve_field(context, str(delta_spec.get("verify", "")))
+    baseline_a_num = self._to_number(baseline_a)
+    verify_a_num = self._to_number(verify_a)
+    if baseline_a_num is None or verify_a_num is None:
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+            category="test",
+            reason_code="delta_value_not_numeric",
+            metadata={
+                "idx": idx,
+                "baseline_field": delta_spec.get("baseline"),
+                "verify_field": delta_spec.get("verify"),
+                "baseline_value": self._preview_value(baseline_a),
+                "verify_value": self._preview_value(verify_a),
+            },
+        )
+        return False
+
+    delta_a = verify_a_num - baseline_a_num
+
+    if operator == "delta_nonzero":
+        if delta_a > 0:
+            return True
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=ZERO_DELTA_COMMENT,
+            category="test",
+            reason_code="delta_zero",
+            metadata={"idx": idx, "delta_a": delta_a},
+        )
+        return False
+
+    # delta_match handled in Task 8
+    log.warning("[%s] _evaluate_delta_criterion: unsupported operator %s", self.name, operator)
+    self._record_runtime_failure(
+        case,
+        phase="evaluate",
+        comment=f"fail 原因為未知 delta operator: {operator}",
+        category="test",
+        reason_code="delta_unknown_operator",
+        metadata={"idx": idx, "operator": operator},
+    )
+    return False
+```
+
+- [ ] **Step 7.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k delta_nonzero -v`
+Expected: 5 PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): implement _evaluate_delta_criterion for delta_nonzero"
+```
+
+---
+
+## Task 8: Plugin — `_evaluate_delta_criterion()` for `delta_match`
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py:_evaluate_delta_criterion`
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 8.1: Write the failing tests**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+def test_delta_match_pass_within_tolerance():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 0}, "after_api": {"X": 100},
+        "before_drv": {"Y": 0}, "after_drv": {"Y": 109},
+    })
+    case = {"id": "T6", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is True
+
+
+def test_delta_match_pass_exact_match():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 0}, "after_api": {"X": 100},
+        "before_drv": {"Y": 0}, "after_drv": {"Y": 100},
+    })
+    case = {"id": "T7", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is True
+
+
+def test_delta_match_tolerance_boundary():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 0}, "after_api": {"X": 100},
+        "before_drv": {"Y": 0}, "after_drv": {"Y": 110},
+    })
+    case = {"id": "T8", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is True
+
+
+def test_delta_match_fail_exceed_tolerance():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 0}, "after_api": {"X": 100},
+        "before_drv": {"Y": 0}, "after_drv": {"Y": 120},
+    })
+    case = {"id": "T9", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_mismatch"
+    assert case["_last_failure"]["comment"] == "fail 原因為 delta 不一致：api=100 drv=120 tol=10%"
+
+
+def test_delta_match_fail_one_side_zero():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 0}, "after_api": {"X": 100},
+        "before_drv": {"Y": 5}, "after_drv": {"Y": 5},  # delta_b = 0
+    })
+    case = {"id": "T10", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+    assert case["_last_failure"]["comment"] == "fail 原因為 0，數值無變化"
+
+
+def test_delta_match_fail_both_zero():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 5}, "after_api": {"X": 5},
+        "before_drv": {"Y": 5}, "after_drv": {"Y": 5},
+    })
+    case = {"id": "T11", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+
+
+def test_delta_match_fail_negative_either_side():
+    plugin = _make_plugin()
+    ctx = _build_context({
+        "before_api": {"X": 10}, "after_api": {"X": 5},  # delta_a < 0
+        "before_drv": {"Y": 0}, "after_drv": {"Y": 100},
+    })
+    case = {"id": "T12", "_attempt_index": 1}
+    criterion = {
+        "delta": {"baseline": "before_api.X", "verify": "after_api.X"},
+        "reference_delta": {"baseline": "before_drv.Y", "verify": "after_drv.Y"},
+        "operator": "delta_match",
+        "tolerance_pct": 10,
+    }
+    assert plugin._evaluate_delta_criterion(case, ctx, criterion, 0) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+```
+
+- [ ] **Step 8.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k delta_match -v`
+Expected: 7 failures (current implementation logs `delta_unknown_operator` for `delta_match`).
+
+- [ ] **Step 8.3: Extend `_evaluate_delta_criterion` for `delta_match`**
+
+Replace the body of `_evaluate_delta_criterion` after the `delta_a` calculation. The full function now reads:
+
+```python
+def _evaluate_delta_criterion(
+    self,
+    case: dict[str, Any],
+    context: dict[str, Any],
+    criterion: dict[str, Any],
+    idx: int,
+) -> bool:
+    operator = str(criterion.get("operator", "")).strip().lower()
+    delta_spec = criterion.get("delta")
+    if not isinstance(delta_spec, dict):
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+            category="test",
+            reason_code="delta_value_not_numeric",
+            metadata={"idx": idx, "issue": "missing_delta_block"},
+        )
+        return False
+
+    baseline_a = self._resolve_field(context, str(delta_spec.get("baseline", "")))
+    verify_a = self._resolve_field(context, str(delta_spec.get("verify", "")))
+    baseline_a_num = self._to_number(baseline_a)
+    verify_a_num = self._to_number(verify_a)
+    if baseline_a_num is None or verify_a_num is None:
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+            category="test",
+            reason_code="delta_value_not_numeric",
+            metadata={
+                "idx": idx,
+                "baseline_field": delta_spec.get("baseline"),
+                "verify_field": delta_spec.get("verify"),
+                "baseline_value": self._preview_value(baseline_a),
+                "verify_value": self._preview_value(verify_a),
+            },
+        )
+        return False
+
+    delta_a = verify_a_num - baseline_a_num
+
+    if operator == "delta_nonzero":
+        if delta_a > 0:
+            return True
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=ZERO_DELTA_COMMENT,
+            category="test",
+            reason_code="delta_zero",
+            metadata={"idx": idx, "delta_a": delta_a},
+        )
+        return False
+
+    if operator == "delta_match":
+        ref_spec = criterion.get("reference_delta")
+        if not isinstance(ref_spec, dict):
+            self._record_runtime_failure(
+                case,
+                phase="evaluate",
+                comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+                category="test",
+                reason_code="delta_value_not_numeric",
+                metadata={"idx": idx, "issue": "missing_reference_delta"},
+            )
+            return False
+        baseline_b = self._resolve_field(context, str(ref_spec.get("baseline", "")))
+        verify_b = self._resolve_field(context, str(ref_spec.get("verify", "")))
+        baseline_b_num = self._to_number(baseline_b)
+        verify_b_num = self._to_number(verify_b)
+        if baseline_b_num is None or verify_b_num is None:
+            self._record_runtime_failure(
+                case,
+                phase="evaluate",
+                comment=DELTA_VALUE_NOT_NUMERIC_COMMENT,
+                category="test",
+                reason_code="delta_value_not_numeric",
+                metadata={
+                    "idx": idx,
+                    "ref_baseline_field": ref_spec.get("baseline"),
+                    "ref_verify_field": ref_spec.get("verify"),
+                    "ref_baseline_value": self._preview_value(baseline_b),
+                    "ref_verify_value": self._preview_value(verify_b),
+                },
+            )
+            return False
+        delta_b = verify_b_num - baseline_b_num
+        if delta_a <= 0 or delta_b <= 0:
+            self._record_runtime_failure(
+                case,
+                phase="evaluate",
+                comment=ZERO_DELTA_COMMENT,
+                category="test",
+                reason_code="delta_zero_side",
+                metadata={"idx": idx, "delta_a": delta_a, "delta_b": delta_b},
+            )
+            return False
+        tolerance_pct = float(criterion.get("tolerance_pct", 0) or 0)
+        # symmetric relative diff: |a - b| / max(|a|, |b|)
+        denominator = max(abs(delta_a), abs(delta_b))
+        relative = abs(delta_a - delta_b) / denominator
+        if relative <= tolerance_pct / 100.0:
+            return True
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment=DELTA_MISMATCH_COMMENT_TEMPLATE.format(
+                a=int(delta_a) if delta_a.is_integer() else delta_a,
+                b=int(delta_b) if delta_b.is_integer() else delta_b,
+                t=int(tolerance_pct) if float(tolerance_pct).is_integer() else tolerance_pct,
+            ),
+            category="test",
+            reason_code="delta_mismatch",
+            metadata={
+                "idx": idx,
+                "delta_a": delta_a,
+                "delta_b": delta_b,
+                "tolerance_pct": tolerance_pct,
+                "relative": relative,
+            },
+        )
+        return False
+
+    log.warning("[%s] _evaluate_delta_criterion: unsupported operator %s", self.name, operator)
+    self._record_runtime_failure(
+        case,
+        phase="evaluate",
+        comment=f"fail 原因為未知 delta operator: {operator}",
+        category="test",
+        reason_code="delta_unknown_operator",
+        metadata={"idx": idx, "operator": operator},
+    )
+    return False
+```
+
+- [ ] **Step 8.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -v`
+Expected: all delta_nonzero AND delta_match tests PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): implement delta_match operator with tolerance and zero-side guards"
+```
+
+---
+
+## Task 9: Plugin — Refactor `evaluate()` to dispatch on `delta` key
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py:Plugin.evaluate` (~line 3289)
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 9.1: Write the failing dispatch tests**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+def test_evaluate_field_path_unchanged():
+    """Existing field+value criterion still produces pass_criteria_not_satisfied."""
+    plugin = _make_plugin()
+    case = {
+        "id": "T20",
+        "_attempt_index": 1,
+        "pass_criteria": [
+            {"field": "step1.X", "operator": "equals", "value": "expected"},
+        ],
+        "steps": [],
+    }
+    results = {"steps": {"step1": {"output": "X=actual\n", "success": True}}}
+    assert plugin.evaluate(case, results) is False
+    assert case["_last_failure"]["reason_code"] == "pass_criteria_not_satisfied"
+
+
+def test_evaluate_delta_path_picks_new_dispatch(monkeypatch):
+    """When criterion has 'delta' key, _compare must NOT be invoked."""
+    plugin = _make_plugin()
+    compare_called = []
+
+    def _spy_compare(self, *a, **kw):
+        compare_called.append((a, kw))
+        return True
+
+    monkeypatch.setattr(Plugin, "_compare", _spy_compare)
+
+    case = {
+        "id": "T21",
+        "_attempt_index": 1,
+        "pass_criteria": [
+            {
+                "delta": {"baseline": "before.X", "verify": "after.X"},
+                "operator": "delta_nonzero",
+            },
+        ],
+        "steps": [],
+    }
+    results = {"steps": {
+        "before": {"output": "X=10\n", "success": True, "captured": {"X": 10}},
+        "after":  {"output": "X=42\n", "success": True, "captured": {"X": 42}},
+    }}
+    assert plugin.evaluate(case, results) is True
+    assert compare_called == [], "delta path must not call _compare"
+
+
+def test_evaluate_mixed_criteria_halts_on_first_fail():
+    """First failing criterion (any type) halts evaluation."""
+    plugin = _make_plugin()
+    case = {
+        "id": "T22",
+        "_attempt_index": 1,
+        "pass_criteria": [
+            {
+                "delta": {"baseline": "before.X", "verify": "after.X"},
+                "operator": "delta_nonzero",
+            },
+            {"field": "before.X", "operator": "equals", "value": "999"},
+        ],
+        "steps": [],
+    }
+    # delta passes (10 → 42), field criterion would fail; but evaluate must keep going
+    results = {"steps": {
+        "before": {"output": "X=10\n", "success": True, "captured": {"X": 10}},
+        "after":  {"output": "X=42\n", "success": True, "captured": {"X": 42}},
+    }}
+    assert plugin.evaluate(case, results) is False
+    assert case["_last_failure"]["reason_code"] == "pass_criteria_not_satisfied"
+```
+
+- [ ] **Step 9.2: Run tests to verify dispatch behaviour fails**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k evaluate_ -v`
+Expected: `test_evaluate_field_path_unchanged` PASSES (existing path); `test_evaluate_delta_path_picks_new_dispatch` and `test_evaluate_mixed_criteria_halts_on_first_fail` FAIL because evaluate hasn't been taught about `delta:` yet.
+
+- [ ] **Step 9.3: Refactor `Plugin.evaluate()` to dispatch by `delta` key**
+
+In `plugins/wifi_llapi/plugin.py`, replace the body of `Plugin.evaluate` (around line 3289). The new structure extracts the existing field-criterion logic into a helper and adds dispatch:
+
+```python
+def evaluate(self, case: dict[str, Any], results: dict[str, Any]) -> bool:
+    """評估通過條件。"""
+    context = self._build_eval_context(case, results)
+    criteria = case.get("pass_criteria")
+    if not isinstance(criteria, list) or not criteria:
+        return False
+
+    for idx, criterion in enumerate(criteria):
+        if not isinstance(criterion, dict):
+            log.warning("[%s] evaluate: invalid criteria[%d]", self.name, idx)
+            return False
+        if "delta" in criterion:
+            ok = self._evaluate_delta_criterion(case, context, criterion, idx)
+        else:
+            ok = self._evaluate_field_criterion(case, context, criterion, idx)
+        if not ok:
+            return False
+    return True
+
+
+def _evaluate_field_criterion(
+    self,
+    case: dict[str, Any],
+    context: dict[str, Any],
+    criterion: dict[str, Any],
+    idx: int,
+) -> bool:
+    """Existing field+value/reference evaluation logic, behavior unchanged."""
+    aggregate_output = str(context.get("_aggregate_output", ""))
+    field = str(criterion.get("field", "")).strip()
+    operator = str(criterion.get("operator", "contains"))
+    expected = criterion.get("value")
+    reference = str(criterion.get("reference", "")).strip()
+
+    actual = self._resolve_field(context, field) if field else None
+    capture_raw = self._as_mapping(context.get("_capture_raw"))
+    if field and "." not in field and isinstance(actual, dict):
+        raw_output = capture_raw.get(field)
+        if isinstance(raw_output, str) and raw_output:
+            actual = raw_output
+    if isinstance(actual, dict) and "captured" in actual and "output" in actual:
+        captured = actual.get("captured")
+        if isinstance(captured, dict) and len(captured) == 1:
+            actual = next(iter(captured.values()))
+    if actual is None:
+        log.warning("[%s] evaluate: field not found (%s), fallback aggregate output", self.name, field)
+        actual = self._field_fallback_output(aggregate_output, field)
+
+    if expected is None and reference:
+        expected = self._resolve_field(context, reference)
+        if expected is None:
+            log.warning(
+                "[%s] evaluate: reference not found (%s), fallback aggregate output",
+                self.name,
+                reference,
+            )
+            expected = aggregate_output
+
+    if not self._compare(actual, operator, expected):
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment="pass_criteria not satisfied",
+            category="test",
+            reason_code="pass_criteria_not_satisfied",
+            output=self._preview_value(actual),
+            metadata={
+                "field": field,
+                "operator": operator,
+                "expected": self._preview_value(expected),
+                "actual": self._preview_value(actual),
+            },
+        )
+        log.info(
+            "[%s] evaluate failed: field=%s op=%s expected=%s actual=%s",
+            self.name,
+            field,
+            operator,
+            self._preview_value(expected),
+            self._preview_value(actual),
+        )
+        return False
+    return True
+```
+
+- [ ] **Step 9.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -v`
+Expected: ALL 18 tests now pass (5 nonzero + 7 match + 3 dispatch + 1 constant + previously written ones).
+
+- [ ] **Step 9.5: Run full wifi_llapi test suite to confirm no regression**
+
+Run: `pytest tests/ -k wifi -v`
+Expected: existing tests still pass (this proves the field-criterion refactor preserves behavior).
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): dispatch evaluate by 'delta' key, extract field-criterion helper"
+```
+
+---
+
+## Task 10: Plugin — `_validate_phase_ordering()` pure helper
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py` (add static method to `Plugin`)
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 10.1: Write the failing tests**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+def test_phase_ok_baseline_trigger_verify():
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [
+            {"id": "s1", "phase": "baseline"},
+            {"id": "s2", "phase": "trigger"},
+            {"id": "s3", "phase": "verify"},
+        ],
+    }
+    assert Plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_no_delta_skip_check():
+    case = {
+        "pass_criteria": [{"field": "x", "operator": "equals", "value": "y"}],
+        "steps": [{"id": "s1", "phase": "verify"}, {"id": "s2", "phase": "baseline"}],
+    }
+    assert Plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_missing_trigger():
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [{"id": "s1", "phase": "baseline"}, {"id": "s2", "phase": "verify"}],
+    }
+    err = Plugin._validate_phase_ordering(case)
+    assert err is not None
+    assert "require at least one phase=trigger" in err
+
+
+def test_phase_baseline_after_trigger():
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [
+            {"id": "s1", "phase": "baseline"},
+            {"id": "s2", "phase": "trigger"},
+            {"id": "s3", "phase": "baseline"},
+            {"id": "s4", "phase": "verify"},
+        ],
+    }
+    err = Plugin._validate_phase_ordering(case)
+    assert err is not None
+    assert "baseline step must precede trigger" in err
+
+
+def test_phase_verify_before_trigger():
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [
+            {"id": "s1", "phase": "baseline"},
+            {"id": "s2", "phase": "verify"},
+            {"id": "s3", "phase": "trigger"},
+        ],
+    }
+    err = Plugin._validate_phase_ordering(case)
+    assert err is not None
+    assert "verify step must follow trigger" in err
+
+
+def test_phase_default_unmarked_is_verify():
+    """Steps without a phase field count as verify (backward compatibility)."""
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [
+            {"id": "s1", "phase": "baseline"},
+            {"id": "s2", "phase": "trigger"},
+            {"id": "s3"},  # no phase = verify
+        ],
+    }
+    assert Plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_invalid_value():
+    case = {
+        "pass_criteria": [{"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"}],
+        "steps": [
+            {"id": "s1", "phase": "baseline"},
+            {"id": "s2", "phase": "warmup"},
+            {"id": "s3", "phase": "verify"},
+        ],
+    }
+    err = Plugin._validate_phase_ordering(case)
+    assert err is not None
+    assert "unknown phase: warmup" in err
+```
+
+- [ ] **Step 10.2: Run tests to verify they fail**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k test_phase -v`
+Expected: 7 failures (`AttributeError: type object 'Plugin' has no attribute '_validate_phase_ordering'`).
+
+- [ ] **Step 10.3: Implement `_validate_phase_ordering()`**
+
+In `plugins/wifi_llapi/plugin.py`, add this `@staticmethod` to the `Plugin` class (place near other static helpers):
+
+```python
+@staticmethod
+def _validate_phase_ordering(case: dict[str, Any]) -> str | None:
+    """Validate baseline → trigger → verify ordering for delta-using cases.
+
+    Returns None when the case is well-formed (or when no delta criterion is
+    present); otherwise returns a single-line error description.
+    """
+    criteria = case.get("pass_criteria") or []
+    has_delta = any(
+        isinstance(c, dict) and "delta" in c for c in criteria
+    )
+    if not has_delta:
+        return None
+
+    valid_phases = {"baseline", "trigger", "verify"}
+    phases: list[str] = []
+    for step in case.get("steps", []) or []:
+        if not isinstance(step, dict):
+            continue
+        raw = step.get("phase")
+        if raw is None:
+            phases.append("verify")  # backward compatibility default
+            continue
+        norm = str(raw).strip().lower()
+        if norm not in valid_phases:
+            return f"unknown phase: {norm}"
+        phases.append(norm)
+
+    last_baseline = max((i for i, p in enumerate(phases) if p == "baseline"), default=-1)
+    first_trigger = next((i for i, p in enumerate(phases) if p == "trigger"), -1)
+    last_trigger = max((i for i, p in enumerate(phases) if p == "trigger"), default=-1)
+    first_verify = next((i for i, p in enumerate(phases) if p == "verify"), -1)
+
+    if first_trigger == -1:
+        return "delta_* operators require at least one phase=trigger step"
+    if last_baseline >= 0 and last_baseline >= first_trigger:
+        return (
+            f"baseline step must precede trigger; "
+            f"last_baseline={last_baseline}, first_trigger={first_trigger}"
+        )
+    if first_verify == -1 or first_verify <= last_trigger:
+        return (
+            f"verify step must follow trigger; "
+            f"last_trigger={last_trigger}, first_verify={first_verify}"
+        )
+    return None
+```
+
+- [ ] **Step 10.4: Run tests to verify they pass**
+
+Run: `pytest tests/test_wifi_llapi_delta.py -k test_phase -v`
+Expected: 7 PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): add _validate_phase_ordering static helper"
+```
+
+---
+
+## Task 11: Plugin — Hook validator into `discover_cases`, collect violators in `_phase_blocked`
+
+**Files:**
+- Modify: `plugins/wifi_llapi/plugin.py:Plugin.discover_cases` and `__init__`
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 11.1: Write the failing test (use a temp dir of fixture yaml)**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+def test_discover_cases_marks_phase_invalid_into__phase_blocked(tmp_path, monkeypatch):
+    """Cases with bad phase ordering are removed from runnable list and recorded."""
+    import yaml
+    cases_dir = tmp_path / "cases"
+    cases_dir.mkdir()
+
+    good_yaml = {
+        "id": "good",
+        "name": "good",
+        "source": {"row": 1, "object": "X.", "api": "Y"},
+        "topology": {"devices": {"DUT": {"role": "ap", "transport": "serial", "selector": "COM1"}}},
+        "steps": [
+            {"id": "s1", "phase": "baseline", "command": "echo 1", "capture": "b"},
+            {"id": "s2", "phase": "trigger", "command": "echo 2"},
+            {"id": "s3", "phase": "verify", "command": "echo 3", "capture": "v"},
+        ],
+        "pass_criteria": [
+            {"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"},
+        ],
+    }
+    bad_yaml = {
+        "id": "bad",
+        "name": "bad",
+        "source": {"row": 2, "object": "X.", "api": "Y"},
+        "topology": {"devices": {"DUT": {"role": "ap", "transport": "serial", "selector": "COM1"}}},
+        "steps": [  # missing trigger
+            {"id": "s1", "phase": "baseline", "command": "echo 1", "capture": "b"},
+            {"id": "s2", "phase": "verify",  "command": "echo 2", "capture": "v"},
+        ],
+        "pass_criteria": [
+            {"delta": {"baseline": "b.X", "verify": "v.X"}, "operator": "delta_nonzero"},
+        ],
+    }
+    (cases_dir / "good.yaml").write_text(yaml.safe_dump(good_yaml))
+    (cases_dir / "bad.yaml").write_text(yaml.safe_dump(bad_yaml))
+
+    plugin = Plugin()
+    monkeypatch.setattr(type(plugin), "cases_dir", property(lambda self: cases_dir))
+
+    runnable = plugin.discover_cases()
+    runnable_ids = [c.get("id") for c in runnable]
+    assert "good" in runnable_ids
+    assert "bad" not in runnable_ids
+
+    blocked = getattr(plugin, "_phase_blocked", [])
+    assert any(getattr(b, "id_before", "") == "bad" for b in blocked)
+    bad_entry = next(b for b in blocked if getattr(b, "id_before", "") == "bad")
+    assert getattr(bad_entry, "status", "") == "blocked"
+    assert "invalid_delta_schema" in (getattr(bad_entry, "blocked_reason", "") or "")
+```
+
+- [ ] **Step 11.2: Run test to verify it fails**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_discover_cases_marks_phase_invalid_into__phase_blocked -v`
+Expected: FAIL — bad case still in runnable list, `_phase_blocked` doesn't exist.
+
+- [ ] **Step 11.3: Modify `discover_cases` and `__init__`**
+
+In `plugins/wifi_llapi/plugin.py`:
+
+(a) Add an import at the top of the file (alongside other testpilot imports):
+
+```python
+from testpilot.reporting.wifi_llapi_align import AlignResult
+```
+
+(b) In `Plugin.__init__` (or, if no `__init__` is defined, add one), initialize the attribute. Locate the `class Plugin(PluginBase):` line and add at the very top of its body:
+
+```python
+class Plugin(PluginBase):
+    def __init__(self) -> None:
+        super().__init__()
+        self._phase_blocked: list[Any] = []
+```
+
+(c) Replace `discover_cases`:
+
+```python
+def discover_cases(self) -> list[dict[str, Any]]:
+    raw = load_cases_dir(self.cases_dir, validator=validate_wifi_llapi_case)
+    self._phase_blocked = []
+    runnable: list[dict[str, Any]] = []
+    cases_root = Path(self.cases_dir)
+    for case in raw:
+        err = self._validate_phase_ordering(case)
+        if err is None:
+            runnable.append(case)
+            continue
+        case_id = str(case.get("id", "")).strip() or "<unknown>"
+        # Best-effort source row + filename for marker compat.
+        source = case.get("source") or {}
+        source_row = int(source.get("row") or 0) if isinstance(source, dict) else 0
+        filename = str(case.get("_source_file", "")) or f"{case_id}.yaml"
+        self._phase_blocked.append(
+            AlignResult(
+                case_file=cases_root / filename,
+                status="blocked",
+                source_row_before=source_row,
+                source_row_after=None,
+                source_object=str((source or {}).get("object", "")),
+                source_api=str((source or {}).get("api", "")),
+                filename_before=filename,
+                filename_after=None,
+                id_before=case_id,
+                id_after=None,
+                blocked_reason=f"invalid_delta_schema: {err}",
+            )
+        )
+        log.warning(
+            "[%s] phase ordering invalid for case %s: %s",
+            self.name,
+            case_id,
+            err,
+        )
+    return runnable
+```
+
+(`load_cases_dir` already attaches `_source_file` for case yaml; `cases_root / filename` reconstructs a path that satisfies `AlignResult.case_file`.)
+
+- [ ] **Step 11.4: Run test to verify it passes**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_discover_cases_marks_phase_invalid_into__phase_blocked -v`
+Expected: PASS.
+
+- [ ] **Step 11.5: Run full wifi_llapi suite**
+
+Run: `pytest tests/ -k wifi -v`
+Expected: existing tests still pass.
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add plugins/wifi_llapi/plugin.py tests/test_wifi_llapi_delta.py
+git commit -m "plugin(wifi_llapi): block phase-invalid cases at discover, collect into _phase_blocked"
+```
+
+---
+
+## Task 12: Orchestrator — merge `plugin._phase_blocked` into `prep.blocked_results`
+
+**Files:**
+- Modify: `src/testpilot/core/orchestrator.py:_prepare_wifi_llapi_alignment` (~line 509-536)
+- Test: `tests/test_wifi_llapi_delta.py`
+
+- [ ] **Step 12.1: Write the failing test**
+
+Append to `tests/test_wifi_llapi_delta.py`:
+
+```python
+def test_orchestrator_merges_phase_blocked_into_prep(tmp_path, monkeypatch):
+    """When plugin._phase_blocked is non-empty, _prepare_wifi_llapi_alignment
+    merges those entries into prep.blocked_results so they reach
+    fill_blocked_markers."""
+    from pathlib import Path as _Path
+    from unittest.mock import MagicMock
+    from testpilot.core.orchestrator import Orchestrator, WifiLlapiAlignmentPrep
+    from testpilot.reporting.wifi_llapi_align import AlignResult
+
+    fake_blocked = AlignResult(
+        case_file=_Path("/tmp/bad.yaml"),
+        status="blocked",
+        source_row_before=99,
+        source_row_after=None,
+        source_object="WiFi.Foo.",
+        source_api="Bar",
+        filename_before="bad.yaml",
+        filename_after=None,
+        id_before="bad",
+        id_after=None,
+        blocked_reason="invalid_delta_schema: missing trigger",
+    )
+
+    fake_plugin = MagicMock()
+    fake_plugin._phase_blocked = [fake_blocked]
+    fake_plugin.cases_dir = tmp_path
+
+    # _load_wifi_llapi_case_pairs returns []; build_template_index returns a
+    # minimal index; align_case is patched to a no-op.
+    monkeypatch.setattr(
+        Orchestrator, "_load_wifi_llapi_case_pairs",
+        lambda self, *, plugin, case_ids: [],
+    )
+
+    import testpilot.core.orchestrator as orch_mod
+    monkeypatch.setattr(orch_mod, "build_template_index", lambda p: MagicMock())
+    monkeypatch.setattr(orch_mod, "align_case", lambda case, idx, path: None)
+    monkeypatch.setattr(orch_mod, "_resolve_collisions", lambda r: None)
+    monkeypatch.setattr(orch_mod, "apply_alignment_mutations", lambda r: None)
+
+    orchestrator = Orchestrator.__new__(Orchestrator)  # bypass __init__
+    prep = Orchestrator._prepare_wifi_llapi_alignment(
+        orchestrator,
+        plugin=fake_plugin,
+        case_ids=None,
+        template_path=tmp_path / "tmpl.xlsx",
+    )
+    assert isinstance(prep, WifiLlapiAlignmentPrep)
+    assert any(b.id_before == "bad" for b in prep.blocked_results)
+    assert any(
+        "invalid_delta_schema" in (b.blocked_reason or "")
+        for b in prep.blocked_results
+    )
+```
+
+- [ ] **Step 12.2: Run test to verify it fails**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_orchestrator_merges_phase_blocked_into_prep -v`
+Expected: FAIL — `phase_blocked` is not merged.
+
+- [ ] **Step 12.3: Modify `_prepare_wifi_llapi_alignment`**
+
+In `src/testpilot/core/orchestrator.py`, locate `_prepare_wifi_llapi_alignment` and append the merge step before `return WifiLlapiAlignmentPrep(...)`:
+
+```python
+def _prepare_wifi_llapi_alignment(
+    self,
+    *,
+    plugin: Any,
+    case_ids: list[str] | None,
+    template_path: Path,
+) -> WifiLlapiAlignmentPrep:
+    case_pairs = self._load_wifi_llapi_case_pairs(plugin=plugin, case_ids=case_ids)
+    index = build_template_index(template_path)
+    align_results = [align_case(case, index, path) for path, case in case_pairs]
+    _resolve_collisions(align_results)
+    apply_alignment_mutations(align_results)
+    runnable_results = [
+        result
+        for result in align_results
+        if result.status in {"already_aligned", "auto_aligned"}
+    ]
+    blocked_results = [result for result in align_results if result.status == "blocked"]
+    skipped_results = [result for result in align_results if result.status == "skipped"]
+
+    # Merge phase-ordering BLOCKED entries detected by plugin.discover_cases
+    phase_blocked = list(getattr(plugin, "_phase_blocked", []) or [])
+    if phase_blocked:
+        blocked_results = blocked_results + phase_blocked
+
+    return WifiLlapiAlignmentPrep(
+        runnable_cases=[
+            load_case(result.case_file, validator=validate_wifi_llapi_case)
+            for result in runnable_results
+        ],
+        blocked_results=blocked_results,
+        skipped_results=skipped_results,
+        alignment_summary=self._build_wifi_llapi_alignment_summary(
+            align_results + phase_blocked
+        ),
+    )
+```
+
+(Note: `phase_blocked` also gets folded into `_build_wifi_llapi_alignment_summary` so the summary "blocked" count is accurate.)
+
+- [ ] **Step 12.4: Run test to verify it passes**
+
+Run: `pytest tests/test_wifi_llapi_delta.py::test_orchestrator_merges_phase_blocked_into_prep -v`
+Expected: PASS.
+
+- [ ] **Step 12.5: Run full orchestrator regression**
+
+Run: `pytest tests/ -k orchestrator -v`
+Expected: PASS.
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add src/testpilot/core/orchestrator.py tests/test_wifi_llapi_delta.py
+git commit -m "orchestrator(wifi_llapi): merge plugin._phase_blocked into alignment blocked_results"
+```
+
+---
+
+## Task 13: Integration test — yaml fixtures + end-to-end run with reporter
+
+**Files:**
+- Create: `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml`
+- Create: `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml`
+- Create: `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml`
+- Create: `tests/test_wifi_llapi_delta_integration.py`
+
+- [ ] **Step 13.1: Create fixtures**
+
+Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml`:
+
+```yaml
+id: fixture-delta-nonzero-pass
+name: delta_nonzero PASS fixture
+source: {row: 9001, object: WiFi.Test.{i}., api: TestCounter}
+topology:
+  devices:
+    DUT: {role: ap, transport: stub, selector: dummy}
+steps:
+- {id: s1, phase: baseline, command: "echo X=10", capture: before}
+- {id: s2, phase: trigger,  command: "echo trigger"}
+- {id: s3, phase: verify,   command: "echo X=42", capture: after}
+pass_criteria:
+- delta: {baseline: before.X, verify: after.X}
+  operator: delta_nonzero
+```
+
+Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml`:
+
+```yaml
+id: fixture-delta-nonzero-fail
+name: delta_nonzero FAIL fixture
+source: {row: 9002, object: WiFi.Test.{i}., api: TestCounter}
+topology:
+  devices:
+    DUT: {role: ap, transport: stub, selector: dummy}
+steps:
+- {id: s1, phase: baseline, command: "echo X=10", capture: before}
+- {id: s2, phase: trigger,  command: "echo trigger"}
+- {id: s3, phase: verify,   command: "echo X=10", capture: after}
+pass_criteria:
+- delta: {baseline: before.X, verify: after.X}
+  operator: delta_nonzero
+```
+
+Create `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml`:
+
+```yaml
+id: fixture-delta-match-pass
+name: delta_match PASS fixture
+source: {row: 9003, object: WiFi.Test.{i}., api: TestCounter}
+topology:
+  devices:
+    DUT: {role: ap, transport: stub, selector: dummy}
+steps:
+- {id: s1, phase: baseline, command: "echo X=0",  capture: api_before}
+- {id: s2, phase: baseline, command: "echo Y=0",  capture: drv_before}
+- {id: s3, phase: trigger,  command: "echo trigger"}
+- {id: s4, phase: verify,   command: "echo X=100", capture: api_after}
+- {id: s5, phase: verify,   command: "echo Y=109", capture: drv_after}
+pass_criteria:
+- delta: {baseline: api_before.X, verify: api_after.X}
+  operator: delta_nonzero
+- delta: {baseline: api_before.X, verify: api_after.X}
+  reference_delta: {baseline: drv_before.Y, verify: drv_after.Y}
+  operator: delta_match
+  tolerance_pct: 10
+```
+
+- [ ] **Step 13.2: Write the failing integration test**
+
+Create `tests/test_wifi_llapi_delta_integration.py`:
+
+```python
+"""End-to-end integration test for wifi_llapi delta runtime (Wave 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "wifi_llapi_delta"
+
+
+def _load_case(path: Path) -> dict:
+    import yaml
+    return yaml.safe_load(path.read_text())
+
+
+def _stub_results_for(case: dict) -> dict:
+    """Produce a results dict that mirrors what the runner would emit:
+
+    For each step, parse its `echo K=V` command into a captured dict.
+    """
+    out: dict[str, dict] = {"steps": {}}
+    for step in case.get("steps", []):
+        cmd = str(step.get("command", "")).strip()
+        captured: dict[str, object] = {}
+        if cmd.startswith("echo "):
+            payload = cmd[len("echo "):].strip().strip("\"")
+            for token in payload.split():
+                if "=" in token:
+                    k, v = token.split("=", 1)
+                    try:
+                        captured[k] = int(v)
+                    except ValueError:
+                        captured[k] = v
+        sid = str(step.get("id", ""))
+        out["steps"][sid] = {
+            "success": True,
+            "output": payload if cmd.startswith("echo ") else "",
+            "captured": captured,
+            "returncode": 0,
+        }
+    return out
+
+
+def test_delta_nonzero_pass_fixture():
+    from plugins.wifi_llapi.plugin import Plugin
+    case = _load_case(FIXTURE_DIR / "delta_nonzero_pass.yaml")
+    plugin = Plugin()
+    results = _stub_results_for(case)
+    assert plugin.evaluate(case, results) is True
+
+
+def test_delta_nonzero_fail_fixture():
+    from plugins.wifi_llapi.plugin import Plugin
+    case = _load_case(FIXTURE_DIR / "delta_nonzero_fail.yaml")
+    plugin = Plugin()
+    results = _stub_results_for(case)
+    assert plugin.evaluate(case, results) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+    assert case["_last_failure"]["comment"] == "fail 原因為 0，數值無變化"
+
+
+def test_delta_match_pass_fixture():
+    from plugins.wifi_llapi.plugin import Plugin
+    case = _load_case(FIXTURE_DIR / "delta_match_pass.yaml")
+    plugin = Plugin()
+    results = _stub_results_for(case)
+    assert plugin.evaluate(case, results) is True
+
+
+def test_delta_failure_propagates_to_xlsx_M_column(tmp_path):
+    """End-to-end: fail fixture's comment is written to M column via fill_case_results."""
+    from openpyxl import Workbook, load_workbook
+    from plugins.wifi_llapi.plugin import Plugin
+    from testpilot.reporting.wifi_llapi_excel import (
+        DEFAULT_SHEET_NAME,
+        WifiLlapiCaseResult,
+        fill_case_results,
+        _normalize_template_headers,
+    )
+    case = _load_case(FIXTURE_DIR / "delta_nonzero_fail.yaml")
+    plugin = Plugin()
+    results = _stub_results_for(case)
+    assert plugin.evaluate(case, results) is False
+
+    # Build a single-row report and pipe the comment through.
+    report = tmp_path / "report.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = DEFAULT_SHEET_NAME
+    _normalize_template_headers(ws)
+    ws.cell(row=4, column=1).value = "anchor"
+    wb.save(report)
+
+    item = WifiLlapiCaseResult(
+        case_id=case["id"],
+        source_row=4,
+        executed_test_command="",
+        command_output="",
+        result_5g="FAIL",
+        result_6g="N/A",
+        result_24g="N/A",
+        comment=case["_last_failure"]["comment"],
+    )
+    fill_case_results(report, [item])
+
+    wb2 = load_workbook(report)
+    ws2 = wb2[DEFAULT_SHEET_NAME]
+    assert ws2.cell(row=4, column=13).value == "fail 原因為 0，數值無變化"
+```
+
+- [ ] **Step 13.3: Run integration tests**
+
+Run: `pytest tests/test_wifi_llapi_delta_integration.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 13.4: Commit**
+
+```bash
+git add tests/fixtures/wifi_llapi_delta/ tests/test_wifi_llapi_delta_integration.py
+git commit -m "test(wifi_llapi): end-to-end delta fixtures + xlsx M column propagation"
+```
+
+---
+
+## Task 14: Documentation — `plugins/wifi_llapi/CASE_YAML_SYNTAX.md`
+
+**Files:**
+- Create: `plugins/wifi_llapi/CASE_YAML_SYNTAX.md`
+
+This is a documentation deliverable, not test-driven. Write the file in one shot, then verify it renders by inspection.
+
+- [ ] **Step 14.1: Inventory top-level fields actually in use**
+
+Run: `grep -h "^[a-z_]*:" plugins/wifi_llapi/cases/D*.yaml | sort -u`
+
+Capture the full set; expect: `id, name, version, source, platform, hlapi_command, llapi_support, implemented_by, bands, topology, test_environment, setup_steps, sta_env_setup, test_procedure, steps, pass_criteria, verification_command, sta_baseline, dut_bounce, ping`
+
+- [ ] **Step 14.2: Inventory step-level fields**
+
+Run: `grep -E "^\s*-\s*id:|^\s*[a-z_]+:" plugins/wifi_llapi/cases/D037_retransmissions.yaml | head -30`
+
+Confirm step keys: `id, action, target, command, capture, depends_on, expected, description`. Add `phase` (newly introduced).
+
+- [ ] **Step 14.3: Write `CASE_YAML_SYNTAX.md`**
+
+Create `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` with this content:
+
+````markdown
+# wifi_llapi Test Case YAML Syntax Reference
+
+> Long-lived reference. Updated in lockstep with `plugin.py` schema changes.
+> When this file goes out of date, fix it before adding new schema features.
+
+## Case-level fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Unique case identifier (kebab or snake) |
+| `name` | yes | Human-readable display name |
+| `version` | no | Spec version (e.g. `'1.1'`) |
+| `source` | yes | `{row: int, object: str, api: str}` — workbook row mapping |
+| `platform` | no | `{prplos: str, bdk: str}` |
+| `hlapi_command` | no | The HLAPI command this case verifies |
+| `llapi_support` | no | One of `Support / Not Supported / Skip / Blocked` |
+| `implemented_by` | no | Vendor module name (e.g. `pWHM`) |
+| `bands` | no | List of bands targeted (`5g / 6g / 2.4g`) |
+| `topology` | yes | `{devices: {NAME: {role, transport, selector, config?}}, links?: [...]}` |
+| `test_environment` | no | Free-form preamble |
+| `setup_steps` | no | Free-form prose |
+| `sta_env_setup` | no | Free-form prose for STA env setup |
+| `test_procedure` | no | Free-form prose for human readers |
+| `steps` | yes | Ordered list of step dicts (see below) |
+| `pass_criteria` | yes | Ordered list of criterion dicts (see below) |
+| `verification_command` | no | Reference list of commands a human can re-run |
+
+## Step-level fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Unique within the case (referenced by `depends_on`) |
+| `target` | no | Device name from `topology.devices` (default DUT) |
+| `action` | no | One of `read / exec / skip` (default `exec`) |
+| `command` | yes (unless `action: skip`) | Shell command run on `target` |
+| `capture` | no | Captured output is also exposed as `<capture>.<key>` in eval context |
+| `depends_on` | no | Step `id` that must succeed first |
+| `expected` | no | Free-form description, no runtime semantics |
+| `description` | no | Free-form display text |
+| `phase` | no | One of `baseline / trigger / verify`. Default: `verify`. **Required when the case uses any `delta_*` operator** (validated at load time). |
+
+### Phase ordering rule
+
+When any `pass_criteria` entry contains a `delta:` key, the runtime enforces:
+
+1. At least one step with `phase: trigger` MUST exist.
+2. All `phase: baseline` steps MUST appear before all `phase: trigger` steps.
+3. All `phase: verify` steps MUST appear after all `phase: trigger` steps.
+
+Cases that violate these rules are marked BLOCKED with `blocked_reason` beginning with `invalid_delta_schema:` and are excluded from the runnable list.
+
+## pass_criteria shapes
+
+### Shape 1 — `field + value`
+
+```yaml
+- field: capture_name.Key
+  operator: equals     # or != / contains / not_contains / regex / not_empty / empty / >= / <= / > / < / skip
+  value: '0'
+  description: optional human note
+```
+
+### Shape 2 — `field + reference`
+
+```yaml
+- field: api_capture.Key
+  operator: equals
+  reference: driver_capture.OtherKey
+  description: 'API value must match driver readback'
+```
+
+### Shape 3 — `delta` (counter validation, requires `phase` labels on steps)
+
+```yaml
+# delta_nonzero — counter must grow under trigger
+- delta: {baseline: before.X, verify: after.X}
+  operator: delta_nonzero
+  description: 'optional'
+
+# delta_match — API delta must match driver delta within tolerance
+- delta: {baseline: api_before.X, verify: api_after.X}
+  reference_delta: {baseline: drv_before.Y, verify: drv_after.Y}
+  operator: delta_match
+  tolerance_pct: 10
+```
+
+## Operators
+
+| Operator | Shape | Pass condition |
+|---|---|---|
+| `equals` / `==` / `eq` | field+value/ref | `actual == expected` (numeric & MAC-aware) |
+| `!=` / `not_equals` / `ne` | field+value/ref | inverse of `equals` |
+| `contains` | field+value/ref | substring match (whitespace-tolerant) |
+| `not_contains` | field+value/ref | inverse of `contains` |
+| `regex` / `matches` | field+value/ref | `re.search(expected, actual)` |
+| `not_empty` | field | `bool(actual.strip())` |
+| `empty` | field | inverse of `not_empty` |
+| `>` / `>=` / `<` / `<=` | field+value/ref | numeric (or string fallback) comparison |
+| `skip` | field | always passes (used by Blocked cases) |
+| `delta_nonzero` | delta | `verify - baseline > 0` (strict) |
+| `delta_match` | delta + reference_delta | both deltas > 0 AND `\|a-b\|/max(\|a\|,\|b\|) <= tolerance_pct/100` |
+
+## reason_codes (delta path)
+
+| reason_code | When |
+|---|---|
+| `invalid_delta_schema` | Phase ordering invalid (BLOCKED path) |
+| `delta_value_not_numeric` | Either endpoint cannot resolve to a number |
+| `delta_zero` | `delta_nonzero` saw `verify - baseline <= 0` |
+| `delta_zero_side` | `delta_match` saw at least one delta `<= 0` |
+| `delta_mismatch` | `delta_match` saw both grow but exceeded tolerance |
+| `pass_criteria_not_satisfied` | (Existing) any field-shape criterion failed; refinement tracked in #39 |
+
+## Failure comments
+
+Plugin-level constants (case yaml MUST NOT override):
+
+- `delta_zero` / `delta_zero_side` → `"fail 原因為 0，數值無變化"`
+- `delta_mismatch` → `"fail 原因為 delta 不一致：api={a} drv={b} tol={t}%"`
+- `delta_value_not_numeric` → `"fail 原因為 delta 端點非數值"`
+
+These appear in the xlsx report's column M (`Comment`).
+
+## llapi_support semantics
+
+| Value | Behavior |
+|---|---|
+| `Support` | Standard execution; pass_criteria evaluated normally |
+| `Not Supported` | Step `action: skip` recommended; pass_criteria typically uses `operator: skip` |
+| `Skip` | Same — case is skipped from execution |
+| `Blocked` | Case requires manual gating; `step.action: skip` + `pass_criteria.operator: skip` |
+
+## Worked Examples
+
+### Example A — Standard case (existing shape, no delta)
+
+```yaml
+id: example-standard
+name: Example
+source: {row: 100, object: WiFi.Foo., api: Bar}
+topology:
+  devices: {DUT: {role: ap, transport: serial, selector: COM1}}
+steps:
+- id: read
+  command: ubus-cli "WiFi.Foo.Bar?"
+  capture: result
+pass_criteria:
+- field: result.Bar
+  operator: equals
+  value: 'expected'
+```
+
+### Example B — Counter-delta case (new shape)
+
+```yaml
+id: example-delta
+name: Example delta counter
+source: {row: 200, object: WiFi.Foo., api: BarCounter}
+topology:
+  devices: {DUT: {role: ap, transport: serial, selector: COM1}}
+steps:
+- id: api_before
+  phase: baseline
+  command: ubus-cli "WiFi.Foo.BarCounter?"
+  capture: api_before
+- id: drv_before
+  phase: baseline
+  command: wl -i wl0 read_counter | grep BarCounter
+  capture: drv_before
+- id: trigger
+  phase: trigger
+  command: <workload that drives the counter>
+- id: api_after
+  phase: verify
+  command: ubus-cli "WiFi.Foo.BarCounter?"
+  capture: api_after
+- id: drv_after
+  phase: verify
+  command: wl -i wl0 read_counter | grep BarCounter
+  capture: drv_after
+pass_criteria:
+- delta: {baseline: api_before.BarCounter, verify: api_after.BarCounter}
+  operator: delta_nonzero
+- delta: {baseline: api_before.BarCounter, verify: api_after.BarCounter}
+  reference_delta: {baseline: drv_before.BarCounter, verify: drv_after.BarCounter}
+  operator: delta_match
+  tolerance_pct: 10
+```
+
+### Example C — Blocked case (live probe known broken)
+
+```yaml
+id: example-blocked
+name: Example blocked
+source: {row: 300, object: WiFi.Foo., api: Baz}
+llapi_support: Blocked
+topology:
+  devices: {DUT: {role: ap, transport: serial, selector: COM1}}
+steps:
+- id: skip_step
+  action: skip
+  command: "echo blocked"
+  description: "live probe shows 0; needs workload to confirm wiring"
+pass_criteria:
+- field: skip
+  operator: skip
+  value: "needs workload to confirm wiring"
+```
+````
+
+- [ ] **Step 14.4: Verify the file renders sensibly**
+
+Run: `head -100 plugins/wifi_llapi/CASE_YAML_SYNTAX.md`
+Expected: clean markdown table, no template artifacts.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/CASE_YAML_SYNTAX.md
+git commit -m "docs(wifi_llapi): add CASE_YAML_SYNTAX.md long-lived schema reference"
+```
+
+---
+
+## Task 15: Migrate sample case D037
+
+**Files:**
+- Modify: `plugins/wifi_llapi/cases/D037_retransmissions.yaml`
+
+This is a yaml refactor. The case must:
+1. Add `phase` labels to all steps (split the existing `step1/2/3` into baseline/trigger/verify trios for the 5G band).
+2. Add a trigger step that is plausible (iperf3 UDP from STA to DUT).
+3. Replace `equals '0'` pass_criteria with `delta_nonzero` + `delta_match`.
+4. Delete the description line that says `'Workbook v4.0.3 marks this API as Fail: ...'`.
+
+- [ ] **Step 15.1: Read the current case to confirm what needs to change**
+
+Run: `cat plugins/wifi_llapi/cases/D037_retransmissions.yaml | head -160`
+
+Confirm: 3 steps, pass_criteria uses `equals '0'` with the workbook-fail description.
+
+- [ ] **Step 15.2: Replace `steps:` and `pass_criteria:` blocks**
+
+Edit `plugins/wifi_llapi/cases/D037_retransmissions.yaml`. Keep the top-level metadata (`id, name, version, source, platform, hlapi_command, llapi_support, implemented_by, bands, topology, test_environment, setup_steps, sta_env_setup, test_procedure`). Replace `steps:` and `pass_criteria:` (and `verification_command:` if present) with:
+
+```yaml
+steps:
+- id: step1_resolve_assoc
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+  capture: assoc_entry
+  description: Resolve the live 5G STA MAC for AP1 AssociatedDevice.1.
+- id: step2_api_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+  capture: api_before_5g
+  description: API-side baseline reading of Retransmissions.
+- id: step3_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && wl -i wl0
+    sta_info $STA_MAC | sed -n ''s/.*tx pkts retries: *\([0-9][0-9]*\).*/DriverRetransmissions=\1/p'''
+  capture: drv_before_5g
+  description: Driver-side baseline of tx pkts retries for the same STA.
+- id: step4_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: iperf3 -u -c 192.168.88.1 -b 100M -l 1400 -t 5 --pacing-timer 1
+  description: Burst UDP downlink to drive AP-side retransmissions.
+- id: step5_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+  capture: api_after_5g
+  description: API-side verify reading of Retransmissions after trigger.
+- id: step6_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && wl -i wl0
+    sta_info $STA_MAC | sed -n ''s/.*tx pkts retries: *\([0-9][0-9]*\).*/DriverRetransmissions=\1/p'''
+  capture: drv_after_5g
+  description: Driver-side verify of tx pkts retries after trigger.
+pass_criteria:
+- field: assoc_entry.MACAddress
+  operator: regex
+  value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
+  description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- delta: {baseline: api_before_5g.Retransmissions, verify: api_after_5g.Retransmissions}
+  operator: delta_nonzero
+  description: 5g API Retransmissions must grow after the trigger workload.
+- delta: {baseline: api_before_5g.Retransmissions, verify: api_after_5g.Retransmissions}
+  reference_delta: {baseline: drv_before_5g.DriverRetransmissions, verify: drv_after_5g.DriverRetransmissions}
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g API delta must agree with driver delta within ±10%.
+verification_command:
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+- iperf3 -u -c 192.168.88.1 -b 100M -l 1400 -t 5 --pacing-timer 1
+- 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC'
+```
+
+(Note: the trigger uses the STA's iperf3 hitting the DUT bridge IP `192.168.88.1`, matching `sta_env_setup` from the existing case.)
+
+- [ ] **Step 15.3: Verify the case parses and schema is valid**
+
+Run:
+```bash
+python -c "
+from plugins.wifi_llapi.plugin import Plugin
+import yaml, pathlib
+case = yaml.safe_load(pathlib.Path('plugins/wifi_llapi/cases/D037_retransmissions.yaml').read_text())
+print('phase ordering:', Plugin._validate_phase_ordering(case))
+"
+```
+Expected output: `phase ordering: None`
+
+- [ ] **Step 15.4: Run wifi_llapi tests to confirm nothing broke**
+
+Run: `pytest tests/ -k wifi -v`
+Expected: green.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/cases/D037_retransmissions.yaml
+git commit -m "case(wifi_llapi): migrate D037 Retransmissions to delta range (sample for #38/#13)"
+```
+
+---
+
+## Task 16: Migrate sample case D313
+
+**Files:**
+- Modify: `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`
+
+D313 already has 3 steps (one per band reading getSSIDStats). Each band needs baseline → trigger → verify.
+
+- [ ] **Step 16.1: Read the current case**
+
+Run: `cat plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`
+
+Confirm: 3 read-stats steps + `equals 0` pass_criteria for each band.
+
+- [ ] **Step 16.2: Replace `steps:` and `pass_criteria:` blocks**
+
+Edit `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`. Keep top-level metadata. Replace steps and pass_criteria with:
+
+```yaml
+steps:
+- id: step_5g_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.4.getSSIDStats()"
+  capture: stats_5g_before
+- id: step_6g_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.6.getSSIDStats()"
+  capture: stats_6g_before
+- id: step_24g_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.8.getSSIDStats()"
+  capture: stats_24g_before
+- id: step_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: iperf3 -u -c 192.168.88.1 -b 100M -l 1400 -t 5 --pacing-timer 1
+  description: Drive retransmissions across all bands by sustained UDP burst.
+- id: step_5g_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.4.getSSIDStats()"
+  capture: stats_5g_after
+- id: step_6g_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.6.getSSIDStats()"
+  capture: stats_6g_after
+- id: step_24g_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.SSID.8.getSSIDStats()"
+  capture: stats_24g_after
+pass_criteria:
+- delta: {baseline: stats_5g_before.RetransCount, verify: stats_5g_after.RetransCount}
+  operator: delta_nonzero
+  description: 5g SSID.4 RetransCount must grow under trigger.
+- delta: {baseline: stats_6g_before.RetransCount, verify: stats_6g_after.RetransCount}
+  operator: delta_nonzero
+  description: 6g SSID.6 RetransCount must grow under trigger.
+- delta: {baseline: stats_24g_before.RetransCount, verify: stats_24g_after.RetransCount}
+  operator: delta_nonzero
+  description: 2.4g SSID.8 RetransCount must grow under trigger.
+```
+
+- [ ] **Step 16.3: Validate the case**
+
+Run:
+```bash
+python -c "
+from plugins.wifi_llapi.plugin import Plugin
+import yaml, pathlib
+case = yaml.safe_load(pathlib.Path('plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml').read_text())
+print('phase ordering:', Plugin._validate_phase_ordering(case))
+"
+```
+Expected output: `phase ordering: None`
+
+- [ ] **Step 16.4: Run full wifi_llapi test suite**
+
+Run: `pytest tests/ -k wifi -v`
+Expected: green.
+
+- [ ] **Step 16.5: Commit**
+
+```bash
+git add plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml
+git commit -m "case(wifi_llapi): migrate D313 RetransCount to delta range (sample for #38/#13)"
+```
+
+---
+
+## Task 17: Final regression + Wave 1 closeout
+
+**Files:** none (smoke run + audit)
+
+- [ ] **Step 17.1: Full pytest suite**
+
+Run: `pytest tests/ -v 2>&1 | tail -40`
+Expected: 0 failures. Note any new test count.
+
+- [ ] **Step 17.2: Confirm dispatch zero-regression on `_compare`**
+
+Run: `pytest tests/ -k "compare" -v`
+Expected: existing comparison tests untouched.
+
+- [ ] **Step 17.3: Audit — no remaining `equals '0'` workbook-fail prose in migrated cases**
+
+Run: `grep -nE "Workbook v4.0.3 marks this API as Fail" plugins/wifi_llapi/cases/D037_retransmissions.yaml plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`
+Expected: no matches.
+
+- [ ] **Step 17.4: OpenSpec change validation**
+
+Run: `openspec validate wifi-llapi-counter-delta-validation --strict`
+Expected: `Change 'wifi-llapi-counter-delta-validation' is valid`.
+
+- [ ] **Step 17.5: Mark Wave 1 PR-ready**
+
+Inspect the commit log:
+
+Run: `git log --oneline main..HEAD`
+Expected: ~16-17 commits, each one focused, all green.
+
+- [ ] **Step 17.6: Push branch and open PR**
+
+(Manual — only when authorized by user.)
+
+```bash
+# Run only after user explicitly says "push" / "open PR".
+git push -u origin <branch-name>
+gh pr create --title "feat(wifi_llapi): counter delta validation Wave 1 (#38, #13)" --body "$(cat <<'EOF'
+Wave 1 (foundation) for the wifi_llapi counter delta validation initiative.
+
+## Scope
+
+- Runtime: `phase: baseline | trigger | verify` step label, `delta_nonzero` and `delta_match` operators, phase ordering schema validator (BLOCKED path).
+- Reporter: new column M `Comment`, `WifiLlapiCaseResult.comment` written with truncation, BLOCKED/SKIP unchanged.
+- Sample cases: D037 (Retransmissions), D313 (RetransCount) migrated to delta range.
+- Documentation: `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` long-lived schema reference.
+
+## Spec & change
+
+- Spec: `docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md`
+- OpenSpec: `openspec/changes/wifi-llapi-counter-delta-validation/`
+
+## Test plan
+
+- [x] `pytest tests/test_wifi_llapi_delta.py` — unit tests for delta operators + phase validator + dispatch
+- [x] `pytest tests/test_wifi_llapi_delta_integration.py` — end-to-end fixtures + xlsx M column propagation
+- [x] `pytest tests/test_wifi_llapi_excel.py` — extended for M column behaviour & BLOCKED/SKIP regression guards
+- [x] `pytest tests/` full suite — no regression
+- [x] `openspec validate wifi-llapi-counter-delta-validation --strict`
+- [x] D037 / D313 schema validates after migration
+
+## Out of scope (subsequent waves)
+
+- Wave 2: ~30 Stage A case migrations
+- Wave 3: ~50 Stage B case migrations
+- `pass_criteria_not_satisfied` reason_code refinement (#39)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage check
+
+Walking through `openspec/changes/wifi-llapi-counter-delta-validation/specs/wifi-llapi-counter-validation/spec.md`:
+
+| Spec Requirement | Plan Coverage |
+|---|---|
+| `phase` field accepted on steps | Tasks 10, 11 + integration Task 13 |
+| `phase` defaults to `verify` | Task 10 step 10.3 (default branch); Task 13 fixtures + Task 11 test |
+| Unknown phase rejected | Task 10 (test_phase_invalid_value) |
+| Phase ordering validated at load when delta present | Tasks 10 + 11 |
+| `delta_nonzero` semantics | Tasks 6, 7 |
+| `delta_match` semantics + tolerance | Task 8 |
+| Evaluate dispatch by `delta` key | Task 9 |
+| Comment as plugin-level constant | Tasks 6 + 7/8 (uses ZERO_DELTA_COMMENT) |
+| M column header + write + truncate | Tasks 1, 2, 3, 4 |
+| BLOCKED/SKIP not in M | Task 5 (regression guards) |
+| Five new reason_codes | Tasks 7, 8 (delta_*) and Task 11 (invalid_delta_schema flow via `blocked_reason`) |
+| `pass_criteria_not_satisfied` preserved | Task 9 (test_evaluate_field_path_unchanged) |
+
+All spec requirements covered.
+
+### Placeholder scan
+
+No `TBD` / `TODO` / "implement later" anywhere; every code block is concrete; every test has assertions; every command has expected output described. Migration trigger workloads use a concrete iperf3 invocation (matching the existing STA env baseline), not a placeholder.
+
+### Type / signature consistency
+
+- `_evaluate_delta_criterion(case, context, criterion, idx) -> bool` — used identically in Tasks 7, 8, 9.
+- `_validate_phase_ordering(case) -> str | None` — used identically in Tasks 10, 11.
+- `_truncate_comment(text: str | None, *, limit: int = 200) -> str` — used identically in Tasks 3, 4.
+- `Plugin._phase_blocked: list[Any]` — initialized in Task 11, consumed in Task 12.
+- `WifiLlapiCaseResult.comment` is the existing dataclass field — wired in Task 4.
+
+Consistent.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-wifi-llapi-counter-delta-validation-wave1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md
+++ b/docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md
@@ -305,7 +305,7 @@ def _validate_phase_ordering(case) -> str | None:
 ```
 Stage A（必遷，~30 case）── api 名稱含 Retry / Retrans / Fail / Error / Drop / Discard / Glitch / BadPLCP
                            且 llapi_support: Support
-                           ─► 必走 delta_nonzero + delta_match
+                           ─► 預設走 delta_nonzero + delta_match
 
 Stage B（個案判斷，~50 case）── api 名稱含 Count / Bytes / Packets / Stats
                                  ─► 進一步區分：
@@ -329,6 +329,9 @@ D406, D407, D448, D451                               # radio_stats retry / pream
 D452, D453, D454, D455, D457, D458                   # vendor stats badplcp / glitch / radio retry / retrans
 D495, D580                                           # retrycount verified / affiliated sta errors
 ```
+
+> Wave 1 樣板中的 **D313** 是刻意保留的例外：它用來示範 **multi-band baseline/trigger/verify phase** 與共享 trigger phase 的描述方式，因此只要求每個 band 的 `delta_nonzero`。  
+> Wave 1 的 `reference_delta + delta_match` 樣板由 **D037** 承擔；等到後續 wave 為 getSSIDStats 家族選定穩定的 companion counter 後，再把同家族遷移收斂到完整的 cross-source delta_match 範式。
 
 ### Stage B 預估遷移名單
 
@@ -525,8 +528,8 @@ Wave 1（基礎建設 PR）必須交付：
 - [ ] `tests/test_wifi_llapi_excel.py`：Integration test E 擴充
 - [ ] `tests/fixtures/wifi_llapi_delta/`：3 個 fixture case
 - [ ] `plugins/wifi_llapi/CASE_YAML_SYNTAX.md`：完整 yaml syntax reference
-- [ ] `plugins/wifi_llapi/cases/D037_retransmissions.yaml`：遷移為 delta 範式（樣板 case）
-- [ ] `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`：遷移為 delta 範式（樣板 case）
+- [ ] `plugins/wifi_llapi/cases/D037_retransmissions.yaml`：遷移為 delta 範式（`delta_nonzero + delta_match` 樣板 case）
+- [ ] `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`：遷移為 multi-band delta 範式（shared trigger phase + per-band `delta_nonzero` 樣板 case）
 
 Wave 2 / Wave 3 各自的遷移 PR 內容見 §7。
 

--- a/docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md
+++ b/docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md
@@ -1,0 +1,539 @@
+# Counter Delta Validation — Design
+
+- **Spec date:** 2026-04-27
+- **Issues:** #38 (counter ==0 一律 fail 並註記原因) · #13 (delta-based counter validation)
+- **Related follow-up:** #39 (reason_code 體系細化，本 spec 不做)
+- **Scope owner:** wifi_llapi plugin
+- **Status:** Draft — awaiting user review
+
+---
+
+## 1. Background & Motivation
+
+LLAPI counter 類測試的核心目的是驗證「API ↔ driver wiring 是否相符」。目前 `wifi_llapi/plugin.py` 的 `_compare()` 只支援單點等值 / 不等式 / regex / contains 等 operator，並沒有「成長性」(`delta`) 概念。實際 case 表現出兩個問題：
+
+1. **#13 已指出**：counter 案例若只比較單點 snapshot，無法分辨「driver 真的沒有 traffic」與「LLAPI 沒有接到 driver」這兩種完全不同的失敗。
+2. **#38 進一步要求**：對 fail / retry / error 類 counter，若在 trigger 後 delta 仍為 0，代表「test 工況本身沒能讓 counter 動」，無法證明 API ↔ driver wiring，這條測試本身不成立、必須判 FAIL，並在報告註解欄寫明「fail 原因為 0，數值無變化」。
+
+兩個 issue 是同一條技術線，本 spec 一次解決：建立 delta 比對基礎建設（#13），並以此表達 #38 的政策。
+
+**核心立意（不可妥協）**
+
+> testpilot 最主要的核心價值是乾淨可測穩定的 test case。本 spec 的所有取捨優先「強制遷移到乾淨格式」而非保留雙軌；不接受「workbook 期望 fail 因此用 `equals '0'` 當 PASS」這類語意倒裝的 case 寫法。
+
+---
+
+## 2. Scope
+
+### In scope
+
+- 在 `wifi_llapi/plugin.py` 新增 `delta_nonzero` / `delta_match` 兩個 operator
+- 在 yaml step 層級新增 `phase: baseline | trigger | verify` 欄位
+- 在 case 載入階段新增 phase ordering schema 驗證
+- 在 `wifi_llapi_excel.py` 新增 M 欄 (`Comment`) 用於失敗註解
+- 將 `WifiLlapiCaseResult.comment` 從 dead field 接上 M 欄寫入路徑
+- 遷移 ~30 個 Stage A 案例（明確 fail/retry/error/discard counter）到 delta 範式
+- 遷移 ~50 個 Stage B 案例（流量類 generic counter）到 delta 範式
+- 新增交付物：`plugins/wifi_llapi/CASE_YAML_SYNTAX.md`（long-lived yaml syntax reference）
+
+### Out of scope
+
+- 把 counter validation 邏輯抽到 `src/testpilot/core/`（YAGNI；未來真有第二個 plugin 要用再做）
+- `_compare()` 既有 operator 的修改 / 簽名變動
+- 既有評估路徑的 `pass_criteria_not_satisfied` 細化 — 已開 **#39** 跟蹤
+- 既有 ~50 個 Stage C 設定類 / 狀態類用 `equals '0'` 案例（D064 / D071 / D076 / D086 / D098 / D183 / D354 / D427-D435 等）— 它們是合法 setpoint 等值斷言，不是 counter
+- workbook source xlsx 結構驗證
+- BLOCKED / SKIP 的視覺渲染（仍寫 H 欄）
+- 真實硬體 trigger workload 自動化（需 attenuator / 干擾源 HW）
+
+---
+
+## 3. Architecture Overview
+
+### 三層職責
+
+| 層 | 元件 | 職責 |
+|---|---|---|
+| **yaml** | case file | step 上標 `phase: baseline / trigger / verify`；用新的 `delta` pass-criteria 表達 delta 規則 |
+| **runtime** | `wifi_llapi/plugin.py` | 沿用既有 step 線性執行；evaluate 階段依 phase 取 baseline/verify capture，呼叫 `delta_nonzero` / `delta_match` |
+| **reporter** | `wifi_llapi_excel.py` | 失敗時把 `WifiLlapiCaseResult.comment` 寫入新增的 M 欄；既有 G~L 行為與 BLOCKED/SKIP 路徑不變 |
+
+### 資料流
+
+```
+yaml case ──► step exec ──► capture (baseline) ──┐
+                  │                                ├─► delta evaluator ──► verdict
+                  ▼                                │      (new ops)         + comment
+              trigger step (workload)              │
+                  │                                │
+                  ▼                                │
+              capture (verify) ─────────────────── ┘
+                                                          │
+                                                          ▼
+                                              WifiLlapiCaseResult
+                                              ├─ result_*: PASS / FAIL  → I/J/K
+                                              └─ comment:  失敗註解      → M (新)
+```
+
+### 關鍵設計取捨
+
+1. **不新增 step 區塊、用 phase 欄位** — 沿用現有 `for step in case.steps` 線性執行流，phase 只是標籤，不動 step machinery
+2. **delta operator 兩個就夠** — `delta_nonzero` (#38 政策) 與 `delta_match` (#13 一致性，含 tolerance)；其餘 corner case 由 yaml 多寫一條 criterion 表達
+3. **comment 字串走預設常數** — `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"`，case yaml 不可覆寫，保證一致性與可搜尋性
+4. **不抽 core** — counter validation 邏輯留在 plugin；遵守 rule of three
+
+---
+
+## 4. YAML Schema
+
+### Step 端：新增 `phase:` 欄位
+
+```yaml
+steps:
+- id: step_5g_api_baseline
+  phase: baseline                         # 新欄位：baseline | trigger | verify
+  capture: api_before_5g
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+
+- id: step_5g_drv_baseline
+  phase: baseline
+  capture: drv_before_5g
+  command: wl -i wl0 sta_info $STA_MAC | sed -n 's/.*tx pkts retries: *\([0-9]*\).*/DriverRetransmissions=\1/p'
+
+- id: step_5g_trigger                     # workload，case 自行設計
+  phase: trigger
+  command: ...                            # 例：iperf3 -u -b 0 -l 1400 --pacing-timer 1
+
+- id: step_5g_api_verify
+  phase: verify
+  capture: api_after_5g
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+
+- id: step_5g_drv_verify
+  phase: verify
+  capture: drv_after_5g
+  command: wl -i wl0 sta_info $STA_MAC | sed -n 's/.*tx pkts retries: *\([0-9]*\).*/DriverRetransmissions=\1/p'
+```
+
+**規則：**
+
+- `phase` 為 optional；未標的 step 預設為 `verify`（向後相容、零遷移壓力）
+- 一個 step 只能屬於一個 phase；互斥
+- 任何 case 含 `delta_*` operator 時，必須滿足「所有 baseline 排在所有 trigger 之前；所有 verify 排在所有 trigger 之後」，否則 case 被標 BLOCKED（fail-fast）
+
+### pass_criteria 端：兩個新 operator
+
+```yaml
+pass_criteria:
+# #38 政策 — trigger 後 delta 必須非 0
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify:   api_after_5g.Retransmissions
+  operator: delta_nonzero
+  description: 5g API 端 Retransmissions 在 trigger 後必須成長
+
+# #13 政策 — API delta 必須與 driver delta 一致 (±10%)
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify:   api_after_5g.Retransmissions
+  reference_delta:
+    baseline: drv_before_5g.DriverRetransmissions
+    verify:   drv_after_5g.DriverRetransmissions
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g API delta 須與 driver delta 在 ±10% 之內
+```
+
+### Operator 語意
+
+| operator | PASS 條件 | 失敗時 reporter comment |
+|---|---|---|
+| `delta_nonzero` | `verify - baseline > 0`（嚴格大於；`==0` 與負數都 FAIL） | `"fail 原因為 0，數值無變化"` |
+| `delta_match` | `\|api_delta - drv_delta\| / max(\|api_delta\|, \|drv_delta\|) <= tolerance_pct/100`，且兩端皆 > 0 | 兩端有任一 ≤ 0：`"fail 原因為 0，數值無變化"`；超 tol：`"fail 原因為 delta 不一致：api=X drv=Y tol=Z%"` |
+
+### 特意不做的事
+
+- ❌ 不引入 `tolerance_abs` / `expected_min_delta` / `retry_trigger_n` (YAGNI)
+- ❌ 不為 `delta_*` 加 `value:` 欄位（避免與 `delta:` 共存產生歧義）
+- ❌ case 不可覆寫 reporter 註解字串（一致性 > 個別表達力）
+
+### 額外交付物：`plugins/wifi_llapi/CASE_YAML_SYNTAX.md`
+
+Long-lived yaml syntax reference（非本 spec 文件本身），與 plugin code colocate。內容涵蓋：
+
+- case top-level 欄位（`id / name / version / source / platform / hlapi_command / llapi_support / implemented_by / bands / topology / test_environment / setup_steps / sta_env_setup / test_procedure / steps / pass_criteria / verification_command`）— 由實作 phase 1 inventory 既有 case 的真實使用情況
+- step 欄位（`id / target / action / capture / command / depends_on / expected / description / **phase**`）
+- pass_criteria 三種形狀：`field+value` / `field+reference` / `delta+(reference_delta)`
+- operator 完整列表：既有 `equals / != / contains / not_contains / regex / not_empty / empty / >= / <= / > / < / skip` + 新增 `delta_nonzero / delta_match`
+- skip / blocked / Support / Blocked 等 `llapi_support` 對應寫法
+- schema 驗證規則（必填、互斥、phase ordering 約束）
+- 三段範例：standard case、counter-delta case、blocked case
+
+不做：JSON Schema / pydantic 自動驗證 source-of-truth、auto-generated（人工維護即可）。
+
+---
+
+## 5. Runtime Flow & Operator Implementation
+
+### evaluate 的 dispatch 改動
+
+`Plugin.evaluate()` 既有的 `for criterion in pass_criteria` 線性掃描不動，只在進入 criterion 處理時加一個 dispatch：
+
+```python
+for idx, criterion in enumerate(criteria):
+    if "delta" in criterion:                        # ← 新分支
+        ok = self._evaluate_delta_criterion(case, context, criterion, idx)
+    else:
+        ok = self._evaluate_field_criterion(...)    # ← 既有邏輯抽函式，行為不變
+    if not ok:
+        return False
+```
+
+`field+value/reference` 路徑**完全不動**；只有出現 `delta:` key 才走新路徑。對既有 case 零回歸風險。
+
+### `_evaluate_delta_criterion()` 流程
+
+```
+1. 解析 criterion["delta"] = {baseline: "<cap>.<key>", verify: "<cap>.<key>"}
+2. baseline_val = self._resolve_field(context, delta["baseline"])
+3. verify_val   = self._resolve_field(context, delta["verify"])
+4. 兩值轉 number；任一無法轉 → FAIL (reason_code="delta_value_not_numeric")
+5. delta_a = verify_val - baseline_val
+6. operator dispatch:
+   - delta_nonzero:
+       pass = (delta_a > 0)
+       on fail comment: ZERO_DELTA_COMMENT
+   - delta_match:
+       重複 1-5 解 reference_delta → delta_b
+       require: delta_a > 0 且 delta_b > 0  (任一 ≤ 0 → reason_code="delta_zero_side")
+       require: |delta_a - delta_b| / max(delta_a, delta_b) <= tolerance_pct/100  (否則 reason_code="delta_mismatch")
+7. 失敗時呼叫既有 self._record_runtime_failure(
+       case, phase="evaluate", comment=<上述字串>,
+       category="test", reason_code=<...>,
+       metadata={"delta_a":..., "delta_b":..., "tolerance_pct":...}
+   )
+```
+
+### 新增常數
+
+```python
+# plugins/wifi_llapi/plugin.py
+ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"
+```
+
+### Phase ordering schema 驗證
+
+加在 `Plugin.discover_cases()` 後：
+
+```python
+def _validate_phase_ordering(case) -> str | None:
+    """Returns error string if invalid; None if OK."""
+    has_delta = any("delta" in c for c in case.get("pass_criteria", []) if isinstance(c, dict))
+    if not has_delta:
+        return None  # 沒用 delta operator 就不檢查 phase
+
+    phases = [(s.get("id"), str(s.get("phase","verify")).lower()) for s in case.get("steps",[])]
+    last_baseline_idx = max((i for i,(_,p) in enumerate(phases) if p=="baseline"), default=-1)
+    first_trigger_idx = next((i for i,(_,p) in enumerate(phases) if p=="trigger"), -1)
+    last_trigger_idx  = max((i for i,(_,p) in enumerate(phases) if p=="trigger"), default=-1)
+    first_verify_idx  = next((i for i,(_,p) in enumerate(phases) if p=="verify"), -1)
+
+    if first_trigger_idx == -1:
+        return "delta_* operators require at least one phase=trigger step"
+    if last_baseline_idx >= first_trigger_idx:
+        return f"baseline step must precede trigger; last_baseline={last_baseline_idx}, first_trigger={first_trigger_idx}"
+    if first_verify_idx <= last_trigger_idx:
+        return f"verify step must follow trigger; last_trigger={last_trigger_idx}, first_verify={first_verify_idx}"
+    return None
+```
+
+**違規處理**：把該 case 標為 BLOCKED（`blocked_reason="invalid_delta_schema: <error>"`），交給既有 `fill_blocked_markers()` 寫進 H 欄。**不 raise，不影響其他 case 載入**。
+
+### `_compare()` 不動
+
+新 operator 不掛在 `_compare()` 裡（不是 single actual vs single expected 形狀）。新 operator 走獨立的 `_evaluate_delta_criterion()`。
+
+### reason_code 對應表（本 spec 新增的 5 個）
+
+| 失敗情境 | reason_code | category | comment |
+|---|---|---|---|
+| schema 驗證失敗 | `invalid_delta_schema` | (走 BLOCKED 路徑，非 runtime failure) | H 欄：`"BLOCKED: invalid_delta_schema: <error>"` |
+| baseline / verify 無法 resolve 為數字 | `delta_value_not_numeric` | `test` | M 欄：`"fail 原因為 delta 端點非數值"` |
+| `delta_nonzero` 失敗 | `delta_zero` | `test` | M 欄：`"fail 原因為 0，數值無變化"` |
+| `delta_match` 兩端有任一 ≤ 0 | `delta_zero_side` | `test` | M 欄：`"fail 原因為 0，數值無變化"` |
+| `delta_match` 兩端皆成長但差距超 tolerance | `delta_mismatch` | `test` | M 欄：`"fail 原因為 delta 不一致：api=X drv=Y tol=Z%"` |
+
+> 既有 `pass_criteria_not_satisfied` 維持不動；其體系細化見 **#39**。
+
+---
+
+## 6. Reporter — 新增 M 欄為失敗註解欄
+
+### `wifi_llapi_excel.py` 改動清單
+
+| 位置 | 改動 |
+|---|---|
+| `DEFAULT_TEMPLATE_MAX_COLUMN` | `"L"` → `"M"` |
+| 新增 `COMMENT_HEADER` | `"Comment"` |
+| `DEFAULT_CLEAR_COLUMNS` | 加 `"M"`（template 清空時也清 M 欄） |
+| `_normalize_template_headers()` | row 3 增加 `ws.cell(row=3, column=13).value = COMMENT_HEADER` |
+| `fill_case_results()` | 既有 G/H/I/J/K/L 不動；新增 `_set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment))` |
+| `WifiLlapiCaseResult.comment` | 從 dead field 變成有實際寫入；長度上限 200 字、超過 truncate + `"..."` |
+
+### M 欄寫入規則
+
+| 情境 | M 欄內容 |
+|---|---|
+| 全部 PASS | 空 |
+| `delta_nonzero` 失敗 | `"fail 原因為 0，數值無變化"` |
+| `delta_match` 失敗（兩端任一為 0） | `"fail 原因為 0，數值無變化"` |
+| `delta_match` 失敗（差距超 tolerance） | `"fail 原因為 delta 不一致：api=X drv=Y tol=Z%"` |
+| `delta_*` 端點無法 resolve 為數字 | `"fail 原因為 delta 端點非數值"` |
+| 既有 evaluate 失敗（非 delta 路徑） | 沿用既有 `_record_runtime_failure` 的 `comment` 字串（細化交給 #39） |
+| BLOCKED / SKIP | M 欄空（`fill_blocked_markers()` / `fill_skip_markers()` 不寫 M 欄；簡述仍由 H 欄承擔，因為 BLOCKED/SKIP 表示「沒測 / 需要重測」，與 evaluate 失敗語意層級不同） |
+
+### Source xlsx 沒有 M 欄怎麼辦
+
+`build_template_from_source()` 既有的 `_trim_sheet_to_max_column()` 會自動保留到第 13 欄；source xlsx 若原本沒有第 13 欄就維持空欄，由 `_normalize_template_headers()` 補上 M 欄 header。**source 端不需要修改**。
+
+---
+
+## 7. Migration Plan — 存量 case
+
+### 範圍判定 — 三層過濾流程
+
+```
+Stage A（必遷，~30 case）── api 名稱含 Retry / Retrans / Fail / Error / Drop / Discard / Glitch / BadPLCP
+                           且 llapi_support: Support
+                           ─► 必走 delta_nonzero + delta_match
+
+Stage B（個案判斷，~50 case）── api 名稱含 Count / Bytes / Packets / Stats
+                                 ─► 進一步區分：
+                                    ├─ counter 語意（會被流量推動）→ 遷 delta_nonzero + delta_match
+                                    └─ 靜態屬性 / 儀器讀數 → 不遷，繼續用 equals + reference
+
+Stage C（不遷，~50 case）── pass_criteria 用 equals '0' 但 api 是設定 / 狀態類
+                            ─► 合法的 setpoint 等值斷言，不是 counter，明確排除
+```
+
+### Stage A 詳細名單（必遷）
+
+```
+D037, D038, D051, D052, D054                         # AssociatedDevice retransmissions / errors
+D267, D268, D269, D270                               # getradiostats discard / errors
+D304, D305, D306, D307, D308                         # getssidstats discard / errors / failedretranscount
+D313, D316                                           # getssidstats RetransCount / UnknownProtoPackets
+D325, D326, D327, D328, D329, D334                   # ssid_stats discard / errors / failedretrans / retrans
+D396, D397, D398, D399, D401, D402                   # radio_stats errors / retry / retrans
+D406, D407, D448, D451                               # radio_stats retry / preamble error pct
+D452, D453, D454, D455, D457, D458                   # vendor stats badplcp / glitch / radio retry / retrans
+D495, D580                                           # retrycount verified / affiliated sta errors
+```
+
+### Stage B 預估遷移名單
+
+```
+D031, D039, D040, D041, D042, D053, D055, D056, D057    # AssociatedDevice rx/tx bytes / packets
+D128, D130, D131, D132, D135, D136, D137                # getstats rx/tx bytes / packets / retransmissions
+D263-D266, D271-D276                                    # getradiostats bcast / mcast / ucast / bytes / packets
+D300-D303, D309-D315                                    # getssidstats bcast / mcast / ucast / bytes / packets
+D321-D324, D330-D337                                    # ssid_stats bcast / mcast / ucast / bytes / packets
+D394, D395, D477, D576-D579                             # radio bytes / unknown proto / affiliated sta bytes/packets
+```
+
+### Stage C — 明確排除
+
+D064 / D065 / D068 / D071 / D072 / D075-D082 / D086 / D090 / D093 / D098 / D104 / D105 / D179 / D183 / D251 / D354 / D366 / D369 / D427-D435 等 ~50 個用 `equals '0'` 但實為設定 / 狀態斷言的 case。**本 spec 不動**。
+
+### 每個遷移 case 的 yaml 改動模板
+
+以 D037 為例：
+
+```yaml
+# 遷移前
+pass_criteria:
+- field: result.Retransmissions
+  operator: equals
+  value: '0'
+  description: 'Workbook v4.0.3 marks this API as Fail: LLAPI Retransmissions still reads 0.'  # ← 刪除
+- field: driver_counter.DriverRetransmissions
+  operator: '>'
+  value: '0'
+
+# 遷移後
+steps:
+- id: step_5g_api_baseline
+  phase: baseline
+  capture: api_before_5g
+- id: step_5g_drv_baseline
+  phase: baseline
+  capture: drv_before_5g
+- id: step_5g_trigger
+  phase: trigger
+  command: <workload>
+- id: step_5g_api_verify
+  phase: verify
+  capture: api_after_5g
+- id: step_5g_drv_verify
+  phase: verify
+  capture: drv_after_5g
+
+pass_criteria:
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify:   api_after_5g.Retransmissions
+  operator: delta_nonzero
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify:   api_after_5g.Retransmissions
+  reference_delta:
+    baseline: drv_before_5g.DriverRetransmissions
+    verify:   drv_after_5g.DriverRetransmissions
+  operator: delta_match
+  tolerance_pct: 10
+```
+
+### Trigger workload 設計類別參考
+
+| Counter 性質 | 典型 trigger workload |
+|---|---|
+| Retrans / Retry | iperf3 UDP 灌流 + 刻意降 RSSI / 干擾源 |
+| TxErrors / FailedRetransCount | 同上 + 短封包 burst 製造 PHY 失敗 |
+| Discard / Drop | iperf3 UDP 超 link capacity；multicast flood |
+| RxBytes / TxBytes / *PacketCount | iperf3 UDP/TCP 任意工況；最容易 |
+| BroadcastPackets / MulticastPackets | ping broadcast / multicast |
+| BadPLCP / Glitch | 干擾源 / 鄰頻打 noise |
+
+### PR 切分 — 三 wave
+
+| Wave | 內容 | 規模 | 風險 |
+|---|---|---|---|
+| **Wave 1（基礎建設）** | runtime（phase 驗證 + delta operator）+ reporter（M 欄）+ `CASE_YAML_SYNTAX.md` + 2 個樣板 case（D037、D313） | 中 | 高 — 新基礎建設，需 unit test 完整覆蓋 |
+| **Wave 2（Stage A）** | 遷移 ~30 個明確 fail/retry/error/drop case | 大 | 中 — 模式重複；trigger workload 設計成本不一 |
+| **Wave 3（Stage B）** | 遷移 ~50 個 generic counter case | 大 | 低 — 多數可共用 iperf workload |
+
+**Wave 1 必須先 merge 並通過 review**，再開 Wave 2/3 PR。Wave 2/3 可依 stat 群組（getradiostats / getssidstats / radio_stats / ssid_stats / associateddevice）進一步切 sub-PR。
+
+---
+
+## 8. Test Strategy
+
+### Unit test（Wave 1 必交付）
+
+放在 `tests/test_wifi_llapi_delta.py`（新檔）。
+
+**A. `_evaluate_delta_criterion` 純函式邏輯**
+
+| Test | 期望 |
+|---|---|
+| `test_delta_nonzero_pass` | baseline=10, verify=42 → PASS |
+| `test_delta_nonzero_fail_zero` | baseline=10, verify=10 → FAIL，reason_code="delta_zero" |
+| `test_delta_nonzero_fail_negative` | baseline=10, verify=5 → FAIL，reason_code="delta_zero" |
+| `test_delta_nonzero_baseline_missing` | baseline 在 context 找不到 → FAIL，reason_code="delta_value_not_numeric" |
+| `test_delta_nonzero_non_numeric` | verify="N/A" → FAIL，reason_code="delta_value_not_numeric" |
+| `test_delta_match_pass_within_tolerance` | api=100, drv=109, tol=10% → PASS |
+| `test_delta_match_pass_exact_match` | api=100, drv=100, tol=10% → PASS |
+| `test_delta_match_fail_exceed_tolerance` | api=100, drv=120, tol=10% → FAIL，reason_code="delta_mismatch" |
+| `test_delta_match_fail_one_side_zero` | api=100, drv=0 → FAIL，reason_code="delta_zero_side" |
+| `test_delta_match_fail_both_zero` | api=0, drv=0 → FAIL，reason_code="delta_zero_side" |
+| `test_delta_match_fail_negative_either_side` | 任一 delta 為負 → FAIL，reason_code="delta_zero_side" |
+| `test_delta_match_tolerance_boundary` | api=100, drv=110, tol=10%（剛好）→ PASS（`<=` 包含邊界） |
+
+**B. `_validate_phase_ordering` schema validator**
+
+| Test | 期望 |
+|---|---|
+| `test_phase_ok_baseline_trigger_verify` | None（合法） |
+| `test_phase_no_delta_skip_check` | None（沒有 delta criterion 不檢查） |
+| `test_phase_missing_trigger` | error: "require at least one phase=trigger" |
+| `test_phase_baseline_after_trigger` | error: "baseline step must precede trigger" |
+| `test_phase_verify_before_trigger` | error: "verify step must follow trigger" |
+| `test_phase_default_unmarked_is_verify` | step 沒寫 phase 視為 verify（向後相容） |
+| `test_phase_invalid_value` | phase: "warmup" → error: "unknown phase: warmup" |
+
+**C. dispatch — `evaluate()` 行為**
+
+| Test | 期望 |
+|---|---|
+| `test_evaluate_field_path_unchanged` | 既有 `field+value` criterion 走原路徑、reason_code 仍為 `pass_criteria_not_satisfied`（regression guard） |
+| `test_evaluate_delta_path_picks_new_dispatch` | criterion 含 `delta:` key → 走新路徑，不誤觸 `_compare()` |
+| `test_evaluate_mixed_criteria` | 同 case 內混 field criterion 與 delta criterion，依序評估，第一個 fail 即停 |
+| `test_invalid_delta_schema_marks_blocked` | phase 違規的 case 在 discover 階段被標 BLOCKED、不進到 evaluate |
+
+### Integration test（Wave 1 必交付）
+
+放在 `tests/test_wifi_llapi_delta_integration.py`。
+
+**D. yaml fixture 端到端** — 用 `tests/fixtures/wifi_llapi_delta/` 放 3 個 fixture case：
+
+- `delta_nonzero_pass.yaml` — baseline/trigger/verify mock 數值 PASS
+- `delta_nonzero_fail.yaml` — verify 數值與 baseline 相同 → FAIL
+- `delta_match_pass.yaml` — api/drv 兩端都成長且差距在 tol 內
+
+跑 `Plugin.discover_cases() → execute_step()（mocked transport）→ evaluate() → fill_case_results()`，斷言 xlsx I/J/K 為 PASS / FAIL，M 欄為預期 comment 字串。
+
+**E. reporter 行為** — 擴充 `tests/test_wifi_llapi_excel.py`：
+
+| Test | 期望 |
+|---|---|
+| `test_template_max_column_is_M` | `_normalize_template_headers` 在 row 3 column 13 寫 "Comment" |
+| `test_clear_columns_includes_M` | `DEFAULT_CLEAR_COLUMNS` 包含 "M" |
+| `test_fill_case_results_writes_M` | `WifiLlapiCaseResult.comment` 內容寫入 M 欄 |
+| `test_fill_case_results_truncates_long_comment` | comment > 200 字 → 截斷至 200 + "..." |
+| `test_fill_case_results_empty_comment` | comment 為空時 M 欄為空、不寫 None |
+| `test_blocked_marker_writes_H_not_M` | regression guard：BLOCKED 仍走 H 欄 |
+| `test_skip_marker_writes_H_not_M` | regression guard：SKIP 仍走 H 欄 |
+
+### Migration smoke（Wave 2/3 PR 必跑、不入 CI）
+
+每個 Wave 2/3 PR 在 review 前，PR 作者需在描述中提供：
+
+1. Emulated suite 跑完截圖（`pytest plugins/wifi_llapi/`，mock transport）
+2. `CASE_YAML_SYNTAX.md` 同步更新（若 wave 中發現 schema 需要新欄位 / 例外）
+3. 本 wave case 列表 diff（從 `equals '0'` 改成 `delta_*` 的清單）
+
+不要求實機 trigger workload 執行（需 attenuator / 干擾源 HW，不適合 CI 化）。
+
+### CI gating
+
+**Wave 1 PR 要 merge 必須：**
+
+- ✅ Unit test (A/B/C) 全綠
+- ✅ Integration test (D/E) 全綠
+- ✅ `tests/test_wifi_llapi_excel.py` 既有測試無 regression
+- ✅ `pytest tests/` 全 suite 無 regression
+
+**Wave 2/3 PR 要 merge：** 上述條件 + Migration smoke 證據附在 PR 描述 + 該 wave 改動的 case 在 emulated suite 拿到預期 verdict
+
+### 不在測試範圍
+
+- workbook source xlsx 結構驗證
+- `_compare()` 既有 operator 的 regression（Wave 1 不動 `_compare()`）
+- 既有 BLOCKED/SKIP 視覺渲染
+- 真實硬體 trigger workload 自動化
+
+---
+
+## 9. Deliverables Checklist
+
+Wave 1（基礎建設 PR）必須交付：
+
+- [ ] `plugins/wifi_llapi/plugin.py`：`_evaluate_delta_criterion()` / `_validate_phase_ordering()` / `ZERO_DELTA_COMMENT` / dispatch 修改
+- [ ] `src/testpilot/reporting/wifi_llapi_excel.py`：M 欄相關常數 + header + write path + truncate
+- [ ] `tests/test_wifi_llapi_delta.py`：Unit test A/B/C 全套
+- [ ] `tests/test_wifi_llapi_delta_integration.py`：Integration test D
+- [ ] `tests/test_wifi_llapi_excel.py`：Integration test E 擴充
+- [ ] `tests/fixtures/wifi_llapi_delta/`：3 個 fixture case
+- [ ] `plugins/wifi_llapi/CASE_YAML_SYNTAX.md`：完整 yaml syntax reference
+- [ ] `plugins/wifi_llapi/cases/D037_retransmissions.yaml`：遷移為 delta 範式（樣板 case）
+- [ ] `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml`：遷移為 delta 範式（樣板 case）
+
+Wave 2 / Wave 3 各自的遷移 PR 內容見 §7。
+
+---
+
+## 10. Open Questions / Follow-ups
+
+- **#39** — `pass_criteria_not_satisfied` 細化（從 brainstorming 直接開出，本 spec 不做）
+- 未來若有第二個 plugin 需要 delta 比對，再考慮把 counter validation 抽到 `src/testpilot/core/`（rule of three）
+- Trigger workload 的硬體 setup（attenuator / 干擾源）— 本 spec 不規範，由 case 設計者依現場資源決定

--- a/openspec/changes/wifi-llapi-counter-delta-validation/.openspec.yaml
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/wifi-llapi-counter-delta-validation/design.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/design.md
@@ -1,0 +1,150 @@
+## Context
+
+`wifi_llapi/plugin.py` 目前的 `_compare()` 只支援 single-actual vs single-expected 的 operator（`equals / != / contains / regex / >= / <= / >` 等）。LLAPI counter 類測試（fail/retry/error/discard 與 packet/byte stats）因此被迫用兩種寫法表達：
+
+1. **正向** — `field+reference equals` 比對 API 端與 driver 端 snapshot 是否一致（無法分辨「driver 沒 traffic」與「LLAPI 沒接到 driver」）
+2. **倒裝** — 用 `equals '0'` 當 PASS 條件「斷言 LLAPI 仍然壞掉」（D037 / D052 等案例：description 註明「Workbook v4.0.3 marks this API as Fail」），語意倒裝、難以閱讀
+
+issue #13 / #38 兩條技術線同時要求改用 trigger 前後 delta 比對。本 design 一次解決兩者。
+
+reporter 端：`wifi_llapi_excel.py` 的 `WifiLlapiCaseResult` dataclass 已有 `comment` 欄位但未被寫入 xlsx（dead field）；`fill_case_results()` 只寫 G~L 欄，BLOCKED/SKIP 走 `fill_blocked_markers()` / `fill_skip_markers()` 覆寫 H 欄。本 design 必須選擇一個欄位承載 #38 要求的「失敗註解」。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在 `wifi_llapi` plugin 內加入 trigger 前後 delta 比對的基礎建設（phase 標註 + delta operator）
+- 表達 #38 政策：「fail/retry/error counter trigger 後 delta 為 0 一律 FAIL，並在報告註解寫『fail 原因為 0，數值無變化』」
+- 表達 #13 政策：「API delta 必須與 driver delta 一致（含 tolerance）」
+- 把 `WifiLlapiCaseResult.comment` 從 dead field 接上 xlsx 寫入路徑
+- 新增 5 個細粒度 reason_code（限 delta 路徑），方便 reporter / 人工 debug 判斷失敗原因
+- 提供 long-lived `CASE_YAML_SYNTAX.md` reference 文件
+- 遷移 ~80 個存量 case 到新範式，徹底消除「workbook-expected-fail 的 negative-pass」這類語意倒裝寫法
+
+**Non-Goals:**
+
+- 把 counter validation 抽到 `src/testpilot/core/`（YAGNI；目前唯一 consumer 是 wifi_llapi）
+- 修改 `_compare()` 既有 operator 簽名與行為
+- 細化既有 `pass_criteria_not_satisfied` reason_code（已開 #39 跟蹤）
+- 動 ~50 個 Stage C 設定/狀態類用 `equals '0'` 的 case（合法的 setpoint 等值斷言，非 counter）
+- workbook source xlsx 結構驗證
+- BLOCKED/SKIP 視覺渲染（仍寫 H 欄）
+- 真實硬體 trigger workload 自動化（需 attenuator / 干擾源 HW，不適合 CI 化）
+
+## Decisions
+
+### Decision 1: 用 step-level `phase:` 欄位，不引入 `counter_validation:` 區塊
+
+**選擇:** 在 step 上加 optional `phase: baseline | trigger | verify` 欄位；未標的 step 預設為 `verify`。
+
+**Rationale:** 沿用既有 `for step in case.steps` 線性執行流，不動 step machinery；向後相容（既有 case 不需改），改動爆炸半徑最小。
+
+**Alternatives considered:**
+
+- 新增 `counter_validation: { baseline_steps: [...], trigger_steps: [...], verify_steps: [...] }` 區塊 — 動到 step 執行流，與既有 `step.id` / `depends_on` 機制重複表達，顯著增加 yaml 複雜度
+- 用 step naming convention（如 `step_baseline_*` 自動推斷）— 隱式約定脆弱、人工易漏
+
+### Decision 2: 只新增兩個 operator (`delta_nonzero` / `delta_match`)
+
+**選擇:** `delta_nonzero` 表 #38 政策；`delta_match` 表 #13 政策（含 `tolerance_pct`）。
+
+**Rationale:** 兩個 operator 涵蓋目前所有需求；其餘 corner case（如 `tolerance_abs`、`expected_min_delta`、`retry_trigger_n`）等真的有 case 需要再加（YAGNI）。
+
+**Alternatives considered:**
+
+- 通用 `delta` operator 加多個 sub-mode flag — 過度設計、yaml 表達性下降
+- 三個 operator 分別處理 nonzero / match / mismatch — `delta_match` 失敗時自然涵蓋 mismatch 語意，無需獨立 operator
+
+### Decision 3: failure comment 字串走 plugin 常數，case yaml 不可覆寫
+
+**選擇:** `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"` 定義在 `plugins/wifi_llapi/plugin.py` 模組頂層；`delta_match` 失敗有對應的 `delta_mismatch` template。
+
+**Rationale:** 一致性與可搜尋性 > 個別 case 表達力；下游 grep / 人工掃描報告時只要找一條固定字串即可。
+
+**Alternatives considered:**
+
+- 讓 case yaml 在 criterion 加 `on_zero_comment:` 欄位 — 個別 case 寫不一致字串會破壞下游 grep
+- comment 模板在 reporter 端而非 plugin — comment 是「失敗原因」屬於 evaluate 語意，放 reporter 會洩漏領域知識
+
+### Decision 4: dispatch 用 `"delta" in criterion` 判斷新舊路徑
+
+**選擇:** evaluate 進入每個 criterion 時檢查 dict 是否含 `"delta"` key，是則走 `_evaluate_delta_criterion()`，否則走既有 field-based 邏輯。
+
+**Rationale:** 零回歸風險（既有 `field+value/reference` criterion 完全不動）；不需在 yaml 引入 `criterion_type:` 額外欄位。
+
+**Alternatives considered:**
+
+- 為 criterion 加 `criterion_type: field | delta` — yaml 冗長、舊 case 需 backfill
+- 把 delta 邏輯掛進 `_compare()` — 簽名不匹配（`_compare(actual, op, expected)` 是 single-value 形狀），硬掛會污染既有介面
+
+### Decision 5: phase 違規走 BLOCKED 路徑、不 raise
+
+**選擇:** `_validate_phase_ordering()` 在 case discover 階段執行；違規 case 標 BLOCKED（`blocked_reason="invalid_delta_schema: <error>"`），交給既有 `fill_blocked_markers()` 寫進 H 欄。其他 case 不受影響。
+
+**Rationale:** Blast radius 最小（單一 case 出問題不拖垮 plugin load）；reporter 路徑現成；人工 debug 一看 H 欄就知道 yaml 哪裡寫錯。
+
+**Alternatives considered:**
+
+- 載入時 raise → plugin 全部 case 都跑不了，過於激進
+- 執行時才檢查 → fail-late，浪費 transport setup 時間
+
+### Decision 6: 新增 M 欄當 `Comment` 欄
+
+**選擇:** xlsx template max column 從 L 擴到 M；新欄 header `Comment`；evaluate 失敗（含 delta 路徑與既有路徑）的 `WifiLlapiCaseResult.comment` 寫入 M 欄。
+
+**Rationale:** 各既有欄位都有明確語意，疊加會破壞語意純粹性；新 M 欄專責「人類可讀失敗註解」是最乾淨的做法。
+
+**Alternatives considered:**
+
+- 寫入 H 欄與 `command_output` 並列 — H 欄已長，再塞註解難閱讀；BLOCKED/SKIP 也用 H 欄，三種語意混雜
+- 寫入 I/J/K 後綴於 verdict（`"FAIL（fail 原因…）"`）— 破壞 result 欄純文字格式，下游解析腳本可能受影響
+- 用 openpyxl `cell.comment`（懸浮 tooltip）— 列印 / PDF / grep 看不到，違背「可測」原則
+
+### Decision 7: BLOCKED / SKIP 仍寫 H 欄、不搬到 M 欄
+
+**選擇:** `fill_blocked_markers()` / `fill_skip_markers()` 行為不變；M 欄專責 evaluate 失敗註解。
+
+**Rationale:** BLOCKED/SKIP 表示「沒測 / 需要重測」，與 evaluate 失敗（測了但沒過）是不同語意層級；分欄表達更利於人工掃描分類。
+
+**Alternatives considered:**
+
+- 一併搬到 M 欄統一「人類可讀說明」 — H 欄變得語意純粹但 BLOCKED/SKIP 與 FAIL 混在 M 欄反而不利分類
+
+### Decision 8: PR 切分為三 wave，Wave 1 必須先 merge
+
+**選擇:**
+
+- Wave 1：runtime + reporter + CASE_YAML_SYNTAX.md + 2 個樣板 case（D037 / D313）
+- Wave 2：~30 個 Stage A 案例
+- Wave 3：~50 個 Stage B 案例
+
+**Rationale:** Wave 1 定型 yaml schema 與 runtime 行為，Wave 2/3 才能確定遷移目標格式；若三 wave parallel 開發，schema 一旦改動 Wave 2/3 都要 rebase。
+
+### Decision 9: tolerance 公式用 `max(|delta_a|, |delta_b|)` 為分母
+
+**選擇:** `|delta_a - delta_b| / max(|delta_a|, |delta_b|) <= tolerance_pct/100`
+
+**Rationale:** 對稱（不偏袒 API 或 driver 任一端）；前置條件「兩端皆 > 0」保證分母不為 0。絕對值是冗餘安全網（一旦前置條件被未來修改，公式仍 robust）。
+
+## Risks / Trade-offs
+
+- **存量遷移範圍大（~80 case）** → Mitigation：分 wave PR、每 wave 提供 emulated suite smoke 證據；Wave 2/3 可依 stat 群組（getradiostats / getssidstats / radio_stats / ssid_stats / associateddevice）切 sub-PR
+- **trigger workload 需要硬體（attenuator / 干擾源），不適合 CI 化** → Mitigation：CI 只跑 emulated transport 的端到端測試；真實 workload 驗證留到 release smoke
+- **既有 case 用 `equals '0'` 當 PASS 的「workbook-expected-fail」語意倒裝寫法將消失** → Mitigation：遷移時刪除 yaml 中對應的 description 註解（如 'Workbook v4.0.3 marks this API as Fail'）；Wave 2 PR diff 即為 audit trail
+- **xlsx 報告新增 M 欄可能影響下游 parser** → Mitigation：grep 過 repo 確認無此類腳本；若未來發現，再以另一個 issue 處理
+- **WifiLlapiCaseResult.comment 從 dead 變 active** → Mitigation：reporter test E 包含 truncate / empty / non-empty / BLOCKED 不寫 M 欄等 regression guard
+- **未標 phase 的 step 預設為 verify 可能讓使用者誤以為「不標就 OK」而忽略 trigger** → Mitigation：phase ordering schema validator 在「有 delta criterion 但無 trigger step」時直接報錯標 BLOCKED（fail-fast）；CASE_YAML_SYNTAX.md 範例強調必須三段齊全
+
+## Migration Plan
+
+詳見 spec.md 與 tasks.md。摘要：
+
+1. **Wave 1（基礎建設 PR）**: runtime + reporter + tests + CASE_YAML_SYNTAX.md + D037/D313 樣板，必須通過 review 並 merge
+2. **Wave 2（Stage A migration PR）**: ~30 個明確 fail/retry/error counter
+3. **Wave 3（Stage B migration PR）**: ~50 個流量類 generic counter
+4. **Rollback strategy**: Wave 1 reverts cleanly（既有 case 不依賴新 schema、`field+value/reference` 路徑零改動）；Wave 2/3 reverts 即恢復 `equals '0'` / `equals reference` 寫法
+
+## Open Questions
+
+- 未來若有第二個 plugin 需要 delta 比對，再考慮把 counter validation 抽到 `src/testpilot/core/`（rule of three）
+- Trigger workload 的硬體 setup（attenuator / 干擾源）由 case 設計者依現場資源決定，不在本 design 規範

--- a/openspec/changes/wifi-llapi-counter-delta-validation/proposal.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+LLAPI counter 類測試（Retrans / Retry / Fail / Error / Drop / packet / byte stats 等）的核心目的是驗證「API ↔ driver wiring 是否相符」。目前 `wifi_llapi/plugin.py` 只支援單點 snapshot 比對，無法分辨「driver 真的沒有 traffic」與「LLAPI 沒有接到 driver」這兩種完全不同的失敗。issue **#13** 已要求改用 before/after delta 比對；issue **#38** 進一步要求對 fail/retry/error 類 counter 在 trigger 後 delta 仍為 0 必須判 FAIL，並在報告註解欄寫明「fail 原因為 0，數值無變化」，理由是「test 工況本身沒能讓 counter 動」即無法證明 wiring。本 change 一次解決這條技術線。
+
+## What Changes
+
+- **新增** yaml step 層級欄位 `phase: baseline | trigger | verify`（optional，預設 `verify` 向後相容）
+- **新增** 兩個 pass_criteria operator：
+  - `delta_nonzero` — 表達 #38 政策：trigger 後 delta 必須 > 0
+  - `delta_match` — 表達 #13 政策：API delta 必須與 driver delta 一致（`tolerance_pct`）
+- **新增** case 載入階段 phase ordering schema 驗證（baseline → trigger → verify），違規 case 標 BLOCKED
+- **新增** 5 個 reason_code：`invalid_delta_schema` / `delta_value_not_numeric` / `delta_zero` / `delta_zero_side` / `delta_mismatch`
+- **新增** xlsx 報告 M 欄 (`Comment`)，承載 evaluate 失敗註解；既有 G~L 欄與 BLOCKED/SKIP 寫入 H 欄路徑不變
+- **將** `WifiLlapiCaseResult.comment` 從 dead field 接上 M 欄寫入路徑（含 200 字截斷）
+- **遷移** ~30 個 Stage A case（明確 fail/retry/error/discard counter）到 delta 範式
+- **遷移** ~50 個 Stage B case（流量類 generic counter）到 delta 範式
+- **新增** `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` long-lived yaml syntax reference
+- **不改** Stage C ~50 個用 `equals '0'` 但實為設定/狀態斷言的 case（D064/D071/D076/D086/D098/D183/D354/D427-D435 等）
+- **不改** `_compare()` 既有 operator 簽名與行為
+- **不改** `pass_criteria_not_satisfied` reason_code（細化已開 #39 跟蹤）
+
+## Capabilities
+
+### New Capabilities
+
+- `wifi-llapi-counter-validation`: counter 類 case 的 delta 比對語意 — phase 標註、`delta_nonzero` / `delta_match` operator、phase ordering schema 驗證、失敗 reason_code 體系、reporter M 欄失敗註解規則
+
+### Modified Capabilities
+
+（無 — `wifi-llapi-alignment-guardrails` 與本 change 不相關）
+
+## Impact
+
+- **Affected code:**
+  - `plugins/wifi_llapi/plugin.py`：evaluate dispatch、`_evaluate_delta_criterion()`、`_validate_phase_ordering()`、`ZERO_DELTA_COMMENT` 常數
+  - `src/testpilot/reporting/wifi_llapi_excel.py`：`DEFAULT_TEMPLATE_MAX_COLUMN` / `COMMENT_HEADER` / `DEFAULT_CLEAR_COLUMNS` / `_normalize_template_headers()` / `fill_case_results()`
+  - `plugins/wifi_llapi/cases/`：~80 個 yaml case 重寫（Wave 2/3）
+- **Affected APIs / 文件:**
+  - `plugins/wifi_llapi/CASE_YAML_SYNTAX.md`（新增）
+  - 既有 case yaml 中 `'Workbook v4.0.3 marks this API as Fail'` 類註解必須刪除（語意被新政策取代）
+- **下游影響:**
+  - xlsx 報告新增 M 欄 → 任何下游 grep / parser 若假設 `max_column = L` 會需要更新（目前未發現此類腳本）
+  - 既有報告歷史檔案不會自動 backfill M 欄
+- **依賴:** 無新增 Python 套件
+- **PR sequencing:** Wave 1（基礎建設）必須先 merge 通過 review，再開 Wave 2/3 PR
+- **CI:** `pytest tests/` 全 suite 必須無 regression
+- **不影響:** `_compare()` 既有 operator、Stage C 既有設定類 case、BLOCKED/SKIP 視覺渲染、workbook source xlsx 結構

--- a/openspec/changes/wifi-llapi-counter-delta-validation/specs/wifi-llapi-counter-validation/spec.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/specs/wifi-llapi-counter-validation/spec.md
@@ -1,0 +1,214 @@
+## ADDED Requirements
+
+### Requirement: Case YAML SHALL support a step-level `phase` label
+
+The wifi_llapi case yaml SHALL accept an optional `phase: baseline | trigger | verify` field on each step. Steps that do not declare a `phase` MUST be treated as `verify` for backward compatibility.
+
+#### Scenario: Step declares baseline phase
+- **WHEN** a step contains `phase: baseline`
+- **THEN** the runtime classifies the step as a baseline capture
+- **AND** the step is recognized as occurring before any `trigger` step
+
+#### Scenario: Step declares trigger phase
+- **WHEN** a step contains `phase: trigger`
+- **THEN** the runtime classifies the step as the workload-trigger phase
+- **AND** the step is allowed to perform side-effects without producing a captured value
+
+#### Scenario: Step omits phase declaration
+- **WHEN** a step does not contain a `phase` field
+- **THEN** the runtime treats the step as `phase: verify`
+- **AND** existing case yaml that predates this change continues to execute unchanged
+
+#### Scenario: Step declares an unknown phase value
+- **WHEN** a step contains `phase: warmup` or any value other than `baseline`, `trigger`, `verify`
+- **THEN** schema validation rejects the case with reason `unknown phase: <value>`
+
+### Requirement: Phase ordering MUST be validated at case load time when a case uses any delta operator
+
+When any `pass_criteria` entry in a case contains a `delta:` key, case loading SHALL verify that all `phase: baseline` steps precede all `phase: trigger` steps, and all `phase: verify` steps follow all `phase: trigger` steps. The case MUST also contain at least one `phase: trigger` step. Cases that violate these constraints MUST be classified as BLOCKED with a `blocked_reason` beginning with `invalid_delta_schema:`. Validation MUST NOT raise; other cases MUST continue loading unaffected.
+
+#### Scenario: Valid baseline-trigger-verify ordering
+- **WHEN** a case has steps in order [baseline, baseline, trigger, verify, verify] and uses `delta_nonzero`
+- **THEN** the case loads successfully
+- **AND** runtime evaluation proceeds normally
+
+#### Scenario: Case with no delta operator skips phase validation
+- **WHEN** a case has only `field+value` or `field+reference` pass criteria (no `delta:`)
+- **THEN** phase ordering is not validated regardless of step phase labels
+- **AND** the case loads successfully
+
+#### Scenario: Missing trigger step
+- **WHEN** a case uses `delta_nonzero` but contains only baseline and verify steps
+- **THEN** the case is classified as BLOCKED
+- **AND** `blocked_reason` is `invalid_delta_schema: delta_* operators require at least one phase=trigger step`
+
+#### Scenario: Baseline step ordered after trigger
+- **WHEN** a case has steps [baseline, trigger, baseline, verify] and uses `delta_match`
+- **THEN** the case is classified as BLOCKED
+- **AND** `blocked_reason` is `invalid_delta_schema: baseline step must precede trigger; ...`
+
+#### Scenario: Verify step ordered before trigger
+- **WHEN** a case has steps [baseline, verify, trigger] and uses `delta_nonzero`
+- **THEN** the case is classified as BLOCKED
+- **AND** `blocked_reason` is `invalid_delta_schema: verify step must follow trigger; ...`
+
+#### Scenario: One invalid case does not affect others
+- **WHEN** a single case fails phase ordering validation during plugin discover
+- **THEN** that case is marked BLOCKED
+- **AND** all other cases in the plugin continue to load and execute normally
+
+### Requirement: `delta_nonzero` operator SHALL pass when `verify - baseline > 0`
+
+The `delta_nonzero` operator SHALL evaluate `verify_value - baseline_value > 0` (strict greater-than). Equality and negative deltas MUST be treated as failure. Both endpoints MUST be resolvable to numeric values; non-numeric endpoints MUST fail with `reason_code="delta_value_not_numeric"`.
+
+#### Scenario: Counter grew under trigger
+- **WHEN** baseline=10, verify=42 with `operator: delta_nonzero`
+- **THEN** the criterion passes
+
+#### Scenario: Counter unchanged after trigger
+- **WHEN** baseline=10, verify=10 with `operator: delta_nonzero`
+- **THEN** the criterion fails with `reason_code="delta_zero"`
+- **AND** the failure comment is `"fail 原因為 0，數值無變化"`
+
+#### Scenario: Counter decreased after trigger
+- **WHEN** baseline=10, verify=5 with `operator: delta_nonzero`
+- **THEN** the criterion fails with `reason_code="delta_zero"`
+- **AND** the failure comment is `"fail 原因為 0，數值無變化"`
+
+#### Scenario: Baseline endpoint unresolvable
+- **WHEN** the `baseline` field path resolves to nothing in the eval context
+- **THEN** the criterion fails with `reason_code="delta_value_not_numeric"`
+- **AND** the failure comment is `"fail 原因為 delta 端點非數值"`
+
+#### Scenario: Verify endpoint not numeric
+- **WHEN** verify resolves to `"N/A"` or non-numeric text
+- **THEN** the criterion fails with `reason_code="delta_value_not_numeric"`
+
+### Requirement: `delta_match` operator SHALL require both deltas to grow and to agree within tolerance
+
+The `delta_match` operator SHALL compute `delta_a = verify_a - baseline_a` and `delta_b = verify_b - baseline_b`. Both deltas MUST be strictly greater than zero; otherwise the criterion MUST fail with `reason_code="delta_zero_side"` and the comment `"fail 原因為 0，數值無變化"`. When both are positive, the operator SHALL pass when `|delta_a - delta_b| / max(|delta_a|, |delta_b|) <= tolerance_pct / 100`. The tolerance boundary MUST be inclusive (`<=`).
+
+#### Scenario: Both sides agree within tolerance
+- **WHEN** api delta=100, drv delta=109, `tolerance_pct: 10`
+- **THEN** the criterion passes
+
+#### Scenario: Both sides agree exactly
+- **WHEN** api delta=100, drv delta=100
+- **THEN** the criterion passes
+
+#### Scenario: Boundary case at tolerance edge
+- **WHEN** api delta=100, drv delta=110, `tolerance_pct: 10`
+- **THEN** the criterion passes (boundary is inclusive)
+
+#### Scenario: Difference exceeds tolerance
+- **WHEN** api delta=100, drv delta=120, `tolerance_pct: 10`
+- **THEN** the criterion fails with `reason_code="delta_mismatch"`
+- **AND** the failure comment is `"fail 原因為 delta 不一致：api=100 drv=120 tol=10%"`
+
+#### Scenario: One side did not grow
+- **WHEN** api delta=100, drv delta=0
+- **THEN** the criterion fails with `reason_code="delta_zero_side"`
+- **AND** the failure comment is `"fail 原因為 0，數值無變化"`
+
+#### Scenario: Both sides did not grow
+- **WHEN** api delta=0, drv delta=0
+- **THEN** the criterion fails with `reason_code="delta_zero_side"`
+
+#### Scenario: Negative delta on either side
+- **WHEN** either delta is negative (counter regression)
+- **THEN** the criterion fails with `reason_code="delta_zero_side"`
+
+### Requirement: Evaluate dispatch SHALL route criteria by presence of `delta` key
+
+`Plugin.evaluate()` SHALL inspect each `pass_criteria` entry and route it to the new delta evaluator when the entry contains a `delta:` key, and otherwise route it to the existing field-based evaluator. The dispatch MUST NOT introduce any change to the behavior of `field+value` or `field+reference` criteria.
+
+#### Scenario: Existing field+value criterion runs unchanged
+- **WHEN** a criterion has `field`, `operator`, `value` and no `delta:` key
+- **THEN** it is evaluated by the existing path
+- **AND** failure produces the existing `reason_code="pass_criteria_not_satisfied"`
+
+#### Scenario: Delta criterion goes to new dispatch
+- **WHEN** a criterion has a `delta:` key with `baseline` and `verify`
+- **THEN** it is evaluated by `_evaluate_delta_criterion`
+- **AND** the existing `_compare()` is not invoked for this criterion
+
+#### Scenario: Mixed criteria evaluate sequentially
+- **WHEN** a case has both field-based and delta-based criteria
+- **THEN** they are evaluated in declared order
+- **AND** evaluation halts on the first failing criterion (existing semantics)
+
+### Requirement: Failure comment string SHALL be a plugin-level constant, not yaml-overridable
+
+The "delta 為零" failure comment SHALL be defined as a module-level constant `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"` in `plugins/wifi_llapi/plugin.py`. Case yaml entries MUST NOT be able to override this string. The `delta_match` mismatch comment SHALL follow a fixed template `"fail 原因為 delta 不一致：api={a} drv={b} tol={t}%"`.
+
+#### Scenario: All delta_nonzero zero-delta failures share the same comment
+- **WHEN** any `delta_nonzero` criterion fails because `verify - baseline <= 0`
+- **THEN** the comment recorded on the case is exactly `"fail 原因為 0，數值無變化"`
+
+#### Scenario: Case yaml cannot inject custom comment for zero delta
+- **WHEN** a case yaml adds an `on_zero_comment:` or similar field on a delta criterion
+- **THEN** the runtime ignores it and writes the constant comment
+
+### Requirement: Reporter SHALL add a Comment column (M) and write evaluate-failure comments to it
+
+`wifi_llapi_excel.py` SHALL extend the report template to include column M with header `"Comment"`. `fill_case_results()` SHALL write each `WifiLlapiCaseResult.comment` (truncated to 200 characters with `"..."` suffix when longer) to column M. `DEFAULT_TEMPLATE_MAX_COLUMN` MUST become `"M"` and `DEFAULT_CLEAR_COLUMNS` MUST include `"M"`. Existing G–L column behavior MUST NOT change.
+
+#### Scenario: Template header includes Comment in column M
+- **WHEN** `_normalize_template_headers()` runs on the template sheet
+- **THEN** row 3 column 13 contains the value `"Comment"`
+
+#### Scenario: Case result writes comment to M column
+- **WHEN** `fill_case_results()` is called with a `WifiLlapiCaseResult` whose `comment` is `"fail 原因為 0，數值無變化"`
+- **THEN** the corresponding row's column M contains exactly that string
+
+#### Scenario: Empty comment leaves M column blank
+- **WHEN** the case passed and `comment` is the empty string
+- **THEN** column M is empty (not the literal `"None"`)
+
+#### Scenario: Long comment is truncated
+- **WHEN** the comment exceeds 200 characters
+- **THEN** column M contains the first 200 characters followed by `"..."`
+
+#### Scenario: G through L columns are unchanged
+- **WHEN** an existing case (no delta criteria, plain PASS) is written
+- **THEN** column G still holds the executed test command
+- **AND** column H still holds the command output
+- **AND** columns I/J/K still hold per-band verdicts
+- **AND** column L still holds the tester name
+
+### Requirement: BLOCKED and SKIP markers SHALL continue to write column H and MUST NOT write column M
+
+`fill_blocked_markers()` and `fill_skip_markers()` MUST keep their existing behavior of writing to column H. They MUST NOT write to column M. Column M is reserved for evaluate-phase failure comments only, since BLOCKED / SKIP represent "not tested / needs retest" — a different semantic level than evaluate failures.
+
+#### Scenario: BLOCKED case fills H column only
+- **WHEN** `fill_blocked_markers()` writes a BLOCKED result for a case
+- **THEN** column H contains `"BLOCKED: <reason>"`
+- **AND** column M for that row is empty
+
+#### Scenario: SKIP case fills H column only
+- **WHEN** `fill_skip_markers()` writes a SKIP result for a case
+- **THEN** column H contains `"SKIP: duplicate with D<row>"`
+- **AND** column M for that row is empty
+
+### Requirement: Five new reason_codes SHALL be reserved for delta evaluation paths
+
+The following `reason_code` values SHALL be used by the delta evaluation path and MUST NOT be repurposed elsewhere:
+
+| reason_code | Triggered by |
+|---|---|
+| `invalid_delta_schema` | Phase ordering validation failure (BLOCKED path) |
+| `delta_value_not_numeric` | Either endpoint cannot resolve to a number |
+| `delta_zero` | `delta_nonzero` failure (`verify - baseline <= 0`) |
+| `delta_zero_side` | `delta_match` failure where either side did not grow |
+| `delta_mismatch` | `delta_match` failure where both sides grew but differ beyond tolerance |
+
+Existing `reason_code="pass_criteria_not_satisfied"` MUST NOT be replaced or removed by this change; its refinement is tracked separately by issue #39.
+
+#### Scenario: invalid_delta_schema is reserved for phase ordering
+- **WHEN** a case is BLOCKED due to phase ordering violation
+- **THEN** `blocked_reason` begins with `"invalid_delta_schema:"`
+- **AND** the reason_code is not used by any other failure path
+
+#### Scenario: Existing pass_criteria_not_satisfied is preserved
+- **WHEN** a `field+value` criterion fails (not a delta criterion)
+- **THEN** the recorded `reason_code` is still `"pass_criteria_not_satisfied"`

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -75,7 +75,7 @@
 ## 6. Wave 1 — Sample Case Migration
 
 - [x] 6.1 Migrate `plugins/wifi_llapi/cases/D037_retransmissions.yaml` to delta range; remove `'Workbook v4.0.3 marks this API as Fail'` description line; ensure baseline → trigger → verify ordering and at least one `delta_nonzero` and one `delta_match`
-- [x] 6.2 Migrate `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` to delta range; remove the per-band `equals 0` criteria; add baseline/trigger/verify steps for each band
+- [x] 6.2 Migrate `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` to delta range; remove the per-band `equals 0` criteria; add baseline/trigger/verify steps for each band with per-band `delta_nonzero` checks
 - [x] 6.3 Run emulated transport suite for both samples; confirm verdicts match design expectations
 
 ## 7. Wave 1 — PR Gating

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -80,7 +80,7 @@
 
 ## 7. Wave 1 — PR Gating
 
-- [ ] 7.1 Confirm Wave 1 PR description includes design link and sample case before/after diff
+- [x] 7.1 Confirm Wave 1 PR description includes design link and sample case before/after diff
 - [ ] 7.2 CI green on unit + integration tests
 - [x] 7.3 `pytest tests/` full suite green (no regression in existing modules)
 - [ ] 7.4 Wave 1 PR merged to main BEFORE opening any Wave 2 / Wave 3 PR
@@ -113,7 +113,7 @@
 ## 10. Closeout
 
 - [ ] 10.1 Confirm `grep -rn "equals" plugins/wifi_llapi/cases/ | grep "value: '0'"` returns only Stage C cases (settings/state assertions explicitly out of scope)
-- [ ] 10.2 Confirm zero references to `'Workbook v4.0.3 marks this API as Fail'` remain in migrated cases
+- [x] 10.2 Confirm zero references to `'Workbook v4.0.3 marks this API as Fail'` remain in migrated cases
 - [x] 10.3 Run `openspec validate wifi-llapi-counter-delta-validation --strict` and confirm green
 - [x] 10.4 Final `pytest tests/` full suite green
 - [ ] 10.5 Archive change with `openspec archive wifi-llapi-counter-delta-validation`

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -1,88 +1,88 @@
 ## 1. Wave 1 — Runtime: Phase Schema & Delta Operators
 
-- [ ] 1.1 Add module-level constant `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"` in `plugins/wifi_llapi/plugin.py`
-- [ ] 1.2 Implement `_validate_phase_ordering(case) -> str | None` per design Decision 5 (returns error string or None)
-- [ ] 1.3 Wire `_validate_phase_ordering` into `Plugin.discover_cases()` so violating cases are marked BLOCKED with `blocked_reason="invalid_delta_schema: <error>"`; other cases continue loading unaffected
-- [ ] 1.4 Extract existing field-criterion evaluation logic from `Plugin.evaluate()` into `_evaluate_field_criterion()` (no behavior change)
-- [ ] 1.5 Implement `_evaluate_delta_criterion(case, context, criterion, idx)` covering both `delta_nonzero` and `delta_match` per spec scenarios
-- [ ] 1.6 Add evaluate dispatch: `if "delta" in criterion → _evaluate_delta_criterion else _evaluate_field_criterion`
-- [ ] 1.7 Reserve and apply five new reason_codes: `invalid_delta_schema`, `delta_value_not_numeric`, `delta_zero`, `delta_zero_side`, `delta_mismatch`
-- [ ] 1.8 Confirm `_compare()` signature and behavior remain unchanged
+- [x] 1.1 Add module-level constant `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"` in `plugins/wifi_llapi/plugin.py`
+- [x] 1.2 Implement `_validate_phase_ordering(case) -> str | None` per design Decision 5 (returns error string or None)
+- [x] 1.3 Wire `_validate_phase_ordering` into `Plugin.discover_cases()` so violating cases are marked BLOCKED with `blocked_reason="invalid_delta_schema: <error>"`; other cases continue loading unaffected
+- [x] 1.4 Extract existing field-criterion evaluation logic from `Plugin.evaluate()` into `_evaluate_field_criterion()` (no behavior change)
+- [x] 1.5 Implement `_evaluate_delta_criterion(case, context, criterion, idx)` covering both `delta_nonzero` and `delta_match` per spec scenarios
+- [x] 1.6 Add evaluate dispatch: `if "delta" in criterion → _evaluate_delta_criterion else _evaluate_field_criterion`
+- [x] 1.7 Reserve and apply five new reason_codes: `invalid_delta_schema`, `delta_value_not_numeric`, `delta_zero`, `delta_zero_side`, `delta_mismatch`
+- [x] 1.8 Confirm `_compare()` signature and behavior remain unchanged
 
 ## 2. Wave 1 — Reporter: M Column
 
-- [ ] 2.1 Change `DEFAULT_TEMPLATE_MAX_COLUMN` from `"L"` to `"M"` in `wifi_llapi_excel.py`
-- [ ] 2.2 Add constant `COMMENT_HEADER = "Comment"`
-- [ ] 2.3 Add `"M"` to `DEFAULT_CLEAR_COLUMNS`
-- [ ] 2.4 Update `_normalize_template_headers()` to write `COMMENT_HEADER` at row 3 column 13
-- [ ] 2.5 Add `_truncate_comment(text, limit=200)` helper (return value: string ≤ 200 chars, append `"..."` if truncated, return empty string for empty input)
-- [ ] 2.6 Update `fill_case_results()` to call `_set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment))` after the existing G–L writes
-- [ ] 2.7 Verify `fill_blocked_markers()` and `fill_skip_markers()` still write only column H and do NOT touch column M (regression guard, no code change expected)
+- [x] 2.1 Change `DEFAULT_TEMPLATE_MAX_COLUMN` from `"L"` to `"M"` in `wifi_llapi_excel.py`
+- [x] 2.2 Add constant `COMMENT_HEADER = "Comment"`
+- [x] 2.3 Add `"M"` to `DEFAULT_CLEAR_COLUMNS`
+- [x] 2.4 Update `_normalize_template_headers()` to write `COMMENT_HEADER` at row 3 column 13
+- [x] 2.5 Add `_truncate_comment(text, limit=200)` helper (return value: string ≤ 200 chars, append `"..."` if truncated, return empty string for empty input)
+- [x] 2.6 Update `fill_case_results()` to call `_set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment))` after the existing G–L writes
+- [x] 2.7 Verify `fill_blocked_markers()` and `fill_skip_markers()` still write only column H and do NOT touch column M (regression guard, no code change expected)
 
 ## 3. Wave 1 — Documentation: CASE_YAML_SYNTAX.md
 
-- [ ] 3.1 Inventory all top-level fields actually used across `plugins/wifi_llapi/cases/*.yaml` (id / name / version / source / platform / hlapi_command / llapi_support / implemented_by / bands / topology / test_environment / setup_steps / sta_env_setup / test_procedure / steps / pass_criteria / verification_command)
-- [ ] 3.2 Inventory all step-level fields actually used (id / target / action / capture / command / depends_on / expected / description) plus the new `phase` field
-- [ ] 3.3 Document the three pass_criteria shapes: `field+value`, `field+reference`, `delta` (with optional `reference_delta`)
-- [ ] 3.4 Document the full operator list (existing `equals / != / contains / not_contains / regex / not_empty / empty / >= / <= / > / < / skip` + new `delta_nonzero / delta_match`)
-- [ ] 3.5 Document `llapi_support` values (`Support / Not Supported / Skip / Blocked`) and how each maps to step actions
-- [ ] 3.6 Document schema validation rules (required fields, mutual exclusions, phase ordering constraint)
-- [ ] 3.7 Add three worked examples: standard case (existing shape), counter-delta case (new shape), blocked case
-- [ ] 3.8 Document the five new reason_codes with one-line trigger description each
-- [ ] 3.9 Save as `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` (colocated with plugin code, not under `docs/`)
+- [x] 3.1 Inventory all top-level fields actually used across `plugins/wifi_llapi/cases/*.yaml` (id / name / version / source / platform / hlapi_command / llapi_support / implemented_by / bands / topology / test_environment / setup_steps / sta_env_setup / test_procedure / steps / pass_criteria / verification_command)
+- [x] 3.2 Inventory all step-level fields actually used (id / target / action / capture / command / depends_on / expected / description) plus the new `phase` field
+- [x] 3.3 Document the three pass_criteria shapes: `field+value`, `field+reference`, `delta` (with optional `reference_delta`)
+- [x] 3.4 Document the full operator list (existing `equals / != / contains / not_contains / regex / not_empty / empty / >= / <= / > / < / skip` + new `delta_nonzero / delta_match`)
+- [x] 3.5 Document `llapi_support` values (`Support / Not Supported / Skip / Blocked`) and how each maps to step actions
+- [x] 3.6 Document schema validation rules (required fields, mutual exclusions, phase ordering constraint)
+- [x] 3.7 Add three worked examples: standard case (existing shape), counter-delta case (new shape), blocked case
+- [x] 3.8 Document the five new reason_codes with one-line trigger description each
+- [x] 3.9 Save as `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` (colocated with plugin code, not under `docs/`)
 
 ## 4. Wave 1 — Tests: Unit (`tests/test_wifi_llapi_delta.py`)
 
-- [ ] 4.1 `test_delta_nonzero_pass` — baseline=10, verify=42 → PASS
-- [ ] 4.2 `test_delta_nonzero_fail_zero` — baseline=10, verify=10 → FAIL, reason_code=`delta_zero`, comment=`ZERO_DELTA_COMMENT`
-- [ ] 4.3 `test_delta_nonzero_fail_negative` — baseline=10, verify=5 → FAIL, reason_code=`delta_zero`
-- [ ] 4.4 `test_delta_nonzero_baseline_missing` — baseline path unresolved → FAIL, reason_code=`delta_value_not_numeric`
-- [ ] 4.5 `test_delta_nonzero_non_numeric` — verify=`"N/A"` → FAIL, reason_code=`delta_value_not_numeric`
-- [ ] 4.6 `test_delta_match_pass_within_tolerance` — api=100, drv=109, tol=10% → PASS
-- [ ] 4.7 `test_delta_match_pass_exact_match` — api=100, drv=100 → PASS
-- [ ] 4.8 `test_delta_match_fail_exceed_tolerance` — api=100, drv=120, tol=10% → FAIL, reason_code=`delta_mismatch`
-- [ ] 4.9 `test_delta_match_fail_one_side_zero` — api=100, drv=0 → FAIL, reason_code=`delta_zero_side`
-- [ ] 4.10 `test_delta_match_fail_both_zero` — api=0, drv=0 → FAIL, reason_code=`delta_zero_side`
-- [ ] 4.11 `test_delta_match_fail_negative_either_side` — any side negative → FAIL, reason_code=`delta_zero_side`
-- [ ] 4.12 `test_delta_match_tolerance_boundary` — api=100, drv=110, tol=10% → PASS (inclusive)
-- [ ] 4.13 `test_phase_ok_baseline_trigger_verify` — standard ordering → returns None
-- [ ] 4.14 `test_phase_no_delta_skip_check` — no delta criterion → returns None regardless of phase labels
-- [ ] 4.15 `test_phase_missing_trigger` — only baseline + verify → error string contains `"require at least one phase=trigger"`
-- [ ] 4.16 `test_phase_baseline_after_trigger` → error contains `"baseline step must precede trigger"`
-- [ ] 4.17 `test_phase_verify_before_trigger` → error contains `"verify step must follow trigger"`
-- [ ] 4.18 `test_phase_default_unmarked_is_verify` — step without phase field treated as verify
-- [ ] 4.19 `test_phase_invalid_value` — phase=`"warmup"` → error contains `"unknown phase: warmup"`
-- [ ] 4.20 `test_evaluate_field_path_unchanged` — regression guard for `field+value`, reason_code remains `pass_criteria_not_satisfied`
-- [ ] 4.21 `test_evaluate_delta_path_picks_new_dispatch` — `_compare()` not invoked when criterion contains `delta:`
-- [ ] 4.22 `test_evaluate_mixed_criteria` — first failing criterion halts evaluation regardless of type
-- [ ] 4.23 `test_invalid_delta_schema_marks_blocked` — phase-violating case is BLOCKED at discover time, never reaches evaluate
+- [x] 4.1 `test_delta_nonzero_pass` — baseline=10, verify=42 → PASS
+- [x] 4.2 `test_delta_nonzero_fail_zero` — baseline=10, verify=10 → FAIL, reason_code=`delta_zero`, comment=`ZERO_DELTA_COMMENT`
+- [x] 4.3 `test_delta_nonzero_fail_negative` — baseline=10, verify=5 → FAIL, reason_code=`delta_zero`
+- [x] 4.4 `test_delta_nonzero_baseline_missing` — baseline path unresolved → FAIL, reason_code=`delta_value_not_numeric`
+- [x] 4.5 `test_delta_nonzero_non_numeric` — verify=`"N/A"` → FAIL, reason_code=`delta_value_not_numeric`
+- [x] 4.6 `test_delta_match_pass_within_tolerance` — api=100, drv=109, tol=10% → PASS
+- [x] 4.7 `test_delta_match_pass_exact_match` — api=100, drv=100 → PASS
+- [x] 4.8 `test_delta_match_fail_exceed_tolerance` — api=100, drv=120, tol=10% → FAIL, reason_code=`delta_mismatch`
+- [x] 4.9 `test_delta_match_fail_one_side_zero` — api=100, drv=0 → FAIL, reason_code=`delta_zero_side`
+- [x] 4.10 `test_delta_match_fail_both_zero` — api=0, drv=0 → FAIL, reason_code=`delta_zero_side`
+- [x] 4.11 `test_delta_match_fail_negative_either_side` — any side negative → FAIL, reason_code=`delta_zero_side`
+- [x] 4.12 `test_delta_match_tolerance_boundary` — api=100, drv=110, tol=10% → PASS (inclusive)
+- [x] 4.13 `test_phase_ok_baseline_trigger_verify` — standard ordering → returns None
+- [x] 4.14 `test_phase_no_delta_skip_check` — no delta criterion → returns None regardless of phase labels
+- [x] 4.15 `test_phase_missing_trigger` — only baseline + verify → error string contains `"require at least one phase=trigger"`
+- [x] 4.16 `test_phase_baseline_after_trigger` → error contains `"baseline step must precede trigger"`
+- [x] 4.17 `test_phase_verify_before_trigger` → error contains `"verify step must follow trigger"`
+- [x] 4.18 `test_phase_default_unmarked_is_verify` — step without phase field treated as verify
+- [x] 4.19 `test_phase_invalid_value` — phase=`"warmup"` → error contains `"unknown phase: warmup"`
+- [x] 4.20 `test_evaluate_field_path_unchanged` — regression guard for `field+value`, reason_code remains `pass_criteria_not_satisfied`
+- [x] 4.21 `test_evaluate_delta_path_picks_new_dispatch` — `_compare()` not invoked when criterion contains `delta:`
+- [x] 4.22 `test_evaluate_mixed_criteria` — first failing criterion halts evaluation regardless of type
+- [x] 4.23 `test_invalid_delta_schema_marks_blocked` — phase-violating case is BLOCKED at discover time, never reaches evaluate
 
 ## 5. Wave 1 — Tests: Integration
 
-- [ ] 5.1 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml` (baseline/trigger/verify mock values produce PASS)
-- [ ] 5.2 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml` (verify equals baseline → FAIL)
-- [ ] 5.3 Create `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml` (api/drv both grow within tolerance)
-- [ ] 5.4 Create `tests/test_wifi_llapi_delta_integration.py` covering `discover_cases → execute_step (mocked transport) → evaluate → fill_case_results`; assert per-band verdict columns and M column comment match expectations for all three fixtures
-- [ ] 5.5 Extend `tests/test_wifi_llapi_excel.py`: `test_template_max_column_is_M`
-- [ ] 5.6 Extend `tests/test_wifi_llapi_excel.py`: `test_clear_columns_includes_M`
-- [ ] 5.7 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_writes_M`
-- [ ] 5.8 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_truncates_long_comment`
-- [ ] 5.9 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_empty_comment` (no `"None"` written)
-- [ ] 5.10 Extend `tests/test_wifi_llapi_excel.py`: `test_blocked_marker_writes_H_not_M`
-- [ ] 5.11 Extend `tests/test_wifi_llapi_excel.py`: `test_skip_marker_writes_H_not_M`
-- [ ] 5.12 Run full `pytest tests/` and confirm zero regression
+- [x] 5.1 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml` (baseline/trigger/verify mock values produce PASS)
+- [x] 5.2 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml` (verify equals baseline → FAIL)
+- [x] 5.3 Create `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml` (api/drv both grow within tolerance)
+- [x] 5.4 Create `tests/test_wifi_llapi_delta_integration.py` covering `discover_cases → execute_step (mocked transport) → evaluate → fill_case_results`; assert per-band verdict columns and M column comment match expectations for all three fixtures
+- [x] 5.5 Extend `tests/test_wifi_llapi_excel.py`: `test_template_max_column_is_M`
+- [x] 5.6 Extend `tests/test_wifi_llapi_excel.py`: `test_clear_columns_includes_M`
+- [x] 5.7 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_writes_M`
+- [x] 5.8 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_truncates_long_comment`
+- [x] 5.9 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_empty_comment` (no `"None"` written)
+- [x] 5.10 Extend `tests/test_wifi_llapi_excel.py`: `test_blocked_marker_writes_H_not_M`
+- [x] 5.11 Extend `tests/test_wifi_llapi_excel.py`: `test_skip_marker_writes_H_not_M`
+- [x] 5.12 Run full `pytest tests/` and confirm zero regression
 
 ## 6. Wave 1 — Sample Case Migration
 
-- [ ] 6.1 Migrate `plugins/wifi_llapi/cases/D037_retransmissions.yaml` to delta range; remove `'Workbook v4.0.3 marks this API as Fail'` description line; ensure baseline → trigger → verify ordering and at least one `delta_nonzero` and one `delta_match`
-- [ ] 6.2 Migrate `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` to delta range; remove the per-band `equals 0` criteria; add baseline/trigger/verify steps for each band
-- [ ] 6.3 Run emulated transport suite for both samples; confirm verdicts match design expectations
+- [x] 6.1 Migrate `plugins/wifi_llapi/cases/D037_retransmissions.yaml` to delta range; remove `'Workbook v4.0.3 marks this API as Fail'` description line; ensure baseline → trigger → verify ordering and at least one `delta_nonzero` and one `delta_match`
+- [x] 6.2 Migrate `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` to delta range; remove the per-band `equals 0` criteria; add baseline/trigger/verify steps for each band
+- [x] 6.3 Run emulated transport suite for both samples; confirm verdicts match design expectations
 
 ## 7. Wave 1 — PR Gating
 
 - [ ] 7.1 Confirm Wave 1 PR description includes design link and sample case before/after diff
 - [ ] 7.2 CI green on unit + integration tests
-- [ ] 7.3 `pytest tests/` full suite green (no regression in existing modules)
+- [x] 7.3 `pytest tests/` full suite green (no regression in existing modules)
 - [ ] 7.4 Wave 1 PR merged to main BEFORE opening any Wave 2 / Wave 3 PR
 
 ## 8. Wave 2 — Stage A Migration (~30 cases)
@@ -114,6 +114,6 @@
 
 - [ ] 10.1 Confirm `grep -rn "equals" plugins/wifi_llapi/cases/ | grep "value: '0'"` returns only Stage C cases (settings/state assertions explicitly out of scope)
 - [ ] 10.2 Confirm zero references to `'Workbook v4.0.3 marks this API as Fail'` remain in migrated cases
-- [ ] 10.3 Run `openspec validate wifi-llapi-counter-delta-validation --strict` and confirm green
-- [ ] 10.4 Final `pytest tests/` full suite green
+- [x] 10.3 Run `openspec validate wifi-llapi-counter-delta-validation --strict` and confirm green
+- [x] 10.4 Final `pytest tests/` full suite green
 - [ ] 10.5 Archive change with `openspec archive wifi-llapi-counter-delta-validation`

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -1,0 +1,119 @@
+## 1. Wave 1 — Runtime: Phase Schema & Delta Operators
+
+- [ ] 1.1 Add module-level constant `ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"` in `plugins/wifi_llapi/plugin.py`
+- [ ] 1.2 Implement `_validate_phase_ordering(case) -> str | None` per design Decision 5 (returns error string or None)
+- [ ] 1.3 Wire `_validate_phase_ordering` into `Plugin.discover_cases()` so violating cases are marked BLOCKED with `blocked_reason="invalid_delta_schema: <error>"`; other cases continue loading unaffected
+- [ ] 1.4 Extract existing field-criterion evaluation logic from `Plugin.evaluate()` into `_evaluate_field_criterion()` (no behavior change)
+- [ ] 1.5 Implement `_evaluate_delta_criterion(case, context, criterion, idx)` covering both `delta_nonzero` and `delta_match` per spec scenarios
+- [ ] 1.6 Add evaluate dispatch: `if "delta" in criterion → _evaluate_delta_criterion else _evaluate_field_criterion`
+- [ ] 1.7 Reserve and apply five new reason_codes: `invalid_delta_schema`, `delta_value_not_numeric`, `delta_zero`, `delta_zero_side`, `delta_mismatch`
+- [ ] 1.8 Confirm `_compare()` signature and behavior remain unchanged
+
+## 2. Wave 1 — Reporter: M Column
+
+- [ ] 2.1 Change `DEFAULT_TEMPLATE_MAX_COLUMN` from `"L"` to `"M"` in `wifi_llapi_excel.py`
+- [ ] 2.2 Add constant `COMMENT_HEADER = "Comment"`
+- [ ] 2.3 Add `"M"` to `DEFAULT_CLEAR_COLUMNS`
+- [ ] 2.4 Update `_normalize_template_headers()` to write `COMMENT_HEADER` at row 3 column 13
+- [ ] 2.5 Add `_truncate_comment(text, limit=200)` helper (return value: string ≤ 200 chars, append `"..."` if truncated, return empty string for empty input)
+- [ ] 2.6 Update `fill_case_results()` to call `_set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment))` after the existing G–L writes
+- [ ] 2.7 Verify `fill_blocked_markers()` and `fill_skip_markers()` still write only column H and do NOT touch column M (regression guard, no code change expected)
+
+## 3. Wave 1 — Documentation: CASE_YAML_SYNTAX.md
+
+- [ ] 3.1 Inventory all top-level fields actually used across `plugins/wifi_llapi/cases/*.yaml` (id / name / version / source / platform / hlapi_command / llapi_support / implemented_by / bands / topology / test_environment / setup_steps / sta_env_setup / test_procedure / steps / pass_criteria / verification_command)
+- [ ] 3.2 Inventory all step-level fields actually used (id / target / action / capture / command / depends_on / expected / description) plus the new `phase` field
+- [ ] 3.3 Document the three pass_criteria shapes: `field+value`, `field+reference`, `delta` (with optional `reference_delta`)
+- [ ] 3.4 Document the full operator list (existing `equals / != / contains / not_contains / regex / not_empty / empty / >= / <= / > / < / skip` + new `delta_nonzero / delta_match`)
+- [ ] 3.5 Document `llapi_support` values (`Support / Not Supported / Skip / Blocked`) and how each maps to step actions
+- [ ] 3.6 Document schema validation rules (required fields, mutual exclusions, phase ordering constraint)
+- [ ] 3.7 Add three worked examples: standard case (existing shape), counter-delta case (new shape), blocked case
+- [ ] 3.8 Document the five new reason_codes with one-line trigger description each
+- [ ] 3.9 Save as `plugins/wifi_llapi/CASE_YAML_SYNTAX.md` (colocated with plugin code, not under `docs/`)
+
+## 4. Wave 1 — Tests: Unit (`tests/test_wifi_llapi_delta.py`)
+
+- [ ] 4.1 `test_delta_nonzero_pass` — baseline=10, verify=42 → PASS
+- [ ] 4.2 `test_delta_nonzero_fail_zero` — baseline=10, verify=10 → FAIL, reason_code=`delta_zero`, comment=`ZERO_DELTA_COMMENT`
+- [ ] 4.3 `test_delta_nonzero_fail_negative` — baseline=10, verify=5 → FAIL, reason_code=`delta_zero`
+- [ ] 4.4 `test_delta_nonzero_baseline_missing` — baseline path unresolved → FAIL, reason_code=`delta_value_not_numeric`
+- [ ] 4.5 `test_delta_nonzero_non_numeric` — verify=`"N/A"` → FAIL, reason_code=`delta_value_not_numeric`
+- [ ] 4.6 `test_delta_match_pass_within_tolerance` — api=100, drv=109, tol=10% → PASS
+- [ ] 4.7 `test_delta_match_pass_exact_match` — api=100, drv=100 → PASS
+- [ ] 4.8 `test_delta_match_fail_exceed_tolerance` — api=100, drv=120, tol=10% → FAIL, reason_code=`delta_mismatch`
+- [ ] 4.9 `test_delta_match_fail_one_side_zero` — api=100, drv=0 → FAIL, reason_code=`delta_zero_side`
+- [ ] 4.10 `test_delta_match_fail_both_zero` — api=0, drv=0 → FAIL, reason_code=`delta_zero_side`
+- [ ] 4.11 `test_delta_match_fail_negative_either_side` — any side negative → FAIL, reason_code=`delta_zero_side`
+- [ ] 4.12 `test_delta_match_tolerance_boundary` — api=100, drv=110, tol=10% → PASS (inclusive)
+- [ ] 4.13 `test_phase_ok_baseline_trigger_verify` — standard ordering → returns None
+- [ ] 4.14 `test_phase_no_delta_skip_check` — no delta criterion → returns None regardless of phase labels
+- [ ] 4.15 `test_phase_missing_trigger` — only baseline + verify → error string contains `"require at least one phase=trigger"`
+- [ ] 4.16 `test_phase_baseline_after_trigger` → error contains `"baseline step must precede trigger"`
+- [ ] 4.17 `test_phase_verify_before_trigger` → error contains `"verify step must follow trigger"`
+- [ ] 4.18 `test_phase_default_unmarked_is_verify` — step without phase field treated as verify
+- [ ] 4.19 `test_phase_invalid_value` — phase=`"warmup"` → error contains `"unknown phase: warmup"`
+- [ ] 4.20 `test_evaluate_field_path_unchanged` — regression guard for `field+value`, reason_code remains `pass_criteria_not_satisfied`
+- [ ] 4.21 `test_evaluate_delta_path_picks_new_dispatch` — `_compare()` not invoked when criterion contains `delta:`
+- [ ] 4.22 `test_evaluate_mixed_criteria` — first failing criterion halts evaluation regardless of type
+- [ ] 4.23 `test_invalid_delta_schema_marks_blocked` — phase-violating case is BLOCKED at discover time, never reaches evaluate
+
+## 5. Wave 1 — Tests: Integration
+
+- [ ] 5.1 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml` (baseline/trigger/verify mock values produce PASS)
+- [ ] 5.2 Create `tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml` (verify equals baseline → FAIL)
+- [ ] 5.3 Create `tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml` (api/drv both grow within tolerance)
+- [ ] 5.4 Create `tests/test_wifi_llapi_delta_integration.py` covering `discover_cases → execute_step (mocked transport) → evaluate → fill_case_results`; assert per-band verdict columns and M column comment match expectations for all three fixtures
+- [ ] 5.5 Extend `tests/test_wifi_llapi_excel.py`: `test_template_max_column_is_M`
+- [ ] 5.6 Extend `tests/test_wifi_llapi_excel.py`: `test_clear_columns_includes_M`
+- [ ] 5.7 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_writes_M`
+- [ ] 5.8 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_truncates_long_comment`
+- [ ] 5.9 Extend `tests/test_wifi_llapi_excel.py`: `test_fill_case_results_empty_comment` (no `"None"` written)
+- [ ] 5.10 Extend `tests/test_wifi_llapi_excel.py`: `test_blocked_marker_writes_H_not_M`
+- [ ] 5.11 Extend `tests/test_wifi_llapi_excel.py`: `test_skip_marker_writes_H_not_M`
+- [ ] 5.12 Run full `pytest tests/` and confirm zero regression
+
+## 6. Wave 1 — Sample Case Migration
+
+- [ ] 6.1 Migrate `plugins/wifi_llapi/cases/D037_retransmissions.yaml` to delta range; remove `'Workbook v4.0.3 marks this API as Fail'` description line; ensure baseline → trigger → verify ordering and at least one `delta_nonzero` and one `delta_match`
+- [ ] 6.2 Migrate `plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml` to delta range; remove the per-band `equals 0` criteria; add baseline/trigger/verify steps for each band
+- [ ] 6.3 Run emulated transport suite for both samples; confirm verdicts match design expectations
+
+## 7. Wave 1 — PR Gating
+
+- [ ] 7.1 Confirm Wave 1 PR description includes design link and sample case before/after diff
+- [ ] 7.2 CI green on unit + integration tests
+- [ ] 7.3 `pytest tests/` full suite green (no regression in existing modules)
+- [ ] 7.4 Wave 1 PR merged to main BEFORE opening any Wave 2 / Wave 3 PR
+
+## 8. Wave 2 — Stage A Migration (~30 cases)
+
+- [ ] 8.1 Sub-PR `wave2-associated-device`: migrate D037, D038, D051, D052, D054
+- [ ] 8.2 Sub-PR `wave2-getradiostats-errors-discard`: migrate D267, D268, D269, D270
+- [ ] 8.3 Sub-PR `wave2-getssidstats-errors-discard`: migrate D304, D305, D306, D307, D308
+- [ ] 8.4 Sub-PR `wave2-getssidstats-retrans-unknown`: migrate D313, D316
+- [ ] 8.5 Sub-PR `wave2-ssid-stats-errors-retrans`: migrate D325, D326, D327, D328, D329, D334
+- [ ] 8.6 Sub-PR `wave2-radio-stats-errors-retry-retrans`: migrate D396, D397, D398, D399, D401, D402
+- [ ] 8.7 Sub-PR `wave2-radio-stats-retry-preamble`: migrate D406, D407, D448, D451
+- [ ] 8.8 Sub-PR `wave2-vendor-radio-retry-retrans`: migrate D452, D453, D454, D455, D457, D458
+- [ ] 8.9 Sub-PR `wave2-affiliated-misc`: migrate D495, D580
+- [ ] 8.10 Each Wave 2 sub-PR description includes emulated suite smoke evidence and case-list diff
+- [ ] 8.11 Update `CASE_YAML_SYNTAX.md` if Wave 2 reveals any schema gap
+
+## 9. Wave 3 — Stage B Migration (~50 cases)
+
+- [ ] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D031, D039, D040, D041, D042, D053, D055, D056, D057
+- [ ] 9.2 Sub-PR `wave3-getstats-traffic`: migrate D128, D130, D131, D132, D135, D136, D137
+- [ ] 9.3 Sub-PR `wave3-getradiostats-bcast-mcast-bytes`: migrate D263–D266, D271–D276
+- [ ] 9.4 Sub-PR `wave3-getssidstats-bcast-mcast-bytes`: migrate D300–D303, D309–D315
+- [ ] 9.5 Sub-PR `wave3-ssid-stats-bcast-mcast-bytes`: migrate D321–D324, D330–D337
+- [ ] 9.6 Sub-PR `wave3-radio-bytes-and-affiliated`: migrate D394, D395, D477, D576–D579
+- [ ] 9.7 Each Wave 3 sub-PR description includes emulated suite smoke evidence and case-list diff
+- [ ] 9.8 Update `CASE_YAML_SYNTAX.md` if Wave 3 reveals any schema gap
+
+## 10. Closeout
+
+- [ ] 10.1 Confirm `grep -rn "equals" plugins/wifi_llapi/cases/ | grep "value: '0'"` returns only Stage C cases (settings/state assertions explicitly out of scope)
+- [ ] 10.2 Confirm zero references to `'Workbook v4.0.3 marks this API as Fail'` remain in migrated cases
+- [ ] 10.3 Run `openspec validate wifi-llapi-counter-delta-validation --strict` and confirm green
+- [ ] 10.4 Final `pytest tests/` full suite green
+- [ ] 10.5 Archive change with `openspec archive wifi-llapi-counter-delta-validation`

--- a/plugins/wifi_llapi/CASE_YAML_SYNTAX.md
+++ b/plugins/wifi_llapi/CASE_YAML_SYNTAX.md
@@ -1,0 +1,449 @@
+# wifi_llapi case YAML syntax
+
+## Purpose and scope
+
+This document is the reference for `plugins/wifi_llapi/cases/*.yaml` and the Wave 1 counter-delta extension.
+It describes the syntax used by discoverable official `wifi_llapi` cases, the validation rules enforced today, and the new delta-oriented `pass_criteria` shape.
+It is not a migration guide and does not cover sample-case rollout planning.
+
+## Discovery and file-level rules
+
+- Discoverable official cases live under `plugins/wifi_llapi/cases/`.
+- `load_cases_dir()` loads `*.yaml` / `*.yml` and skips files whose stem starts with `_`.
+- Use `_*.yaml` only for fixtures, templates, or legacy compatibility artifacts.
+- `wifi_llapi` cases must not use removed oracle metadata:
+  - top-level `results_reference`
+  - `source.baseline`
+  - `source.report`
+  - `source.sheet`
+
+## Top-level field reference
+
+### Required by schema
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Case identifier. Official inventory uses `wifi-llapi-D###-...` or legacy `d###-...` forms. |
+| `name` | string | Human-readable case name. |
+| `topology` | mapping | Must contain `topology.devices`. |
+| `steps` | list[mapping] | Non-empty ordered step list. |
+| `pass_criteria` | list[mapping] | Non-empty verdict rule list. |
+
+### Optional fields used by current official cases
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `source` | mapping | Official cases use `source.row`, `source.object`, and `source.api`. Runtime alignment uses `(source.object, source.api)` as the canonical lookup key and may rewrite `source.row` / `id`. |
+| `llapi_support` | string | `Support`, `Not Supported`, `Skip`, or `Blocked`. See [llapi_support semantics](#llapi_support-semantics). |
+| `bands` | list[string] | Usually `5g`, `6g`, `2.4g`. Prefer canonical spellings in YAML. |
+| `verification_command` | string or list[string] | Human-readable audit / cross-check command list. |
+| `test_environment` | string | Human-readable lab context. |
+| `implemented_by` | string | Implementation ownership marker such as `pWHM` or `N/A`. |
+| `version` | string | Case revision string. |
+| `platform` | mapping | Commonly `platform.prplos` and `platform.bdk`. |
+| `hlapi_command` | string | HLAPI command under test. |
+| `test_procedure` | string | Human-readable execution summary. |
+| `setup_steps` | string | Human-readable setup summary. |
+| `sta_env_setup` | string | Executable or semi-structured DUT/STA environment setup notes. |
+| `aliases` | list[string] | Legacy compatibility names. Do not rely on row-derived aliases as the source of truth; `source.row` is the row reference. |
+
+### Topology structure
+
+`topology` is a mapping with at least:
+
+- `devices` (required): non-empty mapping of device name to device config
+- `links` (optional): link inventory used by human readers and some workflows
+
+Current `wifi_llapi` cases typically use device names such as `DUT` and `STA`, with fields like `role`, `transport`, and `selector`.
+
+## Step field reference
+
+### Required step fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | string | Unique within the case. |
+| `action` | string | Current case inventory uses `exec`, `read`, `wait`, and `skip`. |
+| `target` | string | Usually a key from `topology.devices`, such as `DUT` or `STA`. |
+
+### Optional step fields
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `command` | string or list[string] | Must be a string or a non-empty list of non-empty strings when present. |
+| `capture` | string | Capture name exposed to later step templating and `pass_criteria` field paths. |
+| `depends_on` | string | Must reference an earlier step `id`. |
+| `description` | string | Human-readable step purpose. |
+| `expected` | string | Human-readable expectation; currently descriptive only. |
+| `band` | string | Commonly `5g`, `6g`, or `2.4g`. |
+| `reason` | string | Freeform rationale or blocker note. |
+| `duration` | number | Used by `action: wait`. |
+| `phase` | string | Wave 1 field for delta-aware cases: `baseline`, `trigger`, or `verify`. Optional; default is `verify`. |
+
+### Step action notes
+
+| `action` | Execution expectation |
+| --- | --- |
+| `exec` | Execute the command and optionally capture parsed output. |
+| `read` | Same runtime path as `exec`; use when the step is semantically a readback/probe. |
+| `wait` | Sleep for `duration` seconds; no shell command is required. |
+| `skip` | Do not execute a real test command; runtime returns a synthetic skip echo. |
+
+## pass_criteria shapes
+
+`pass_criteria` is an ordered non-empty list. Each entry is a mapping.
+
+### 1. `field + value`
+
+Use this shape for direct comparison against a literal value.
+
+```yaml
+pass_criteria:
+  - field: result.Enable
+    operator: equals
+    value: "1"
+```
+
+Supported companion fields:
+
+- `description` (optional)
+- `band` (optional)
+
+### 2. `field + reference`
+
+Use this shape when the expected value comes from another captured field.
+
+```yaml
+pass_criteria:
+  - field: after_5g.DisassociationTime
+    operator: !=
+    reference: before_5g.DisassociationTime
+```
+
+Supported companion fields:
+
+- `description` (optional)
+- `band` (optional)
+
+### 3. `delta` with optional `reference_delta`
+
+Use this shape for counter-style validation across phases.
+
+```yaml
+pass_criteria:
+  - delta:
+      baseline: baseline_api.BytesSent
+      verify: verify_api.BytesSent
+    operator: delta_nonzero
+```
+
+```yaml
+pass_criteria:
+  - delta:
+      baseline: baseline_api.PacketsSent
+      verify: verify_api.PacketsSent
+    reference_delta:
+      baseline: baseline_drv.DriverPacketsSent
+      verify: verify_drv.DriverPacketsSent
+    operator: delta_match
+    tolerance_pct: 10
+```
+
+Supported companion fields:
+
+- `description` (optional)
+- `band` (optional)
+- `tolerance_pct` (optional number, `delta_match` only; defaults to `0`)
+
+Rules:
+
+- `delta.baseline` and `delta.verify` must be non-empty field paths.
+- `reference_delta` is required for `delta_match` and omitted for `delta_nonzero`.
+- Delta evaluation is numeric at runtime. Non-numeric endpoint values fail the case.
+- Delta cases require valid `phase` ordering in `steps`. See [schema validation rules](#schema-validation-rules).
+
+## Operator reference
+
+### Canonical operators for case authors
+
+| Operator | Shape | Meaning |
+| --- | --- | --- |
+| `equals` | `field + value` or `field + reference` | Equality check. |
+| `!=` | `field + value` or `field + reference` | Inequality check. |
+| `contains` | `field + value` | Expected substring must appear. |
+| `not_contains` | `field + value` | Expected substring must not appear. |
+| `regex` | `field + value` | Regular-expression match. |
+| `not_empty` | `field + value` or `field + reference` | Actual value must be non-empty. |
+| `empty` | `field + value` or `field + reference` | Actual value must be empty. |
+| `>=` | `field + value` or `field + reference` | Numeric compare when both sides are numeric, otherwise string compare. |
+| `<=` | `field + value` or `field + reference` | Numeric compare when both sides are numeric, otherwise string compare. |
+| `>` | `field + value` or `field + reference` | Numeric compare when both sides are numeric, otherwise string compare. |
+| `<` | `field + value` or `field + reference` | Numeric compare when both sides are numeric, otherwise string compare. |
+| `delta_nonzero` | `delta` | `verify - baseline` must be greater than zero. |
+| `delta_match` | `delta + reference_delta` | API delta and reference delta must both be positive and match within optional tolerance. |
+
+### Legacy compatibility accepted by current runtime
+
+Current runtime also accepts several legacy aliases still present in the repo or code path:
+
+- `not_equals` as the historical form of `!=`
+- `==` and `eq` as aliases for `equals`
+- `ne` as an alias for `!=`
+- `matches` as an alias for `regex`
+
+For new YAML, prefer the canonical operators in the table above.
+
+### Legacy placeholder still present in current inventory
+
+| Operator | Status | Notes |
+| --- | --- | --- |
+| `skip` | Legacy inventory artifact | Present in some existing `Skip` / `Blocked` placeholder cases, but it is not a normal `_compare()` operator for new runnable YAML. Do not use it for new case authoring unless the runtime is explicitly taught to evaluate it. |
+
+## llapi_support semantics
+
+`llapi_support` is documentation and runtime-status metadata. It does not replace `steps` or `pass_criteria`; the case body still defines execution behavior.
+
+| Value | Meaning | Expected case shape |
+| --- | --- | --- |
+| `Support` | The LLAPI path is intended to run normally. | Real executable steps (`exec` / `read` / `wait`) plus normal `pass_criteria`. |
+| `Not Supported` | The LLAPI is expected to fail or return an unsupported indication, but the case is still runnable. | Real executable steps plus `pass_criteria` that assert the expected unsupported response (for example `function not found`). |
+| `Skip` | The case is intentionally not executed in the current lab or workflow. | Existing inventory may still use legacy placeholder shapes such as `action: skip`; do not treat `operator: skip` as a normal comparison pattern for new YAML. |
+| `Blocked` | The case is not currently runnable because of a known blocker. | May be a hand-authored placeholder case, or an auto-blocked case such as invalid delta schema. |
+
+Wave 1 delta-specific note:
+
+- If a case contains delta criteria with invalid schema or invalid phase ordering, discovery / runtime prep may rewrite `llapi_support` to `Blocked` and attach `blocked_reason: invalid_delta_schema: ...` before execution.
+
+## Schema validation rules
+
+### General validation
+
+The current schema enforces the following baseline rules:
+
+1. Required top-level fields: `id`, `name`, `topology`, `steps`, `pass_criteria`.
+2. `topology` must be a mapping.
+3. `topology.devices` must be a non-empty mapping.
+4. `steps` must be a non-empty list.
+5. Every step must be a mapping.
+6. Every step must include `id`, `action`, and `target`.
+7. Step `id` values must be unique within the case.
+8. `command`, when present, must be a string or a non-empty list of non-empty strings.
+9. `depends_on` must reference an earlier step; forward references are invalid.
+10. `pass_criteria` must be a non-empty list.
+11. `results_reference`, `source.baseline`, `source.report`, and `source.sheet` are forbidden in `wifi_llapi` cases.
+
+### Delta-specific validation
+
+When any `pass_criteria` entry contains `delta`, the plugin adds these checks:
+
+1. `operator` must be `delta_nonzero` or `delta_match`.
+2. `delta` must be a mapping with non-empty `baseline` and `verify` strings.
+3. `reference_delta` must be a mapping with non-empty `baseline` and `verify` strings for `delta_match`.
+4. `phase` values, when used, must be one of `baseline`, `trigger`, or `verify`.
+5. Delta cases must include at least one `phase: trigger` step.
+6. `baseline` steps must appear before the first `trigger` step.
+7. All `verify` steps must appear after a `trigger` step, and no later `trigger` step may appear after verification has started.
+8. A delta case with invalid delta schema is blocked before normal execution/alignment.
+
+### Delta runtime validity
+
+The following checks happen at evaluation time rather than YAML schema load time:
+
+1. Delta endpoint field paths must resolve to numeric values.
+2. `delta_nonzero` requires `verify - baseline > 0`.
+3. `delta_match` requires both deltas to be positive.
+4. `delta_match` compares the two positive deltas and applies optional `tolerance_pct`.
+
+## Delta-related reason codes
+
+| Reason code | Trigger |
+| --- | --- |
+| `invalid_delta_schema` | The case definition fails delta schema or phase-order validation before execution. |
+| `delta_value_not_numeric` | A delta endpoint resolves to a missing or non-numeric runtime value. |
+| `delta_zero` | A `delta_nonzero` check produced a zero or negative delta. |
+| `delta_zero_side` | A `delta_match` check had a zero or negative API-side or reference-side delta. |
+| `delta_mismatch` | A `delta_match` check produced two positive deltas that differ beyond tolerance. |
+
+## Worked examples
+
+### Example 1: standard executable case
+
+```yaml
+id: wifi-llapi-D004-kickstation
+name: kickStation() - WiFi.AccessPoint.{i}.
+version: "1.1"
+source:
+  row: 4
+  object: "WiFi.AccessPoint.{i}."
+  api: "kickStation()"
+llapi_support: Support
+bands:
+  - 5g
+  - 6g
+  - 2.4g
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+      selector: COM1
+    STA:
+      role: sta
+      transport: serial
+      selector: COM0
+steps:
+  - id: step1_5g_assoc
+    action: exec
+    target: DUT
+    band: 5g
+    command: "wl -i wl0 assoclist | sed -n 's/^assoclist /AssocMac5g=/p'"
+    capture: assoc_5g
+  - id: step2_5g_before
+    action: exec
+    target: DUT
+    band: 5g
+    command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.DisassociationTime?"'
+    depends_on: step1_5g_assoc
+    capture: before_5g
+  - id: step3_5g_kick
+    action: exec
+    target: DUT
+    band: 5g
+    command: 'ubus-cli "WiFi.AccessPoint.1.kickStation(MACAddress={{assoc_5g.AssocMac5g}})"'
+    depends_on: step2_5g_before
+  - id: step4_5g_after
+    action: exec
+    target: DUT
+    band: 5g
+    command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.DisassociationTime?"'
+    depends_on: step3_5g_kick
+    capture: after_5g
+pass_criteria:
+  - field: assoc_5g.AssocMac5g
+    operator: regex
+    value: (?i)^([0-9a-f]{2}:){5}[0-9a-f]{2}$
+    description: 5G STA must be associated before kickStation()
+  - field: after_5g.DisassociationTime
+    operator: !=
+    reference: before_5g.DisassociationTime
+    band: 5g
+    description: DisassociationTime must change after kickStation()
+verification_command:
+  - 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.*.MACAddress?"'
+  - 'wl -i wl0 assoclist'
+```
+
+### Example 2: counter-delta case
+
+```yaml
+id: wifi-llapi-delta-match-pass
+name: PacketsSent
+version: "1.0"
+source:
+  row: 6
+  object: "WiFi.SSID.{i}.Stats."
+  api: "PacketsSent"
+llapi_support: Support
+bands:
+  - 2.4g
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+steps:
+  - id: baseline_api
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"'
+    capture: baseline_api
+  - id: baseline_drv
+    action: exec
+    target: DUT
+    phase: baseline
+    command: "wl -i wl2 counters | grep '^txframe '"
+    capture: baseline_drv
+  - id: trigger_traffic
+    action: exec
+    target: DUT
+    phase: trigger
+    command: "echo traffic-24g"
+  - id: verify_api
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"'
+    capture: verify_api
+  - id: verify_drv
+    action: exec
+    target: DUT
+    phase: verify
+    command: "wl -i wl2 counters | grep '^txframe '"
+    capture: verify_drv
+pass_criteria:
+  - delta:
+      baseline: baseline_api.PacketsSent
+      verify: verify_api.PacketsSent
+    reference_delta:
+      baseline: baseline_drv.TxFrames
+      verify: verify_drv.TxFrames
+    operator: delta_match
+    tolerance_pct: 10
+```
+
+### Example 3: auto-blocked delta case
+
+```yaml
+id: wifi-llapi-delta-invalid-order
+name: PacketsSent invalid phase ordering
+source:
+  row: 313
+  object: "WiFi.SSID.{i}.Stats."
+  api: "PacketsSent"
+bands:
+  - 2.4g
+llapi_support: Support
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+      selector: COM1
+steps:
+  - id: baseline_api
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"'
+    capture: baseline_api
+  - id: verify_api
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"'
+    capture: verify_api
+  - id: trigger_traffic
+    action: exec
+    target: DUT
+    phase: trigger
+    command: "echo traffic-24g"
+pass_criteria:
+  - delta:
+      baseline: baseline_api.PacketsSent
+      verify: verify_api.PacketsSent
+    operator: delta_nonzero
+```
+
+Discovery / runtime prep blocks this case before execution with:
+
+- `llapi_support: Blocked`
+- `blocked_reason: invalid_delta_schema: verify step must follow trigger`
+
+## Authoring notes
+
+- Keep new official case files discoverable and row-indexed; reserve `_*.yaml` for non-discoverable fixtures.
+- Prefer canonical band names: `5g`, `6g`, `2.4g`.
+- Prefer canonical operators from this document for new edits, even if legacy aliases still execute.
+- For delta cases, explicitly annotate every step with `phase`. Omitted `phase` defaults to `verify` and can invalidate a case if the step appears before the trigger window.
+- For official inventory cases, treat `source.row`, `source.object`, and `source.api` as required authoring metadata even though only the base YAML schema is formally required.

--- a/plugins/wifi_llapi/cases/D037_retransmissions.yaml
+++ b/plugins/wifi_llapi/cases/D037_retransmissions.yaml
@@ -93,60 +93,114 @@ sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cl
   \  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n\
   DUT association evidence:\n  wl -i wl0 assoclist\n"
 test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  address plus STA wl0 IPv4 address.
 
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions on DUT. The workbook
-  expects this case to fail: the LLAPI stays 0 even though driver retry counters are
-  non-zero for the same STA.
+  2) Capture baseline DUT LLAPI Retransmissions and the matching driver `tx pkts
+  retries` counter for the same STA.
 
-  3) Cross-check the same STA against wl0 sta_info `tx pkts retries`.
+  3) From the DUT bridge IP, run a best-effort large-packet ping burst toward the
+  resolved STA IP to exercise AP-to-STA retransmission behavior.
+
+  4) Capture verify DUT LLAPI Retransmissions and the matching driver `tx pkts
+  retries` counter, then compare baseline-to-verify deltas.
 
   '
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_resolve_sta_ip
+  phase: baseline
+  action: exec
+  target: STA
+  command: ifconfig wl0 | awk '/inet addr:/ {gsub("addr:","",$2); print "StaIp=" $2;
+    exit} $1=="inet" {print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
-  depends_on: step1
-  capture: result
-- id: step3
+  depends_on: step2_resolve_sta_ip
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
     [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
     *\([0-9][0-9]*\).*/DriverRetransmissions=\1/p'''
-  depends_on: step2
-  capture: driver_counter
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  command: PROBE_OUT=$(ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}} 2>&1);
+    printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" | awk '/packets transmitted/
+    {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
+    *\([0-9][0-9]*\).*/DriverRetransmissions=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.Retransmissions
-  operator: equals
-  value: '0'
-  description: 'Workbook v4.0.3 marks this API as Fail: LLAPI Retransmissions still
-    reads 0.'
-- field: driver_counter.DriverAssocMac
-  operator: equals
-  reference: assoc_entry.MACAddress
-  description: Driver counter sampling must use the same live AssociatedDevice 
-    MAC resolved in step1.
-- field: driver_counter.DriverRetransmissions
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The 5G STA wl0 interface must expose an IPv4 address for the DUT-originated trigger.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: Driver retry counters must still show real retransmissions for 
-    the same STA.
+  description: The DUT trigger step must actually transmit a downlink burst toward the resolved STA IP.
+- field: drv_before_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify: api_after_5g.Retransmissions
+  operator: delta_nonzero
+  description: 5G API Retransmissions must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_5g.Retransmissions
+    verify: api_after_5g.Retransmissions
+  reference_delta:
+    baseline: drv_before_5g.DriverRetransmissions
+    verify: drv_after_5g.DriverRetransmissions
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API retransmission delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p')
-- '[ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC'
-- '[ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
+- ifconfig wl0 | awk '/inet addr:/ {gsub("addr:","",$2); print "StaIp=" $2; exit}
+  $1=="inet" {print "StaIp=" $2; exit}'
+- ping -I br-lan -c 20 -s 1400 -W 1 <resolved STA wl0 IPv4>
+- 'STA_MAC="{{assoc_entry.MACAddress}}" && [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC'
+- 'STA_MAC="{{assoc_entry.MACAddress}}" && [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
   *\([0-9][0-9]*\).*/DriverRetransmissions=\1/p'''

--- a/plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml
+++ b/plugins/wifi_llapi/cases/D313_getssidstats_retranscount.yaml
@@ -9,6 +9,11 @@ bands:
 - 6g
 - 2.4g
 llapi_support: Support
+test_procedure: |
+  1) Capture baseline getSSIDStats().RetransCount on 5G, 6G, and 2.4G before any trigger activity.
+  2) Hold a shared multi-band trigger phase with dedicated 5G / 6G / 2.4G segments so external traffic can be induced per band as needed.
+  3) Because delta-phase ordering requires all verify reads after all trigger steps, each band is judged against the full shared trigger phase rather than a private per-band window.
+  4) Re-read getSSIDStats().RetransCount on all three bands and require each band delta to be positive.
 topology:
   devices:
     DUT:
@@ -16,34 +21,91 @@ topology:
       transport: serial
       selector: COM1
 steps:
-- id: step_5g_stats
+- id: step_5g_baseline_stats
+  phase: baseline
   target: dut
   action: read
-  capture: stats_5g
+  capture: stats_5g_before
   command: ubus-cli "WiFi.SSID.4.getSSIDStats()"
   expected: getSSIDStats() 回傳有效值
-  description: SSID.4 (5g) getSSIDStats()
-- id: step_6g_stats
+  description: SSID.4 (5g) RetransCount baseline read
+- id: step_6g_baseline_stats
+  phase: baseline
   target: dut
   action: read
-  capture: stats_6g
+  capture: stats_6g_before
   command: ubus-cli "WiFi.SSID.6.getSSIDStats()"
   expected: getSSIDStats() 回傳有效值
-  description: SSID.6 (6g) getSSIDStats()
-- id: step_24g_stats
+  description: SSID.6 (6g) RetransCount baseline read
+- id: step_24g_baseline_stats
+  phase: baseline
   target: dut
   action: read
-  capture: stats_24g
+  capture: stats_24g_before
   command: ubus-cli "WiFi.SSID.8.getSSIDStats()"
   expected: getSSIDStats() 回傳有效值
-  description: SSID.8 (2.4g) getSSIDStats()
+  description: SSID.8 (2.4g) RetransCount baseline read
+- id: step_5g_trigger_segment
+  phase: trigger
+  target: dut
+  action: wait
+  duration: 30
+  capture: trigger_segment_5g
+  expected: 保留 shared multi-band trigger phase 的 5G segment，供人工或外部流量在此期間發生
+  description: 5G trigger segment inside the shared multi-band trigger phase
+- id: step_6g_trigger_segment
+  phase: trigger
+  target: dut
+  action: wait
+  duration: 30
+  capture: trigger_segment_6g
+  expected: 保留 shared multi-band trigger phase 的 6G segment，供人工或外部流量在此期間發生
+  description: 6G trigger segment inside the shared multi-band trigger phase
+- id: step_24g_trigger_segment
+  phase: trigger
+  target: dut
+  action: wait
+  duration: 30
+  capture: trigger_segment_24g
+  expected: 保留 shared multi-band trigger phase 的 2.4G segment，供人工或外部流量在此期間發生
+  description: 2.4G trigger segment inside the shared multi-band trigger phase
+- id: step_5g_verify_stats
+  phase: verify
+  target: dut
+  action: read
+  capture: stats_5g_after
+  command: ubus-cli "WiFi.SSID.4.getSSIDStats()"
+  expected: getSSIDStats() 回傳有效值
+  description: SSID.4 (5g) RetransCount verify read
+- id: step_6g_verify_stats
+  phase: verify
+  target: dut
+  action: read
+  capture: stats_6g_after
+  command: ubus-cli "WiFi.SSID.6.getSSIDStats()"
+  expected: getSSIDStats() 回傳有效值
+  description: SSID.6 (6g) RetransCount verify read
+- id: step_24g_verify_stats
+  phase: verify
+  target: dut
+  action: read
+  capture: stats_24g_after
+  command: ubus-cli "WiFi.SSID.8.getSSIDStats()"
+  expected: getSSIDStats() 回傳有效值
+  description: SSID.8 (2.4g) RetransCount verify read
 pass_criteria:
-- field: stats_5g.RetransCount
-  operator: equals
-  value: 0
-- field: stats_6g.RetransCount
-  operator: equals
-  value: 0
-- field: stats_24g.RetransCount
-  operator: equals
-  value: 0
+- delta:
+    baseline: stats_5g_before.RetransCount
+    verify: stats_5g_after.RetransCount
+  operator: delta_nonzero
+  description: 5G RetransCount must increase across the shared multi-band trigger phase.
+- delta:
+    baseline: stats_6g_before.RetransCount
+    verify: stats_6g_after.RetransCount
+  operator: delta_nonzero
+  description: 6G RetransCount must increase across the shared multi-band trigger phase.
+- delta:
+    baseline: stats_24g_before.RetransCount
+    verify: stats_24g_after.RetransCount
+  operator: delta_nonzero
+  description: 2.4G RetransCount must increase across the shared multi-band trigger phase.

--- a/plugins/wifi_llapi/plugin.py
+++ b/plugins/wifi_llapi/plugin.py
@@ -27,6 +27,7 @@ from baseline_qualifier import BaselineQualifier
 from command_resolver import CommandResolver
 
 log = logging.getLogger(__name__)
+ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"
 
 
 class Plugin(PluginBase):
@@ -129,7 +130,12 @@ class Plugin(PluginBase):
         return Path(__file__).parent / "cases"
 
     def discover_cases(self) -> list[dict[str, Any]]:
-        return load_cases_dir(self.cases_dir, validator=validate_wifi_llapi_case)
+        cases = load_cases_dir(self.cases_dir, validator=validate_wifi_llapi_case)
+        for case in cases:
+            if error := self._validate_delta_schema(case):
+                case["llapi_support"] = "Blocked"
+                case["blocked_reason"] = f"invalid_delta_schema: {error}"
+        return cases
 
     # -- reporter overrides ----------------------------------------------------
 
@@ -164,6 +170,10 @@ class Plugin(PluginBase):
             return float(value)
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _format_number(value: float) -> str:
+        return f"{value:g}"
 
     @staticmethod
     def _as_mapping(value: Any) -> dict[str, Any]:
@@ -1042,6 +1052,85 @@ class Plugin(PluginBase):
         if "result" not in context:
             context["result"] = aggregate_fields if aggregate_fields else aggregate_output
         return context
+
+    def _validate_delta_schema(self, case: dict[str, Any]) -> str | None:
+        criteria = case.get("pass_criteria")
+        if not isinstance(criteria, list):
+            return None
+
+        saw_delta = False
+        for criterion in criteria:
+            if not isinstance(criterion, dict) or "delta" not in criterion:
+                continue
+            saw_delta = True
+            operator = str(criterion.get("operator", "")).strip().lower()
+            if operator not in {"delta_nonzero", "delta_match"}:
+                return f"unknown delta operator: {operator or '<empty>'}"
+            error = self._validate_delta_endpoint_schema(criterion.get("delta"), field="delta")
+            if error:
+                return error
+            if operator == "delta_match":
+                error = self._validate_delta_endpoint_schema(
+                    criterion.get("reference_delta"),
+                    field="reference_delta",
+                )
+                if error:
+                    return error
+
+        if not saw_delta:
+            return None
+        return self._validate_phase_ordering(case)
+
+    @staticmethod
+    def _validate_delta_endpoint_schema(value: Any, *, field: str) -> str | None:
+        if not isinstance(value, dict):
+            return f"{field} must be a mapping with non-empty baseline/verify"
+        if not value:
+            return f"{field} must be a mapping with non-empty baseline/verify"
+
+        baseline = value.get("baseline")
+        if not isinstance(baseline, str) or not baseline.strip():
+            return f"{field}.baseline must be a non-empty string"
+
+        verify = value.get("verify")
+        if not isinstance(verify, str) or not verify.strip():
+            return f"{field}.verify must be a non-empty string"
+
+        return None
+
+    def _validate_phase_ordering(self, case: dict[str, Any]) -> str | None:
+        criteria = case.get("pass_criteria")
+        if not isinstance(criteria, list) or not any(
+            isinstance(criterion, dict) and "delta" in criterion for criterion in criteria
+        ):
+            return None
+
+        saw_trigger = False
+        saw_verify_before_trigger = False
+        saw_verify = False
+        for step in case.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            phase = str(step.get("phase", "verify")).strip() or "verify"
+            if phase not in {"baseline", "trigger", "verify"}:
+                return f"unknown phase: {phase}"
+            if phase == "trigger":
+                if saw_verify and saw_trigger:
+                    return "trigger step must precede verify"
+                saw_trigger = True
+                continue
+            if phase == "baseline" and saw_trigger:
+                return "baseline step must precede trigger"
+            if phase == "verify" and not saw_trigger:
+                saw_verify_before_trigger = True
+            if phase == "verify":
+                saw_verify = True
+
+        if not saw_trigger:
+            return "delta_* operators require at least one phase=trigger step"
+        if saw_verify_before_trigger:
+            return "verify step must follow trigger"
+        return None
 
     def _compare(self, actual: Any, operator: str, expected: Any) -> bool:
         op = operator.strip().lower()
@@ -3286,10 +3375,192 @@ class Plugin(PluginBase):
             "fallback_reason": fallback_reason,
         }
 
+    def _evaluate_field_criterion(
+        self,
+        case: dict[str, Any],
+        context: dict[str, Any],
+        criterion: dict[str, Any],
+        idx: int,
+    ) -> bool:
+        aggregate_output = str(context.get("_aggregate_output", ""))
+        field = str(criterion.get("field", "")).strip()
+        operator = str(criterion.get("operator", "contains"))
+        expected = criterion.get("value")
+        reference = str(criterion.get("reference", "")).strip()
+
+        actual = self._resolve_field(context, field) if field else None
+        capture_raw = self._as_mapping(context.get("_capture_raw"))
+        if field and "." not in field and isinstance(actual, dict):
+            raw_output = capture_raw.get(field)
+            if isinstance(raw_output, str) and raw_output:
+                actual = raw_output
+        if isinstance(actual, dict) and "captured" in actual and "output" in actual:
+            captured = actual.get("captured")
+            if isinstance(captured, dict) and len(captured) == 1:
+                actual = next(iter(captured.values()))
+        if actual is None:
+            log.warning("[%s] evaluate: field not found (%s), fallback aggregate output", self.name, field)
+            actual = self._field_fallback_output(aggregate_output, field)
+
+        if expected is None and reference:
+            expected = self._resolve_field(context, reference)
+            if expected is None:
+                log.warning(
+                    "[%s] evaluate: reference not found (%s), fallback aggregate output",
+                    self.name,
+                    reference,
+                )
+                expected = aggregate_output
+
+        if self._compare(actual, operator, expected):
+            return True
+
+        self._record_runtime_failure(
+            case,
+            phase="evaluate",
+            comment="pass_criteria not satisfied",
+            category="test",
+            reason_code="pass_criteria_not_satisfied",
+            output=self._preview_value(actual),
+            metadata={
+                "criterion_index": idx,
+                "field": field,
+                "operator": operator,
+                "expected": self._preview_value(expected),
+                "actual": self._preview_value(actual),
+            },
+        )
+        log.info(
+            "[%s] evaluate failed: field=%s op=%s expected=%s actual=%s",
+            self.name,
+            field,
+            operator,
+            self._preview_value(expected),
+            self._preview_value(actual),
+        )
+        return False
+
+    def _evaluate_delta_criterion(
+        self,
+        case: dict[str, Any],
+        context: dict[str, Any],
+        criterion: dict[str, Any],
+        idx: int,
+    ) -> bool:
+        def resolve_number(path: str) -> float | None:
+            value = self._resolve_field(context, path) if path else None
+            return self._to_number(value)
+
+        def record_failure(comment: str, reason_code: str, metadata: dict[str, Any]) -> bool:
+            self._record_runtime_failure(
+                case,
+                phase="evaluate",
+                comment=comment,
+                category="test",
+                reason_code=reason_code,
+                metadata={"criterion_index": idx, **metadata},
+            )
+            return False
+
+        operator = str(criterion.get("operator", "")).strip().lower()
+        if operator not in {"delta_nonzero", "delta_match"}:
+            return record_failure(
+                f"fail 原因為 invalid delta operator: {operator or '<empty>'}",
+                "invalid_delta_operator",
+                {"operator": operator},
+            )
+        delta = self._as_mapping(criterion.get("delta"))
+        baseline_path = str(delta.get("baseline", "")).strip()
+        verify_path = str(delta.get("verify", "")).strip()
+        baseline_value = self._resolve_field(context, baseline_path) if baseline_path else None
+        verify_value = self._resolve_field(context, verify_path) if verify_path else None
+        baseline_number = resolve_number(baseline_path)
+        verify_number = resolve_number(verify_path)
+
+        if baseline_number is None or verify_number is None:
+            return record_failure(
+                "fail 原因為 delta 端點非數值",
+                "delta_value_not_numeric",
+                {
+                    "operator": operator,
+                    "baseline": baseline_path,
+                    "verify": verify_path,
+                    "baseline_value": self._preview_value(baseline_value),
+                    "verify_value": self._preview_value(verify_value),
+                },
+            )
+
+        delta_a = verify_number - baseline_number
+        if operator == "delta_nonzero":
+            if delta_a > 0:
+                return True
+            return record_failure(
+                ZERO_DELTA_COMMENT,
+                "delta_zero",
+                {
+                    "operator": operator,
+                    "baseline": baseline_path,
+                    "verify": verify_path,
+                    "delta": self._format_number(delta_a),
+                },
+            )
+
+        reference_delta = self._as_mapping(criterion.get("reference_delta"))
+        baseline_ref_path = str(reference_delta.get("baseline", "")).strip()
+        verify_ref_path = str(reference_delta.get("verify", "")).strip()
+        baseline_ref_value = self._resolve_field(context, baseline_ref_path) if baseline_ref_path else None
+        verify_ref_value = self._resolve_field(context, verify_ref_path) if verify_ref_path else None
+        baseline_ref_number = resolve_number(baseline_ref_path)
+        verify_ref_number = resolve_number(verify_ref_path)
+
+        if baseline_ref_number is None or verify_ref_number is None:
+            return record_failure(
+                "fail 原因為 delta 端點非數值",
+                "delta_value_not_numeric",
+                {
+                    "operator": operator,
+                    "baseline": baseline_ref_path,
+                    "verify": verify_ref_path,
+                    "baseline_value": self._preview_value(baseline_ref_value),
+                    "verify_value": self._preview_value(verify_ref_value),
+                },
+            )
+
+        delta_b = verify_ref_number - baseline_ref_number
+        if delta_a <= 0 or delta_b <= 0:
+            return record_failure(
+                ZERO_DELTA_COMMENT,
+                "delta_zero_side",
+                {
+                    "operator": operator,
+                    "delta": self._format_number(delta_a),
+                    "reference_delta": self._format_number(delta_b),
+                },
+            )
+
+        tolerance_pct = self._to_float(criterion.get("tolerance_pct"), 0.0)
+        tolerance = tolerance_pct / 100.0
+        ratio = abs(delta_a - delta_b) / max(abs(delta_a), abs(delta_b))
+        if ratio <= tolerance:
+            return True
+
+        return record_failure(
+            "fail 原因為 delta 不一致："
+            f"api={self._format_number(delta_a)} "
+            f"drv={self._format_number(delta_b)} "
+            f"tol={self._format_number(tolerance_pct)}%",
+            "delta_mismatch",
+            {
+                "operator": operator,
+                "delta": self._format_number(delta_a),
+                "reference_delta": self._format_number(delta_b),
+                "tolerance_pct": self._format_number(tolerance_pct),
+            },
+        )
+
     def evaluate(self, case: dict[str, Any], results: dict[str, Any]) -> bool:
         """評估通過條件。"""
         context = self._build_eval_context(case, results)
-        aggregate_output = str(context.get("_aggregate_output", ""))
         criteria = case.get("pass_criteria")
         if not isinstance(criteria, list) or not criteria:
             return False
@@ -3299,61 +3570,12 @@ class Plugin(PluginBase):
                 log.warning("[%s] evaluate: invalid criteria[%d]", self.name, idx)
                 return False
 
-            field = str(criterion.get("field", "")).strip()
-            operator = str(criterion.get("operator", "contains"))
-            expected = criterion.get("value")
-            reference = str(criterion.get("reference", "")).strip()
+            if "delta" in criterion:
+                if not self._evaluate_delta_criterion(case, context, criterion, idx):
+                    return False
+                continue
 
-            actual = self._resolve_field(context, field) if field else None
-            capture_raw = self._as_mapping(context.get("_capture_raw"))
-            if field and "." not in field and isinstance(actual, dict):
-                raw_output = capture_raw.get(field)
-                if isinstance(raw_output, str) and raw_output:
-                    actual = raw_output
-            # Unwrap step context: when field resolves to a step_context dict
-            # with a single captured value, use that value directly so regex /
-            # equals criteria match the extracted data rather than the whole dict.
-            if isinstance(actual, dict) and "captured" in actual and "output" in actual:
-                captured = actual.get("captured")
-                if isinstance(captured, dict) and len(captured) == 1:
-                    actual = next(iter(captured.values()))
-            if actual is None:
-                log.warning("[%s] evaluate: field not found (%s), fallback aggregate output", self.name, field)
-                actual = self._field_fallback_output(aggregate_output, field)
-
-            if expected is None and reference:
-                expected = self._resolve_field(context, reference)
-                if expected is None:
-                    log.warning(
-                        "[%s] evaluate: reference not found (%s), fallback aggregate output",
-                        self.name,
-                        reference,
-                    )
-                    expected = aggregate_output
-
-            if not self._compare(actual, operator, expected):
-                self._record_runtime_failure(
-                    case,
-                    phase="evaluate",
-                    comment="pass_criteria not satisfied",
-                    category="test",
-                    reason_code="pass_criteria_not_satisfied",
-                    output=self._preview_value(actual),
-                    metadata={
-                        "field": field,
-                        "operator": operator,
-                        "expected": self._preview_value(expected),
-                        "actual": self._preview_value(actual),
-                    },
-                )
-                log.info(
-                    "[%s] evaluate failed: field=%s op=%s expected=%s actual=%s",
-                    self.name,
-                    field,
-                    operator,
-                    self._preview_value(expected),
-                    self._preview_value(actual),
-                )
+            if not self._evaluate_field_criterion(case, context, criterion, idx):
                 return False
 
         return True

--- a/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
+++ b/plugins/wifi_llapi/tests/test_orchestrator_realistic_runtime.py
@@ -722,7 +722,7 @@ def test_realistic_runtime_covers_hooks_and_report_outputs(tmp_path: Path, monke
     assert ws["J4"].value == "N/A"
     assert ws["K4"].value == "N/A"
     assert ws["L4"].value == "testpilot"
-    assert ws.max_column == 12
+    assert ws.max_column == 13
 
     assert ws["G5"].value == 'ubus-cli "WiFi.Radio.1.getRadioStats()"'
     assert PASS_TOKEN in str(ws["H5"].value)

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_align.py
@@ -607,6 +607,7 @@ def test_fill_blocked_markers(tmp_path: Path):
     assert ws["H6"].value == "BLOCKED: name_not_in_template"
     assert ws["G6"].value is None
     assert ws["I6"].value is None
+    assert ws["M6"].value is None
     wb.close()
 
 
@@ -639,6 +640,7 @@ def test_fill_skip_markers(tmp_path: Path):
     assert ws["H6"].value == "SKIP: duplicate with D006"
     assert ws["G6"].value is None
     assert ws["I6"].value is None
+    assert ws["M6"].value is None
     wb.close()
 
 

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
@@ -36,7 +36,7 @@ def test_official_case_command_lengths_fit_transport_budget_summary():
                     if isinstance(item, str) and len(item) > threshold:
                         violations.append(f"{yaml_path.name}:{field}[{index}]:{len(item)}")
 
-    assert len(violations) == 939, (
+    assert len(violations) == 941, (
         "Official-case >120-char command inventory changed; "
         "review whether this was an intended calibration update.\n"
         + "\n".join(violations[:40])

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_excel_template.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_excel_template.py
@@ -5,6 +5,9 @@ from openpyxl import Workbook, load_workbook
 from openpyxl.utils import get_column_letter
 
 from testpilot.reporting.wifi_llapi_excel import (
+    COMMENT_HEADER,
+    DEFAULT_CLEAR_COLUMNS,
+    DEFAULT_TEMPLATE_MAX_COLUMN,
     WifiLlapiCaseResult,
     build_template_from_source,
     collect_alignment_issues,
@@ -13,6 +16,7 @@ from testpilot.reporting.wifi_llapi_excel import (
     generate_report_filename,
     normalize_command_block,
     sanitize_report_output,
+    _truncate_comment,
 )
 from testpilot.schema.case_schema import load_case
 
@@ -71,24 +75,28 @@ def test_build_template_from_source(tmp_path: Path):
     result = build_template_from_source(source, template)
     assert result.total_case_rows == 2
     assert result.sheet_name == "Wifi_LLAPI"
+    assert DEFAULT_TEMPLATE_MAX_COLUMN == "M"
+    assert result.cleared_columns == DEFAULT_CLEAR_COLUMNS
+    assert "M" in result.cleared_columns
 
     wb = load_workbook(template)
     assert wb.sheetnames == ["Wifi_LLAPI"]
     ws = wb["Wifi_LLAPI"]
-    assert ws.max_column == 12
-    assert get_column_letter(ws.max_column) == "L"
-    assert all(r.max_col <= 12 for r in ws.merged_cells.ranges)
+    assert ws.max_column == 13
+    assert get_column_letter(ws.max_column) == "M"
+    assert all(r.max_col <= 13 for r in ws.merged_cells.ranges)
     assert ws["I2"].value == "Result"
     assert ws["L2"].value == "Tester"
     assert ws["I3"].value == "WiFi 5G"
     assert ws["J3"].value == "WiFi 6G"
     assert ws["K3"].value == "WiFi 2.4G"
     assert ws["L3"].value == "Tester"
+    assert ws["M3"].value == COMMENT_HEADER
     assert "S" not in ws.column_dimensions
     assert "AB" not in ws.column_dimensions
     assert ws["C4"].value == "kickStation()"
     assert ws["C5"].value == "scan()"
-    for cell in ("G4", "H4", "I4", "J4", "K4", "L4", "G5", "H5", "I5", "J5", "K5", "L5"):
+    for cell in ("G4", "H4", "I4", "J4", "K4", "L4", "M4", "G5", "H5", "I5", "J5", "K5", "L5", "M5"):
         assert ws[cell].value is None
     wb.close()
 
@@ -112,6 +120,7 @@ def test_fill_case_results(tmp_path: Path):
                 result_5g="Pass",
                 result_6g="Pass",
                 result_24g="Pass",
+                comment="verified via DUT and STA logs",
             )
         ],
     )
@@ -124,6 +133,51 @@ def test_fill_case_results(tmp_path: Path):
     assert ws["J4"].value == "Pass"
     assert ws["K4"].value == "Pass"
     assert ws["L4"].value == "testpilot"
+    assert ws["M4"].value == "verified via DUT and STA logs"
+    wb.close()
+
+
+def test_fill_case_results_comment_truncates_and_blank_stays_empty(tmp_path: Path):
+    source = tmp_path / "source.xlsx"
+    template = tmp_path / "wifi_llapi_template.xlsx"
+    report = tmp_path / "20260304_BGW720-B0-403_wifi_LLAPI.xlsx"
+    _create_source_xlsx(source)
+    build_template_from_source(source, template)
+    create_run_report_from_template(template, report)
+
+    fill_case_results(
+        report,
+        [
+            WifiLlapiCaseResult(
+                case_id="wifi-llapi-D004-kickstation",
+                source_row=4,
+                executed_test_command="cmd",
+                command_output="out",
+                result_5g="Pass",
+                result_6g="Pass",
+                result_24g="Pass",
+                comment="x" * 201,
+            ),
+            WifiLlapiCaseResult(
+                case_id="wifi-llapi-D005-scan",
+                source_row=5,
+                executed_test_command="cmd2",
+                command_output="out2",
+                result_5g="Fail",
+                result_6g="Fail",
+                result_24g="Fail",
+                comment="",
+            ),
+        ],
+    )
+
+    wb = load_workbook(report)
+    ws = wb["Wifi_LLAPI"]
+    assert ws["M4"].value == ("x" * 197) + "..."
+    assert len(ws["M4"].value) == 200
+    assert _truncate_comment("") == ""
+    assert _truncate_comment(None) == ""
+    assert ws["M5"].value in (None, "")
     wb.close()
 
 
@@ -141,6 +195,7 @@ def test_fill_case_results_with_merged_row(tmp_path: Path):
     ws.merge_cells("J4:J5")
     ws.merge_cells("K4:K5")
     ws.merge_cells("L4:L5")
+    ws.merge_cells("M4:M5")
     wb.save(source)
     wb.close()
 
@@ -170,6 +225,7 @@ def test_fill_case_results_with_merged_row(tmp_path: Path):
     assert ws["J4"].value == "N/A"
     assert ws["K4"].value == "Pass"
     assert ws["L4"].value == "testpilot"
+    assert ws["M4"].value in (None, "")
     wb.close()
 
 

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -3142,7 +3142,6 @@ def test_pre_skip_aligned_manual_cases_avoid_stale_sample_values():
         "D310_getssidstats_multicastpacketssent.yaml": {"row": 310, "api": "MulticastPacketsSent", "expected": "Pass"},
         "D311_getssidstats_packetsreceived.yaml": {"row": 311, "api": "PacketsReceived", "expected": "Pass"},
         "D312_getssidstats_packetssent.yaml": {"row": 312, "api": "PacketsSent", "expected": "Pass"},
-        "D313_getssidstats_retranscount.yaml": {"row": 313, "api": "RetransCount", "expected": "Not Supported", "name": "RetransCount — WiFi.SSID.{i}.getSSIDStats()."},
         "D314_getssidstats_unicastpacketsreceived.yaml": {"row": 314, "api": "UnicastPacketsReceived", "expected": "Pass"},
         "D315_getssidstats_unicastpacketssent.yaml": {"row": 315, "api": "UnicastPacketsSent", "expected": "Pass"},
         "D316_getssidstats_unknownprotopacketsreceived.yaml": {"row": 316, "api": "UnknownProtoPacketsReceived", "expected": "Not Supported", "name": "UnknownProtoPacketsReceived — WiFi.SSID.{i}.getSSIDStats()."},
@@ -21130,7 +21129,6 @@ _SSID_STATS_CASES = [
     ("D310_getssidstats_multicastpacketssent.yaml", 310, "MulticastPacketsSent", "Pass"),
     ("D311_getssidstats_packetsreceived.yaml", 311, "PacketsReceived", "Pass"),
     ("D312_getssidstats_packetssent.yaml", 312, "PacketsSent", "Pass"),
-    ("D313_getssidstats_retranscount.yaml", 313, "RetransCount", "Not Supported"),
     ("D314_getssidstats_unicastpacketsreceived.yaml", 314, "UnicastPacketsReceived", "Pass"),
     ("D315_getssidstats_unicastpacketssent.yaml", 315, "UnicastPacketsSent", "Pass"),
     ("D316_getssidstats_unknownprotopacketsreceived.yaml", 316, "UnknownProtoPacketsReceived", "Not Supported"),
@@ -21184,6 +21182,180 @@ def test_ssid_stats_evaluate(yaml_file, row, field, verdict):
         }
     assert plugin.evaluate(case, results) is True
 
+
+def test_d313_getssidstats_retranscount_uses_delta_contract():
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    plugin = _load_plugin()
+    discoverable_ids = {case["id"] for case in plugin.discover_cases()}
+    assert "d313-getssidstats-retranscount" in discoverable_ids
+
+    raw_case = yaml.safe_load((cases_dir / "D313_getssidstats_retranscount.yaml").read_text(encoding="utf-8"))
+    case_data = load_case(cases_dir / "D313_getssidstats_retranscount.yaml")
+
+    assert "aliases" not in raw_case
+    assert case_data["id"] == "d313-getssidstats-retranscount"
+    assert case_data["source"]["row"] == 313
+    assert case_data["source"]["api"] == "getSSIDStats()"
+    assert case_data["bands"] == ["5g", "6g", "2.4g"]
+    assert "shared multi-band trigger phase" in case_data["test_procedure"]
+    assert [step["phase"] for step in case_data["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "trigger",
+        "trigger",
+        "verify",
+        "verify",
+        "verify",
+    ]
+    assert [step["action"] for step in case_data["steps"]] == [
+        "read",
+        "read",
+        "read",
+        "wait",
+        "wait",
+        "wait",
+        "read",
+        "read",
+        "read",
+    ]
+    assert [step["capture"] for step in case_data["steps"] if step.get("capture")] == [
+        "stats_5g_before",
+        "stats_6g_before",
+        "stats_24g_before",
+        "trigger_segment_5g",
+        "trigger_segment_6g",
+        "trigger_segment_24g",
+        "stats_5g_after",
+        "stats_6g_after",
+        "stats_24g_after",
+    ]
+    assert all(step.get("duration") == 30 for step in case_data["steps"][3:6])
+    assert all("shared multi-band trigger phase" in step["description"].lower() for step in case_data["steps"][3:6])
+    assert all("ubus-cli" not in step.get("command", "") for step in case_data["steps"][3:6])
+    assert len(case_data["pass_criteria"]) == 3
+    assert case_data["pass_criteria"] == [
+        {
+            "delta": {
+                "baseline": "stats_5g_before.RetransCount",
+                "verify": "stats_5g_after.RetransCount",
+            },
+            "operator": "delta_nonzero",
+            "description": "5G RetransCount must increase across the shared multi-band trigger phase.",
+        },
+        {
+            "delta": {
+                "baseline": "stats_6g_before.RetransCount",
+                "verify": "stats_6g_after.RetransCount",
+            },
+            "operator": "delta_nonzero",
+            "description": "6G RetransCount must increase across the shared multi-band trigger phase.",
+        },
+        {
+            "delta": {
+                "baseline": "stats_24g_before.RetransCount",
+                "verify": "stats_24g_after.RetransCount",
+            },
+            "operator": "delta_nonzero",
+            "description": "2.4G RetransCount must increase across the shared multi-band trigger phase.",
+        },
+    ]
+    assert not any(
+        criterion.get("field", "").endswith(".RetransCount")
+        and criterion.get("operator") == "equals"
+        and str(criterion.get("value")) == "0"
+        for criterion in case_data["pass_criteria"]
+    )
+
+
+def test_d313_getssidstats_retranscount_setup_env(monkeypatch):
+    """D313 remains DUT-only even after delta migration."""
+    plugin = _load_plugin()
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    case = load_case(cases_dir / "D313_getssidstats_retranscount.yaml")
+    topo = _FakeTopology()
+    recorder = _FactoryRecorder()
+    _install_fake_factory(monkeypatch, recorder)
+    assert plugin.setup_env(case, topology=topo) is True
+    plugin.teardown(case, topo)
+
+
+def test_d313_getssidstats_retranscount_evaluate_delta_examples():
+    plugin = _load_plugin()
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    case_data = load_case(cases_dir / "D313_getssidstats_retranscount.yaml")
+
+    def stats_output(ssid: str, value: int) -> str:
+        return (
+            f"WiFi.SSID.{ssid}.getSSIDStats() returned\n"
+            "[\n    {\n"
+            f"        RetransCount = {value},\n"
+            "    }\n]"
+        )
+
+    pass_results = {
+        "steps": {
+            "step_5g_baseline_stats": {
+                "success": True,
+                "output": stats_output("4", 10),
+                "timing": 0.01,
+            },
+            "step_6g_baseline_stats": {
+                "success": True,
+                "output": stats_output("6", 20),
+                "timing": 0.01,
+            },
+            "step_24g_baseline_stats": {
+                "success": True,
+                "output": stats_output("8", 30),
+                "timing": 0.01,
+            },
+            "step_5g_trigger_segment": {
+                "success": True,
+                "output": "waited 30.000s",
+                "timing": 30.0,
+            },
+            "step_6g_trigger_segment": {
+                "success": True,
+                "output": "waited 30.000s",
+                "timing": 30.0,
+            },
+            "step_24g_trigger_segment": {
+                "success": True,
+                "output": "waited 30.000s",
+                "timing": 30.0,
+            },
+            "step_5g_verify_stats": {
+                "success": True,
+                "output": stats_output("4", 11),
+                "timing": 0.01,
+            },
+            "step_6g_verify_stats": {
+                "success": True,
+                "output": stats_output("6", 25),
+                "timing": 0.01,
+            },
+            "step_24g_verify_stats": {
+                "success": True,
+                "output": stats_output("8", 31),
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(case_data, pass_results) is True
+
+    zero_delta_results = {
+        "steps": {
+            **pass_results["steps"],
+            "step_6g_verify_stats": {
+                "success": True,
+                "output": stats_output("6", 20),
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(case_data, zero_delta_results) is False
 
 # --- Batch 4d: D317 BSSID SSID property ---
 

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -5338,24 +5338,182 @@ def test_d034_noise_associateddevice_evaluate_live_examples():
     assert plugin.evaluate(d034, d034_missing_driver_range_results) is False
 
 
+def test_d037_retransmissions_uses_delta_contract():
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    plugin = _load_plugin()
+    discoverable_ids = {case["id"] for case in plugin.discover_cases()}
+    assert "wifi-llapi-D037-retransmissions" in discoverable_ids
+
+    raw_case = yaml.safe_load((cases_dir / "D037_retransmissions.yaml").read_text(encoding="utf-8"))
+    case_data = load_case(cases_dir / "D037_retransmissions.yaml")
+
+    assert "Workbook v4.0.3 marks this API as Fail" not in case_data["test_procedure"]
+    assert "aliases" not in raw_case
+    assert case_data["id"] == "wifi-llapi-D037-retransmissions"
+    assert case_data["source"]["row"] == 37
+    assert case_data["bands"] == ["5g"]
+    assert case_data["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"'
+    assert [step["phase"] for step in case_data["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "verify",
+        "verify",
+    ]
+    assert [step["capture"] for step in case_data["steps"] if step.get("capture")] == [
+        "assoc_entry",
+        "sta_ip",
+        "api_before_5g",
+        "drv_before_5g",
+        "trigger_probe",
+        "api_after_5g",
+        "drv_after_5g",
+    ]
+    assert "ifconfig wl0" in case_data["steps"][1]["command"]
+    assert "ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}}" in case_data["steps"][4]["command"]
+    assert any(
+        criterion["field"] == "assoc_entry.MACAddress"
+        and criterion["operator"] == "regex"
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "sta_ip.StaIp"
+        and criterion["operator"] == "regex"
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "trigger_probe.TriggerTxPackets"
+        and criterion["operator"] == ">"
+        and str(criterion["value"]) == "0"
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "drv_before_5g.DriverAssocMac"
+        and criterion["operator"] == "equals"
+        and criterion["reference"] == "assoc_entry.MACAddress"
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "drv_after_5g.DriverAssocMac"
+        and criterion["operator"] == "equals"
+        and criterion["reference"] == "assoc_entry.MACAddress"
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.Retransmissions",
+            "verify": "api_after_5g.Retransmissions",
+        }
+        for criterion in case_data["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.Retransmissions",
+            "verify": "api_after_5g.Retransmissions",
+        }
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_5g.DriverRetransmissions",
+            "verify": "drv_after_5g.DriverRetransmissions",
+        }
+        and criterion.get("tolerance_pct") == 10
+        for criterion in case_data["pass_criteria"]
+    )
+    assert not any(
+        criterion.get("field") == "result.Retransmissions"
+        and criterion.get("operator") == "equals"
+        and str(criterion.get("value")) == "0"
+        for criterion in case_data["pass_criteria"]
+    )
+
+
+def test_d037_retransmissions_evaluate_delta_examples():
+    plugin = _load_plugin()
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    case_data = load_case(cases_dir / "D037_retransmissions.yaml")
+
+    pass_results = {
+        "steps": {
+            "step1_resolve_assoc": {
+                "success": True,
+                "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
+                "timing": 0.01,
+            },
+            "step2_resolve_sta_ip": {
+                "success": True,
+                "output": "StaIp=192.168.88.2",
+                "timing": 0.01,
+            },
+            "step3_api_baseline": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=10",
+                "timing": 0.01,
+            },
+            "step4_drv_baseline": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=100",
+                "timing": 0.01,
+            },
+            "step5_trigger": {
+                "success": True,
+                "output": "20 packets transmitted, 20 received, 0% packet loss\nTriggerTxPackets=20",
+                "timing": 1.5,
+            },
+            "step6_api_verify": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=16",
+                "timing": 0.01,
+            },
+            "step7_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=106",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(case_data, pass_results) is True
+
+    zero_delta_results = {
+        "steps": {
+            **pass_results["steps"],
+            "step6_api_verify": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=10",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(case_data, zero_delta_results) is False
+
+    mismatch_results = {
+        "steps": {
+            **pass_results["steps"],
+            "step7_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=140",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(case_data, mismatch_results) is False
+
+
 def test_pending_counter_stub_associateddevice_cases_use_supported_contracts():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     plugin = _load_plugin()
     discoverable_ids = {case["id"] for case in plugin.discover_cases()}
     assert {
-        "wifi-llapi-D037-retransmissions",
         "wifi-llapi-D038-rx-retransmissions",
         "wifi-llapi-D042-rxunicastpacketcount",
     }.issubset(discoverable_ids)
 
     counter_cases = {
-        "D037_retransmissions.yaml": {
-            "id": "wifi-llapi-D037-retransmissions",
-            "row": 37,
-            "api": "Retransmissions",
-            "driver_token": "DriverRetransmissions=",
-            "driver_field": "driver_counter.DriverRetransmissions",
-        },
         "D038_rx_retransmissions.yaml": {
             "id": "wifi-llapi-D038-rx-retransmissions",
                 "row": 38,
@@ -5406,7 +5564,6 @@ def test_pending_counter_stub_associateddevice_cases_use_supported_contracts():
             for criterion in case_data["pass_criteria"]
         )
         _cstub_rr = {
-            "D037_retransmissions.yaml": ("Pass", "Pass", "Pass"),
             "D038_rx_retransmissions.yaml": ("Fail", "N/A", "N/A"),
             "D042_rxunicastpacketcount.yaml": ("Not Supported", "Not Supported", "Not Supported"),
         }
@@ -5418,11 +5575,6 @@ def test_pending_counter_stub_associateddevice_cases_evaluate_live_examples():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
 
     counter_cases = {
-        "D037_retransmissions.yaml": {
-            "api": "Retransmissions",
-            "driver_output": "DriverRetransmissions=65",
-            "driver_fail_output": "DriverRetransmissions=0",
-        },
         "D038_rx_retransmissions.yaml": {
             "api": "Rx_Retransmissions",
             "driver_output": "DriverRxRetransmissions=21",
@@ -16951,7 +17103,7 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
     ("filename", "step_index", "driver_token"),
     [
         ("D034_noise_accesspoint_associateddevice.yaml", 2, "DriverNoise="),
-        ("D037_retransmissions.yaml", 2, "DriverRetransmissions="),
+        ("D037_retransmissions.yaml", 3, "DriverRetransmissions="),
         ("D039_rxbytes.yaml", 2, "DriverRxBytes="),
         ("D040_rxmulticastpacketcount.yaml", 3, "DriverRxMulticastPacketCount="),
         ("D044_signalnoiseratio.yaml", 2, "DriverSignalNoiseRatio="),

--- a/src/testpilot/core/execution_engine.py
+++ b/src/testpilot/core/execution_engine.py
@@ -227,7 +227,11 @@ class ExecutionEngine:
                 if not comment:
                     verdict = bool(plugin.evaluate(runtime_case, {"steps": step_results}))
                     if not verdict:
-                        comment = "pass_criteria not satisfied"
+                        last_failure = runtime_case.get("_last_failure")
+                        if isinstance(last_failure, dict):
+                            comment = str(last_failure.get("comment") or "pass_criteria not satisfied")
+                        else:
+                            comment = "pass_criteria not satisfied"
                         failure_payload = self._dispatch_failure(
                             runtime_case=runtime_case,
                             runner=runner,

--- a/src/testpilot/core/orchestrator.py
+++ b/src/testpilot/core/orchestrator.py
@@ -58,6 +58,7 @@ from testpilot.core.testbed_config import TestbedConfig
 from testpilot.reporting.reporter import generate_reports
 from testpilot.reporting import log_capture
 from testpilot.reporting.wifi_llapi_align import (
+    AlignResult,
     _resolve_collisions,
     align_case,
     apply_alignment_mutations,
@@ -515,7 +516,30 @@ class Orchestrator:
     ) -> WifiLlapiAlignmentPrep:
         case_pairs = self._load_wifi_llapi_case_pairs(plugin=plugin, case_ids=case_ids)
         index = build_template_index(template_path)
-        align_results = [align_case(case, index, path) for path, case in case_pairs]
+        align_results: list[AlignResult] = []
+        validate_delta_schema = getattr(plugin, "_validate_delta_schema", None)
+        for path, case in case_pairs:
+            if callable(validate_delta_schema):
+                error = validate_delta_schema(case)
+                if error:
+                    source = case.get("source") if isinstance(case.get("source"), dict) else {}
+                    align_results.append(
+                        AlignResult(
+                            case_file=path,
+                            status="blocked",
+                            source_row_before=int(source.get("row", 0) or 0),
+                            source_row_after=None,
+                            source_object=str(source.get("object", "") or ""),
+                            source_api=str(source.get("api", "") or ""),
+                            filename_before=path.name,
+                            filename_after=None,
+                            id_before=str(case.get("id", "")),
+                            id_after=None,
+                            blocked_reason=f"invalid_delta_schema: {error}",
+                        )
+                    )
+                    continue
+            align_results.append(align_case(case, index, path))
         _resolve_collisions(align_results)
         apply_alignment_mutations(align_results)
         runnable_results = [

--- a/src/testpilot/reporting/wifi_llapi_align.py
+++ b/src/testpilot/reporting/wifi_llapi_align.py
@@ -19,12 +19,13 @@ from testpilot.reporting.wifi_llapi_excel import (
 )
 
 AlignStatus = Literal["already_aligned", "auto_aligned", "blocked", "skipped"]
-BlockedReason = Literal[
+KnownBlockedReason = Literal[
     "object_api_not_in_template",
     "name_points_to_different_row",
     "name_not_in_template",
     "ambiguous_object_api_family",
 ]
+BlockedReason = KnownBlockedReason | str
 
 _ID_D_PATTERN = re.compile(r"(wifi-llapi-D)(\d{3})(-)")
 _FILE_D_PATTERN = re.compile(r"^D(?P<row>\d{3})(?P<suffix>.*)$")

--- a/src/testpilot/reporting/wifi_llapi_excel.py
+++ b/src/testpilot/reporting/wifi_llapi_excel.py
@@ -26,7 +26,7 @@ from testpilot.reporting.excel_adapter import (
 
 DEFAULT_SHEET_NAME = "Wifi_LLAPI"
 DEFAULT_TEMPLATE_NAME = "wifi_llapi_template.xlsx"
-DEFAULT_TEMPLATE_MAX_COLUMN = "L"
+DEFAULT_TEMPLATE_MAX_COLUMN = "M"
 RESULT_GROUP_HEADER = "Result"
 RESULT_HEADERS_BY_COLUMN = {
     "I": "WiFi 5G",
@@ -34,6 +34,7 @@ RESULT_HEADERS_BY_COLUMN = {
     "K": "WiFi 2.4G",
 }
 TESTER_HEADER = "Tester"
+COMMENT_HEADER = "Comment"
 DEFAULT_CLEAR_COLUMNS = (
     "G",   # Test steps
     "H",   # Driver-level verified command output
@@ -41,6 +42,7 @@ DEFAULT_CLEAR_COLUMNS = (
     "J",   # ARC 6g result
     "K",   # ARC 2.4g result
     "L",   # ARC tester
+    "M",   # Reporter comment
 )
 DATA_START_ROW = 4
 EMPTY_STREAK_STOP = 200
@@ -302,7 +304,7 @@ def _set_cell_value_safe(ws, row: int, col: str, value: str) -> None:
 
 
 def _normalize_template_headers(ws) -> None:
-    """Normalize Wifi_LLAPI result/tester header semantics for columns I~L."""
+    """Normalize Wifi_LLAPI result/tester header semantics for columns I~M."""
     for merged in list(ws.merged_cells.ranges):
         if merged.max_row < 2 or merged.min_row > 2:
             continue
@@ -317,6 +319,16 @@ def _normalize_template_headers(ws) -> None:
     ws.cell(row=3, column=10).value = RESULT_HEADERS_BY_COLUMN["J"]
     ws.cell(row=3, column=11).value = RESULT_HEADERS_BY_COLUMN["K"]
     ws.cell(row=3, column=12).value = TESTER_HEADER
+    ws.cell(row=3, column=13).value = COMMENT_HEADER
+
+
+def _truncate_comment(text: str | None, limit: int = 200) -> str:
+    if not text:
+        return ""
+    value = str(text)
+    if len(value) <= limit:
+        return value
+    return value[: max(limit - 3, 0)] + "..."
 
 
 def build_template_from_source(
@@ -326,7 +338,7 @@ def build_template_from_source(
     sheet_name: str = DEFAULT_SHEET_NAME,
     clear_rules: ClearRules | None = None,
 ) -> TemplateBuildResult:
-    """Extract wifi_LLAPI sheet as template, keep A~L columns, and clear runtime fields."""
+    """Extract wifi_LLAPI sheet as template, keep A~M columns, and clear runtime fields."""
     rules = clear_rules or ClearRules()
     source = Path(source_xlsx)
     out_path = Path(out_template_xlsx)
@@ -343,7 +355,7 @@ def build_template_from_source(
     wb.active = 0
     ws = wb[actual_sheet_name]
 
-    # Keep template schema stable: only columns A~L are preserved.
+    # Keep template schema stable: only columns A~M are preserved.
     template_max_col_idx = _to_col_idx(DEFAULT_TEMPLATE_MAX_COLUMN)
     _trim_sheet_to_max_column(ws, template_max_col_idx)
     _normalize_template_headers(ws)
@@ -452,6 +464,7 @@ def fill_case_results(
         _set_cell_value_safe(ws, row, "J", item.result_6g)
         _set_cell_value_safe(ws, row, "K", item.result_24g)
         _set_cell_value_safe(ws, row, "L", item.tester)
+        _set_cell_value_safe(ws, row, "M", _truncate_comment(item.comment))
 
     wb.save(path)
     wb.close()
@@ -584,6 +597,8 @@ def collect_alignment_issues(
 
 
 def _clear_result_row(ws, row: int) -> None:
+    # Column M is reserved for evaluate-failure comments, so BLOCKED/SKIP
+    # marker flows intentionally clear only G~L and leave M unchanged.
     for column in ("G", "H", "I", "J", "K", "L"):
         _set_cell_value_safe(ws, row, column, None)
 

--- a/tests/fixtures/wifi_llapi_delta/delta_invalid_blocked.yaml
+++ b/tests/fixtures/wifi_llapi_delta/delta_invalid_blocked.yaml
@@ -1,0 +1,33 @@
+id: wifi-llapi-delta-invalid-blocked
+name: blocked invalid delta schema
+version: "1.0"
+source:
+  row: 7
+  object: "WiFi.SSID.{i}.Stats."
+  api: "BlockedInvalid"
+bands:
+  - 5g
+llapi_support: Support
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+steps:
+  - id: baseline
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.4.Stats.BlockedInvalid?"'
+    capture: baseline_stats
+  - id: verify
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.4.Stats.BlockedInvalid?"'
+    capture: verify_stats
+pass_criteria:
+  - delta:
+      baseline: baseline_stats.BlockedInvalid
+      verify: verify_stats.BlockedInvalid
+    operator: delta_nonzero

--- a/tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml
+++ b/tests/fixtures/wifi_llapi_delta/delta_match_pass.yaml
@@ -1,0 +1,54 @@
+id: wifi-llapi-delta-match-pass
+name: PacketsSent
+version: "1.0"
+source:
+  row: 6
+  object: "WiFi.SSID.{i}.Stats."
+  api: "PacketsSent"
+bands:
+  - 2.4g
+llapi_support: Support
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+steps:
+  - id: baseline_api
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"'
+    capture: baseline_api
+  - id: baseline_drv
+    action: exec
+    target: DUT
+    phase: baseline
+    command: "wl -i wl2 counters | grep '^pkt:'"
+    capture: baseline_drv
+  - id: trigger_traffic
+    action: exec
+    target: DUT
+    phase: trigger
+    command: "echo traffic-24g"
+  - id: verify_api
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.8.Stats.PacketsSentVerify?"'
+    capture: verify_api
+  - id: verify_drv
+    action: exec
+    target: DUT
+    phase: verify
+    command: "wl -i wl2 counters | grep '^pkt:verify'"
+    capture: verify_drv
+pass_criteria:
+  - delta:
+      baseline: baseline_api.PacketsSent
+      verify: verify_api.PacketsSent
+    reference_delta:
+      baseline: baseline_drv.DriverPacketsSent
+      verify: verify_drv.DriverPacketsSent
+    operator: delta_match
+    tolerance_pct: 10

--- a/tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml
+++ b/tests/fixtures/wifi_llapi_delta/delta_nonzero_fail.yaml
@@ -1,0 +1,38 @@
+id: wifi-llapi-delta-nonzero-fail
+name: BytesReceived
+version: "1.0"
+source:
+  row: 5
+  object: "WiFi.SSID.{i}.Stats."
+  api: "BytesReceived"
+bands:
+  - 6g
+llapi_support: Support
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+steps:
+  - id: baseline_api
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.6.Stats.BytesReceived?"'
+    capture: baseline_api
+  - id: trigger_traffic
+    action: exec
+    target: DUT
+    phase: trigger
+    command: "echo traffic-6g"
+  - id: verify_api
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.6.Stats.BytesReceivedVerify?"'
+    capture: verify_api
+pass_criteria:
+  - delta:
+      baseline: baseline_api.BytesReceived
+      verify: verify_api.BytesReceived
+    operator: delta_nonzero

--- a/tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml
+++ b/tests/fixtures/wifi_llapi_delta/delta_nonzero_pass.yaml
@@ -1,0 +1,38 @@
+id: wifi-llapi-delta-nonzero-pass
+name: BytesSent
+version: "1.0"
+source:
+  row: 4
+  object: "WiFi.SSID.{i}.Stats."
+  api: "BytesSent"
+bands:
+  - 5g
+llapi_support: Support
+topology:
+  devices:
+    DUT:
+      role: ap
+      transport: serial
+steps:
+  - id: baseline_api
+    action: exec
+    target: DUT
+    phase: baseline
+    command: 'ubus-cli "WiFi.SSID.4.Stats.BytesSent?"'
+    capture: baseline_api
+  - id: trigger_traffic
+    action: exec
+    target: DUT
+    phase: trigger
+    command: "echo traffic-5g"
+  - id: verify_api
+    action: exec
+    target: DUT
+    phase: verify
+    command: 'ubus-cli "WiFi.SSID.4.Stats.BytesSentVerify?"'
+    capture: verify_api
+pass_criteria:
+  - delta:
+      baseline: baseline_api.BytesSent
+      verify: verify_api.BytesSent
+    operator: delta_nonzero

--- a/tests/test_wifi_llapi_delta.py
+++ b/tests/test_wifi_llapi_delta.py
@@ -1,0 +1,692 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from testpilot.core.orchestrator import Orchestrator
+from testpilot.core.plugin_loader import PluginLoader
+from testpilot.reporting.wifi_llapi_align import AlignResult
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_plugin() -> Any:
+    loader = PluginLoader(ROOT / "plugins")
+    return loader.load("wifi_llapi")
+
+
+Plugin = _load_plugin().__class__
+ZERO_DELTA_COMMENT = "fail 原因為 0，數值無變化"
+DELTA_NOT_NUMERIC_COMMENT = "fail 原因為 delta 端點非數值"
+
+
+def _case(*, criteria: list[dict[str, Any]], steps: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "id": "D999",
+        "name": "delta test",
+        "steps": steps
+        or [
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "trigger", "phase": "trigger"},
+            {"id": "verify", "phase": "verify"},
+        ],
+        "pass_criteria": criteria,
+    }
+
+
+def _results(step_values: dict[str, Any]) -> dict[str, Any]:
+    steps: dict[str, Any] = {}
+    for step_id, value in step_values.items():
+        item = {"success": True, "output": ""}
+        if value is not None:
+            item["captured"] = {"value": value}
+        steps[step_id] = item
+    return {"steps": steps}
+
+
+def _delta_nonzero_case(*, baseline_path: str = "baseline.captured.value", verify_path: str = "verify.captured.value") -> dict[str, Any]:
+    return _case(
+        criteria=[
+            {
+                "delta": {"baseline": baseline_path, "verify": verify_path},
+                "operator": "delta_nonzero",
+            }
+        ]
+    )
+
+
+def _delta_match_case(*, tolerance_pct: int | None = None) -> dict[str, Any]:
+    criterion: dict[str, Any] = {
+        "delta": {
+            "baseline": "baseline_api.captured.value",
+            "verify": "verify_api.captured.value",
+        },
+        "reference_delta": {
+            "baseline": "baseline_drv.captured.value",
+            "verify": "verify_drv.captured.value",
+        },
+        "operator": "delta_match",
+    }
+    if tolerance_pct is not None:
+        criterion["tolerance_pct"] = tolerance_pct
+    return _case(
+        criteria=[criterion],
+        steps=[
+            {"id": "baseline_api", "phase": "baseline"},
+            {"id": "baseline_drv", "phase": "baseline"},
+            {"id": "trigger", "phase": "trigger"},
+            {"id": "verify_api", "phase": "verify"},
+            {"id": "verify_drv", "phase": "verify"},
+        ],
+    )
+
+
+def test_delta_nonzero_pass() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "42"})) is True
+    assert "_last_failure" not in case
+
+
+def test_delta_nonzero_fail_zero() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "10"})) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+    assert case["_last_failure"]["comment"] == ZERO_DELTA_COMMENT
+
+
+def test_delta_nonzero_fail_negative() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "5"})) is False
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+    assert case["_last_failure"]["comment"] == ZERO_DELTA_COMMENT
+
+
+def test_delta_nonzero_baseline_missing() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case(baseline_path="missing.captured.value")
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "42"})) is False
+    assert case["_last_failure"]["reason_code"] == "delta_value_not_numeric"
+    assert case["_last_failure"]["comment"] == DELTA_NOT_NUMERIC_COMMENT
+
+
+def test_delta_nonzero_non_numeric() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "N/A"})) is False
+    assert case["_last_failure"]["reason_code"] == "delta_value_not_numeric"
+    assert case["_last_failure"]["comment"] == DELTA_NOT_NUMERIC_COMMENT
+
+
+def test_delta_match_pass_within_tolerance() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "100",
+                    "verify_drv": "109",
+                }
+            ),
+        )
+        is True
+    )
+
+
+def test_delta_match_pass_exact_match() -> None:
+    plugin = Plugin()
+    case = _delta_match_case()
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "100",
+                    "verify_drv": "100",
+                }
+            ),
+        )
+        is True
+    )
+
+
+def test_delta_match_fail_exceed_tolerance() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "100",
+                    "verify_drv": "120",
+                }
+            ),
+        )
+        is False
+    )
+    assert case["_last_failure"]["reason_code"] == "delta_mismatch"
+    assert case["_last_failure"]["comment"] == "fail 原因為 delta 不一致：api=100 drv=120 tol=10%"
+
+
+def test_delta_match_fail_one_side_zero() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "100",
+                    "verify_drv": "0",
+                }
+            ),
+        )
+        is False
+    )
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+    assert case["_last_failure"]["comment"] == ZERO_DELTA_COMMENT
+
+
+def test_delta_match_fail_both_zero() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "0",
+                    "verify_drv": "0",
+                }
+            ),
+        )
+        is False
+    )
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+    assert case["_last_failure"]["comment"] == ZERO_DELTA_COMMENT
+
+
+def test_delta_match_fail_negative_either_side() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "10",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "5",
+                    "verify_drv": "100",
+                }
+            ),
+        )
+        is False
+    )
+    assert case["_last_failure"]["reason_code"] == "delta_zero_side"
+    assert case["_last_failure"]["comment"] == ZERO_DELTA_COMMENT
+
+
+def test_delta_match_tolerance_boundary() -> None:
+    plugin = Plugin()
+    case = _delta_match_case(tolerance_pct=10)
+
+    assert (
+        plugin.evaluate(
+            case,
+            _results(
+                {
+                    "baseline_api": "0",
+                    "baseline_drv": "0",
+                    "trigger": None,
+                    "verify_api": "100",
+                    "verify_drv": "110",
+                }
+            ),
+        )
+        is True
+    )
+
+
+def test_phase_ok_baseline_trigger_verify() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    assert plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_no_delta_skip_check() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"field": "verify.captured.value", "operator": "equals", "value": "ok"}],
+        steps=[
+            {"id": "s1", "phase": "warmup"},
+            {"id": "s2", "phase": "baseline"},
+        ],
+    )
+
+    assert plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_missing_trigger() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "verify", "phase": "verify"},
+        ],
+    )
+
+    assert plugin._validate_phase_ordering(case) == "delta_* operators require at least one phase=trigger step"
+
+
+def test_phase_baseline_after_trigger() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "trigger", "phase": "trigger"},
+            {"id": "baseline2", "phase": "baseline"},
+            {"id": "verify", "phase": "verify"},
+        ],
+    )
+
+    assert "baseline step must precede trigger" in plugin._validate_phase_ordering(case)
+
+
+def test_phase_verify_before_trigger() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "verify", "phase": "verify"},
+            {"id": "trigger", "phase": "trigger"},
+        ],
+    )
+
+    assert "verify step must follow trigger" in plugin._validate_phase_ordering(case)
+
+
+def test_phase_trigger_after_verify() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "trigger", "phase": "trigger"},
+            {"id": "verify", "phase": "verify"},
+            {"id": "trigger2", "phase": "trigger"},
+        ],
+    )
+
+    assert plugin._validate_phase_ordering(case) == "trigger step must precede verify"
+
+
+def test_phase_default_unmarked_is_verify() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "trigger", "phase": "trigger"},
+            {"id": "verify"},
+        ],
+    )
+
+    assert plugin._validate_phase_ordering(case) is None
+
+
+def test_phase_invalid_value() -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+    case["steps"][0]["phase"] = "warmup"
+
+    assert plugin._validate_phase_ordering(case) == "unknown phase: warmup"
+
+
+@pytest.mark.parametrize(
+    ("criterion", "expected"),
+    [
+        (
+            {"delta": {}, "operator": "delta_nonzero"},
+            "delta must be a mapping with non-empty baseline/verify",
+        ),
+        (
+            {"delta": "baseline.captured.value", "operator": "delta_nonzero"},
+            "delta must be a mapping with non-empty baseline/verify",
+        ),
+        (
+            {"delta": {"baseline": "baseline.captured.value"}, "operator": "delta_nonzero"},
+            "delta.verify must be a non-empty string",
+        ),
+        (
+            {"delta": {"baseline": "", "verify": "verify.captured.value"}, "operator": "delta_nonzero"},
+            "delta.baseline must be a non-empty string",
+        ),
+        (
+            {
+                "delta": {"baseline": "baseline_api.captured.value", "verify": "verify_api.captured.value"},
+                "operator": "delta_match",
+            },
+            "reference_delta must be a mapping with non-empty baseline/verify",
+        ),
+        (
+            {
+                "delta": {"baseline": "baseline_api.captured.value", "verify": "verify_api.captured.value"},
+                "reference_delta": "baseline_drv.captured.value",
+                "operator": "delta_match",
+            },
+            "reference_delta must be a mapping with non-empty baseline/verify",
+        ),
+        (
+            {
+                "delta": {"baseline": "baseline_api.captured.value", "verify": "verify_api.captured.value"},
+                "reference_delta": {"baseline": "baseline_drv.captured.value"},
+                "operator": "delta_match",
+            },
+            "reference_delta.verify must be a non-empty string",
+        ),
+    ],
+)
+def test_validate_delta_schema_rejects_malformed_structures(
+    criterion: dict[str, Any],
+    expected: str,
+) -> None:
+    plugin = Plugin()
+    case = _case(criteria=[criterion])
+
+    assert plugin._validate_delta_schema(case) == expected
+
+
+def test_evaluate_field_path_unchanged() -> None:
+    plugin = Plugin()
+    case = _case(criteria=[{"field": "verify.captured.value", "operator": "equals", "value": "expected"}])
+
+    assert plugin.evaluate(case, _results({"baseline": None, "trigger": None, "verify": "actual"})) is False
+    assert case["_last_failure"]["reason_code"] == "pass_criteria_not_satisfied"
+    assert case["_last_failure"]["comment"] == "pass_criteria not satisfied"
+
+
+def test_evaluate_delta_path_picks_new_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = Plugin()
+    case = _delta_nonzero_case()
+
+    monkeypatch.setattr(plugin, "_compare", lambda *args, **kwargs: pytest.fail("_compare should not run for delta criteria"))
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "42"})) is True
+
+
+def test_evaluate_mixed_criteria(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[
+            {"field": "verify.captured.value", "operator": "equals", "value": "100"},
+            {
+                "delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"},
+                "operator": "delta_nonzero",
+            },
+            {"field": "verify.captured.value", "operator": "equals", "value": "never"},
+        ]
+    )
+    calls: list[str] = []
+    original = plugin._evaluate_delta_criterion
+
+    def _spy(case_data: dict[str, Any], context: dict[str, Any], criterion: dict[str, Any], idx: int) -> bool:
+        calls.append(f"delta:{idx}")
+        return original(case_data, context, criterion, idx)
+
+    monkeypatch.setattr(plugin, "_evaluate_delta_criterion", _spy)
+
+    assert plugin.evaluate(case, _results({"baseline": "100", "trigger": None, "verify": "100"})) is False
+    assert calls == ["delta:1"]
+    assert case["_last_failure"]["reason_code"] == "delta_zero"
+
+
+def test_unknown_delta_operator_cannot_pass() -> None:
+    plugin = Plugin()
+    case = _case(
+        criteria=[
+            {
+                "delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"},
+                "operator": "delta_surprise",
+            }
+        ]
+    )
+
+    assert plugin.evaluate(case, _results({"baseline": "10", "trigger": None, "verify": "42"})) is False
+    assert case["_last_failure"]["reason_code"] == "invalid_delta_operator"
+
+
+def test_invalid_delta_schema_marks_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    valid = _delta_nonzero_case()
+    valid["id"] = "D-valid"
+    invalid = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "verify", "phase": "verify"},
+        ],
+    )
+    invalid["id"] = "D-invalid"
+
+    monkeypatch.setitem(Plugin.discover_cases.__globals__, "load_cases_dir", lambda *args, **kwargs: [valid, invalid])
+
+    cases = {case["id"]: case for case in Plugin().discover_cases()}
+
+    assert set(cases) == {"D-valid", "D-invalid"}
+    assert cases["D-valid"].get("blocked_reason") is None
+    assert cases["D-invalid"]["llapi_support"] == "Blocked"
+    assert cases["D-invalid"]["blocked_reason"] == "invalid_delta_schema: delta_* operators require at least one phase=trigger step"
+
+
+def test_runtime_prep_blocks_invalid_delta_schema_before_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _load_plugin()
+    orch = object.__new__(Orchestrator)
+    valid_path = tmp_path / "D001_valid.yaml"
+    invalid_path = tmp_path / "D002_invalid.yaml"
+    valid = _delta_nonzero_case()
+    valid["id"] = "D-valid"
+    valid["source"] = {"row": 1, "object": "Device.WiFi.", "api": "Valid()"}
+    invalid = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value", "verify": "verify.captured.value"}, "operator": "delta_nonzero"}],
+        steps=[
+            {"id": "baseline", "phase": "baseline"},
+            {"id": "verify", "phase": "verify"},
+        ],
+    )
+    invalid["id"] = "D-invalid"
+    invalid["source"] = {"row": 2, "object": "Device.WiFi.", "api": "Invalid()"}
+    seen_align_ids: list[str] = []
+    loaded_cases = {valid_path: {"id": "D-valid-loaded"}}
+
+    monkeypatch.setattr(
+        orch,
+        "_load_wifi_llapi_case_pairs",
+        lambda **kwargs: [(valid_path, valid), (invalid_path, invalid)],
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "build_template_index",
+        lambda template_path: object(),
+    )
+
+    def fake_align_case(case: dict[str, Any], index: object, path: Path) -> AlignResult:
+        seen_align_ids.append(case["id"])
+        return AlignResult(
+            case_file=path,
+            status="already_aligned",
+            source_row_before=int(case["source"]["row"]),
+            source_row_after=int(case["source"]["row"]),
+            source_object=str(case["source"]["object"]),
+            source_api=str(case["source"]["api"]),
+            filename_before=path.name,
+            filename_after=None,
+            id_before=str(case["id"]),
+            id_after=None,
+        )
+
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "align_case",
+        fake_align_case,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "_resolve_collisions",
+        lambda results: None,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "apply_alignment_mutations",
+        lambda results: None,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "load_case",
+        lambda path, validator=None: loaded_cases[path],
+    )
+
+    prep = orch._prepare_wifi_llapi_alignment(
+        plugin=plugin,
+        case_ids=None,
+        template_path=tmp_path / "wifi_llapi_template.xlsx",
+    )
+
+    assert seen_align_ids == ["D-valid"]
+    assert prep.runnable_cases == [{"id": "D-valid-loaded"}]
+    assert len(prep.blocked_results) == 1
+    assert prep.blocked_results[0].id_before == "D-invalid"
+    assert (
+        prep.blocked_results[0].blocked_reason
+        == "invalid_delta_schema: delta_* operators require at least one phase=trigger step"
+    )
+    assert prep.alignment_summary["blocked"] == 1
+    assert prep.alignment_summary["blocked_details"] == [
+        {
+            "case_id": "D-invalid",
+            "reason": "invalid_delta_schema: delta_* operators require at least one phase=trigger step",
+            "candidate_template_rows": [],
+        }
+    ]
+
+
+def test_runtime_prep_blocks_malformed_delta_schema_before_alignment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _load_plugin()
+    orch = object.__new__(Orchestrator)
+    valid_path = tmp_path / "D001_valid.yaml"
+    invalid_path = tmp_path / "D002_invalid.yaml"
+    valid = _delta_nonzero_case()
+    valid["id"] = "D-valid"
+    valid["source"] = {"row": 1, "object": "Device.WiFi.", "api": "Valid()"}
+    invalid = _case(
+        criteria=[{"delta": {"baseline": "baseline.captured.value"}, "operator": "delta_nonzero"}],
+    )
+    invalid["id"] = "D-invalid"
+    invalid["source"] = {"row": 2, "object": "Device.WiFi.", "api": "Invalid()"}
+    seen_align_ids: list[str] = []
+    loaded_cases = {valid_path: {"id": "D-valid-loaded"}}
+
+    monkeypatch.setattr(
+        orch,
+        "_load_wifi_llapi_case_pairs",
+        lambda **kwargs: [(valid_path, valid), (invalid_path, invalid)],
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "build_template_index",
+        lambda template_path: object(),
+    )
+
+    def fake_align_case(case: dict[str, Any], index: object, path: Path) -> AlignResult:
+        seen_align_ids.append(case["id"])
+        return AlignResult(
+            case_file=path,
+            status="already_aligned",
+            source_row_before=int(case["source"]["row"]),
+            source_row_after=int(case["source"]["row"]),
+            source_object=str(case["source"]["object"]),
+            source_api=str(case["source"]["api"]),
+            filename_before=path.name,
+            filename_after=None,
+            id_before=str(case["id"]),
+            id_after=None,
+        )
+
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "align_case",
+        fake_align_case,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "_resolve_collisions",
+        lambda results: None,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "apply_alignment_mutations",
+        lambda results: None,
+    )
+    monkeypatch.setitem(
+        Orchestrator._prepare_wifi_llapi_alignment.__globals__,
+        "load_case",
+        lambda path, validator=None: loaded_cases[path],
+    )
+
+    prep = orch._prepare_wifi_llapi_alignment(
+        plugin=plugin,
+        case_ids=None,
+        template_path=tmp_path / "wifi_llapi_template.xlsx",
+    )
+
+    assert seen_align_ids == ["D-valid"]
+    assert prep.runnable_cases == [{"id": "D-valid-loaded"}]
+    assert len(prep.blocked_results) == 1
+    assert prep.blocked_results[0].id_before == "D-invalid"
+    assert (
+        prep.blocked_results[0].blocked_reason
+        == "invalid_delta_schema: delta.verify must be a non-empty string"
+    )

--- a/tests/test_wifi_llapi_delta_integration.py
+++ b/tests/test_wifi_llapi_delta_integration.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+for extra_path in (ROOT / 'src', ROOT / 'plugins' / 'wifi_llapi'):
+    extra = str(extra_path)
+    if extra not in sys.path:
+        sys.path.insert(0, extra)
+
+from openpyxl import Workbook, load_workbook
+import pytest
+
+from testpilot.core.orchestrator import Orchestrator
+from testpilot.reporting.wifi_llapi_excel import ensure_template_report
+
+FIXTURE_DIR = ROOT / 'tests' / 'fixtures' / 'wifi_llapi_delta'
+ZERO_DELTA_COMMENT = 'fail 原因為 0，數值無變化'
+CASE_IDS = [
+    'wifi-llapi-delta-nonzero-pass',
+    'wifi-llapi-delta-nonzero-fail',
+    'wifi-llapi-delta-match-pass',
+]
+CASE_OUTPUTS = {
+    'wifi-llapi-delta-nonzero-pass': {
+        'ubus-cli "WiFi.SSID.4.Stats.BytesSent?"': 'BytesSent=100',
+        'echo traffic-5g': 'traffic-5g',
+        'ubus-cli "WiFi.SSID.4.Stats.BytesSentVerify?"': 'BytesSent=132',
+    },
+    'wifi-llapi-delta-nonzero-fail': {
+        'ubus-cli "WiFi.SSID.6.Stats.BytesReceived?"': 'BytesReceived=88',
+        'echo traffic-6g': 'traffic-6g',
+        'ubus-cli "WiFi.SSID.6.Stats.BytesReceivedVerify?"': 'BytesReceived=88',
+    },
+    'wifi-llapi-delta-match-pass': {
+        'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"': 'PacketsSent=10',
+        "wl -i wl2 counters | grep '^pkt:'": 'DriverPacketsSent=20',
+        'echo traffic-24g': 'traffic-24g',
+        'ubus-cli "WiFi.SSID.8.Stats.PacketsSentVerify?"': 'PacketsSent=40',
+        "wl -i wl2 counters | grep '^pkt:verify'": 'DriverPacketsSent=53',
+    },
+}
+
+
+class MockTransport:
+    def __init__(self, outputs: dict[str, str]) -> None:
+        self.outputs = outputs
+        self.history: list[str] = []
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def connect(self) -> None:
+        self._connected = True
+
+    def disconnect(self) -> None:
+        self._connected = False
+
+    def execute(self, command: str, timeout: float = 30.0) -> dict[str, Any]:
+        self.history.append(command)
+        return {
+            'returncode': 0,
+            'stdout': self.outputs.get(command, ''),
+            'stderr': '',
+            'elapsed': 0.01,
+        }
+
+
+def _write_testbed_yaml(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '\n'.join(
+            [
+                'testbed:',
+                '  name: delta-integration-testbed',
+                '  serialwrap_binary: ./serialwrap-stub',
+                '  devices:',
+                '    DUT:',
+                '      role: ap',
+                '      transport: serial',
+            ]
+        )
+        + '\n',
+        encoding='utf-8',
+    )
+
+
+def _write_source_xlsx(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = 'Wifi_LLAPI'
+    ws['A2'] = 'Object'
+    ws['C2'] = 'Parameter Name'
+    ws['G2'] = 'Test steps'
+    ws['H2'] = 'Command Output'
+    ws['I2'] = 'ARC 4.0.3 Test Result\nWiFi 5g'
+    ws['J2'] = 'ARC 4.0.3 Test Result\nWiFi 6g'
+    ws['K2'] = 'ARC 4.0.3 Test Result\nWiFi 2.4g'
+    ws['L2'] = 'Tester'
+    ws['M2'] = 'ARC Comment'
+    ws['A4'] = 'WiFi.SSID.{i}.Stats.'
+    ws['C4'] = 'BytesSent'
+    ws['A5'] = 'WiFi.SSID.{i}.Stats.'
+    ws['C5'] = 'BytesReceived'
+    ws['A6'] = 'WiFi.SSID.{i}.Stats.'
+    ws['C6'] = 'PacketsSent'
+    ws['A7'] = 'WiFi.SSID.{i}.Stats.'
+    ws['C7'] = 'BlockedInvalid'
+    wb.save(path)
+    wb.close()
+
+
+def _prepare_runtime_project(tmp_path: Path) -> Path:
+    project_root = tmp_path / 'project'
+    plugin_dir = project_root / 'plugins' / 'wifi_llapi'
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+
+    source_plugin_dir = ROOT / 'plugins' / 'wifi_llapi'
+    for name in (
+        'plugin.py',
+        'command_resolver.py',
+        'baseline_qualifier.py',
+        'agent-config.yaml',
+        'band-baselines.yaml',
+    ):
+        shutil.copy2(source_plugin_dir / name, plugin_dir / name)
+
+    _write_testbed_yaml(project_root / 'configs' / 'testbed.yaml')
+    source_xlsx = project_root / 'source.xlsx'
+    _write_source_xlsx(source_xlsx)
+    ensure_template_report(
+        source_xlsx=source_xlsx,
+        template_path=plugin_dir / 'reports' / 'templates' / 'wifi_llapi_template.xlsx',
+        manifest_path=plugin_dir / 'reports' / 'templates' / 'wifi_llapi_template.manifest.json',
+    )
+    return project_root
+
+
+def _stage_cases(project_root: Path, names: list[str]) -> Path:
+    cases_dir = project_root / 'plugins' / 'wifi_llapi' / 'cases'
+    cases_dir.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        shutil.copy2(FIXTURE_DIR / name, cases_dir / name)
+    return cases_dir
+
+
+def _patch_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    orch: Orchestrator,
+) -> dict[str, MockTransport]:
+    plugin = orch.loader.load('wifi_llapi')
+    transports: dict[str, MockTransport] = {}
+
+    def setup_env(case: dict[str, Any], topology: Any) -> bool:
+        case_id = str(case.get('id', ''))
+        transport = MockTransport(CASE_OUTPUTS[case_id])
+        transport.connect()
+        transports[case_id] = transport
+        plugin._transports = {'DUT': transport}
+        return True
+
+    def verify_env(case: dict[str, Any], topology: Any) -> bool:
+        return True
+
+    def teardown(case: dict[str, Any], topology: Any) -> None:
+        transport = plugin._transports.get('DUT')
+        if transport is not None:
+            transport.disconnect()
+        plugin._transports.clear()
+
+    monkeypatch.setattr(plugin, 'setup_env', setup_env)
+    monkeypatch.setattr(plugin, 'verify_env', verify_env)
+    monkeypatch.setattr(plugin, 'teardown', teardown)
+    monkeypatch.setattr(orch, '_start_serialwrap_for_run', lambda: None)
+    monkeypatch.setattr(
+        orch,
+        '_export_serialwrap_logs',
+        lambda **kwargs: {},
+    )
+    monkeypatch.setattr(orch, '_stop_serialwrap', lambda: None)
+    monkeypatch.setattr(orch.runner_selector, 'load_agent_config', lambda plugin_name: {})
+    monkeypatch.setattr(
+        orch.runner_selector,
+        'build_execution_policy',
+        lambda agent_config: {
+            'retry': {'max_attempts': 1},
+            'failure_policy': 'retry_then_fail_and_continue',
+            'timeout': {
+                'base_seconds': 1,
+                'per_step_seconds': 0,
+                'retry_multiplier': 1,
+                'max_seconds': 1,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        orch.runner_selector,
+        'select_case_runner',
+        lambda plugin_name, case, agent_config: (
+            {'provider': 'stub', 'model': 'test', 'reasoning_effort': 'low'},
+            {'selected': {'provider': 'stub', 'model': 'test'}},
+        ),
+    )
+    return transports
+
+
+def _report_snapshot(report_path: Path) -> dict[int, dict[str, Any]]:
+    wb = load_workbook(report_path)
+    ws = wb['Wifi_LLAPI']
+    snapshot = {
+        row: {
+            column: (ws[f'{column}{row}'].value or '')
+            for column in ('G', 'H', 'I', 'J', 'K', 'M')
+        }
+        for row in (4, 5, 6)
+    }
+    wb.close()
+    return snapshot
+
+
+def test_delta_runtime_and_report_integration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project_root = _prepare_runtime_project(tmp_path)
+    _stage_cases(
+        project_root,
+        [
+            'delta_nonzero_pass.yaml',
+            'delta_nonzero_fail.yaml',
+            'delta_match_pass.yaml',
+        ],
+    )
+    orch = Orchestrator(
+        project_root=project_root,
+        plugins_dir=project_root / 'plugins',
+        config_path=project_root / 'configs' / 'testbed.yaml',
+    )
+    transports = _patch_runtime(monkeypatch, orch)
+
+    result = orch.run('wifi_llapi', case_ids=CASE_IDS, dut_fw_ver='FW-DELTA-IT-1')
+    snapshot = _report_snapshot(Path(result['report_path']))
+
+    assert result['cases_count'] == 3
+    assert result['pass_count'] == 2
+    assert result['fail_count'] == 1
+
+    assert snapshot[4] == {
+        'G': 'ubus-cli "WiFi.SSID.4.Stats.BytesSent?"\necho traffic-5g\nubus-cli "WiFi.SSID.4.Stats.BytesSentVerify?"',
+        'H': 'BytesSent=100\ntraffic-5g\nBytesSent=132',
+        'I': 'Pass',
+        'J': 'N/A',
+        'K': 'N/A',
+        'M': '',
+    }
+    assert snapshot[5] == {
+        'G': 'ubus-cli "WiFi.SSID.6.Stats.BytesReceived?"\necho traffic-6g\nubus-cli "WiFi.SSID.6.Stats.BytesReceivedVerify?"',
+        'H': 'BytesReceived=88\ntraffic-6g\nBytesReceived=88',
+        'I': 'N/A',
+        'J': 'Fail',
+        'K': 'N/A',
+        'M': ZERO_DELTA_COMMENT,
+    }
+    assert snapshot[6] == {
+        'G': (
+            'ubus-cli "WiFi.SSID.8.Stats.PacketsSent?"\n'
+            "wl -i wl2 counters | grep '^pkt:'\n"
+            'echo traffic-24g\n'
+            'ubus-cli "WiFi.SSID.8.Stats.PacketsSentVerify?"\n'
+            "wl -i wl2 counters | grep '^pkt:verify'"
+        ),
+        'H': 'PacketsSent=10\nDriverPacketsSent=20\ntraffic-24g\nPacketsSent=40\nDriverPacketsSent=53',
+        'I': 'N/A',
+        'J': 'N/A',
+        'K': 'Pass',
+        'M': '',
+    }
+    assert transports['wifi-llapi-delta-nonzero-pass'].history == [
+        'ubus-cli "WiFi.SSID.4.Stats.BytesSent?"',
+        'echo traffic-5g',
+        'ubus-cli "WiFi.SSID.4.Stats.BytesSentVerify?"',
+    ]
+
+
+def test_invalid_delta_schema_case_is_blocked_before_execution(tmp_path: Path) -> None:
+    project_root = _prepare_runtime_project(tmp_path)
+    template_path = project_root / 'plugins' / 'wifi_llapi' / 'reports' / 'templates' / 'wifi_llapi_template.xlsx'
+    _stage_cases(
+        project_root,
+        [
+            'delta_nonzero_pass.yaml',
+            'delta_nonzero_fail.yaml',
+            'delta_match_pass.yaml',
+            'delta_invalid_blocked.yaml',
+        ],
+    )
+
+    orch = Orchestrator(
+        project_root=project_root,
+        plugins_dir=project_root / 'plugins',
+        config_path=project_root / 'configs' / 'testbed.yaml',
+    )
+    plugin = orch.loader.load('wifi_llapi')
+    discovered_cases = sorted(plugin.discover_cases(), key=lambda case: str(case.get('id', '')))
+    blocked_case = next(case for case in discovered_cases if case['id'] == 'wifi-llapi-delta-invalid-blocked')
+
+    assert [case['id'] for case in discovered_cases] == [
+        'wifi-llapi-delta-invalid-blocked',
+        'wifi-llapi-delta-match-pass',
+        'wifi-llapi-delta-nonzero-fail',
+        'wifi-llapi-delta-nonzero-pass',
+    ]
+    assert blocked_case['llapi_support'] == 'Blocked'
+    assert blocked_case['blocked_reason'] == (
+        'invalid_delta_schema: delta_* operators require at least one phase=trigger step'
+    )
+
+    prep = orch._prepare_wifi_llapi_alignment(
+        plugin=plugin,
+        case_ids=CASE_IDS + ['wifi-llapi-delta-invalid-blocked'],
+        template_path=template_path,
+    )
+
+    assert sorted(case['id'] for case in prep.runnable_cases) == sorted(CASE_IDS)
+    assert [result.id_before for result in prep.blocked_results] == ['wifi-llapi-delta-invalid-blocked']
+    assert prep.blocked_results[0].blocked_reason == (
+        'invalid_delta_schema: delta_* operators require at least one phase=trigger step'
+    )


### PR DESCRIPTION
## Summary
- add delta-aware evaluation, invalid-delta-schema blocking, and result reason handling in `wifi_llapi`
- add Comment column M reporting plus delta unit/integration coverage and syntax reference
- migrate D037 and D313 as Wave 1 sample cases and sync OpenSpec Wave 1 task status

## Design
- `docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md`

## Sample case before/after
- `D037_retransmissions.yaml`: replace workbook-fail `equals 0` assertions with explicit baseline/trigger/verify, trigger evidence, `delta_nonzero`, and `delta_match`
- `D313_getssidstats_retranscount.yaml`: replace per-band `equals 0` snapshots with a shared multi-band trigger phase plus per-band baseline/verify `delta_nonzero` checks

## Validation
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q tests/test_wifi_llapi_delta.py tests/test_wifi_llapi_delta_integration.py tests/test_wifi_llapi_excel.py`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q`
- `openspec validate wifi-llapi-counter-delta-validation --strict`

Refs #38
