### PR TITLE
feat: 遷移 Wave 2 AssociatedDevice delta cases

### DIFF
--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -83,14 +83,14 @@
 - [x] 7.1 Confirm Wave 1 PR description includes design link and sample case before/after diff
 - [ ] 7.2 CI green on unit + integration tests
 - [x] 7.3 `pytest tests/` full suite green (no regression in existing modules)
-- [ ] 7.4 Wave 1 PR merged to main BEFORE opening any Wave 2 / Wave 3 PR
+- [x] 7.4 Wave 1 PR merged to main BEFORE opening any Wave 2 / Wave 3 PR
 
 ## 8. Wave 2 — Stage A Migration (~30 cases)
 
-- [ ] 8.1 Sub-PR `wave2-associated-device`: migrate D037, D038, D051, D052, D054
+- [x] 8.1 Sub-PR `wave2-associated-device`: migrate remaining D038, D051, D052, D054 (`D037` already completed in Wave 1)
 - [ ] 8.2 Sub-PR `wave2-getradiostats-errors-discard`: migrate D267, D268, D269, D270
 - [ ] 8.3 Sub-PR `wave2-getssidstats-errors-discard`: migrate D304, D305, D306, D307, D308
-- [ ] 8.4 Sub-PR `wave2-getssidstats-retrans-unknown`: migrate D313, D316
+- [ ] 8.4 Sub-PR `wave2-getssidstats-retrans-unknown`: migrate remaining D316 (`D313` already completed in Wave 1)
 - [ ] 8.5 Sub-PR `wave2-ssid-stats-errors-retrans`: migrate D325, D326, D327, D328, D329, D334
 - [ ] 8.6 Sub-PR `wave2-radio-stats-errors-retry-retrans`: migrate D396, D397, D398, D399, D401, D402
 - [ ] 8.7 Sub-PR `wave2-radio-stats-retry-preamble`: migrate D406, D407, D448, D451

--- a/plugins/wifi_llapi/cases/D038_rx_retransmissions.yaml
+++ b/plugins/wifi_llapi/cases/D038_rx_retransmissions.yaml
@@ -60,10 +60,10 @@ test_environment: 'Topology:
 setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
   \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
   \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
-  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ AP1/AP2 on COM0\n   - move COM0 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
   \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
-  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
-  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM0: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM1: wl -i wl0\
   \ assoclist\n"
 sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
   \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\

--- a/plugins/wifi_llapi/cases/D038_rx_retransmissions.yaml
+++ b/plugins/wifi_llapi/cases/D038_rx_retransmissions.yaml
@@ -8,8 +8,7 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: ubus-cli 
-  "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions?"
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions?"
 llapi_support: Support
 implemented_by: pWHM
 bands:
@@ -58,16 +57,17 @@ test_environment: 'Topology:
   - use the validated 5G single-band WPA3 baseline for this case
 
   '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
+  \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
+  \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
+  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ assoclist\n"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
+  \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\
+  \ WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
   \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
   \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
   \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
@@ -80,74 +80,138 @@ sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cl
   \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan\
+  \ 192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
   \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
-  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"\
-  testpilot6g\"\nieee80211w=2\nscan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant
-  -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\n\
-  STA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n\
-  \  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n\
-  DUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null\
+  \ || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0\
+  \ set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf\
+  \ 'ctrl_interface=/var/run/wpa_supplicant\nupdate_config=1\nsae_pwe=2\nnetwork={\n\
+  ssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
+  \ /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\nSTA 5G connect verify:\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
+  \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\
+  \  wl -i wl0 assoclist\n"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve the DUT br-lan
+  IPv4 address.
 
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions on DUT. The workbook
-  expects this case to fail: the LLAPI stays 0 even though driver `rx total pkts retried`
-  is non-zero for the same STA.
 
-  3) Cross-check the same STA against wl0 sta_info `rx total pkts retried`.
+  2) Capture baseline DUT LLAPI Rx_Retransmissions and the matching driver `rx total
+  pkts retried` counter for the same STA.
+
+
+  3) From the STA wl0 interface, run a best-effort large-packet ping burst toward
+  the resolved DUT bridge IP to exercise STA-to-DUT retransmission behavior.
+
+
+  4) Capture verify DUT LLAPI Rx_Retransmissions and the matching driver `rx total
+  pkts retried` counter, then compare baseline-to-verify deltas.
 
   '
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_resolve_probe_target
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp="
+    $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: dut_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions?"
-  depends_on: step1
-  capture: result
-- id: step3
+  depends_on: step2_resolve_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
     [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx total pkts
     retried: *\([0-9][0-9]*\).*/DriverRxRetransmissions=\1/p'''
-  depends_on: step2
-  capture: driver_counter
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: PROBE_OUT=$(ping -I wl0 -c 20 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf
+    '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" | awk '/packets transmitted/ {print
+    "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx total pkts
+    retried: *\([0-9][0-9]*\).*/DriverRxRetransmissions=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.Rx_Retransmissions
-  operator: equals
-  value: '0'
-  description: 'Workbook v4.0.3 marks this API as Fail: LLAPI Rx_Retransmissions still
-    reads 0.'
-- field: driver_counter.DriverAssocMac
-  operator: equals
-  reference: assoc_entry.MACAddress
-  description: Driver counter sampling must use the same live AssociatedDevice 
-    MAC resolved in step1.
-- field: driver_counter.DriverRxRetransmissions
+- field: dut_ip.DutIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The DUT br-lan interface must expose an IPv4 address for the STA-originated
+    trigger.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: Driver counters must still show real RX retransmissions for the 
-    same STA.
+  description: The STA trigger step must actually transmit an uplink burst toward
+    the resolved DUT bridge IP.
+- field: drv_before_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Baseline driver sampling must target the same live AssociatedDevice
+    MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC
+    resolved in step1.
+- delta:
+    baseline: api_before_5g.Rx_Retransmissions
+    verify: api_after_5g.Rx_Retransmissions
+  operator: delta_nonzero
+  description: 5G API Rx_Retransmissions must grow after the STA-originated trigger
+    workload.
+- delta:
+    baseline: api_before_5g.Rx_Retransmissions
+    verify: api_after_5g.Rx_Retransmissions
+  reference_delta:
+    baseline: drv_before_5g.DriverRxRetransmissions
+    verify: drv_after_5g.DriverRxRetransmissions
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API Rx_Retransmissions delta must stay within ±10% of the driver
+    delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p')
-- '[ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC'
-- '[ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx total pkts retried:
+- ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit}
+  $1=="inet" {print "DutIp=" $2; exit}'
+- ping -I wl0 -c 20 -s 1400 -W 1 <resolved DUT br-lan IPv4>
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx total pkts retried:
   *\([0-9][0-9]*\).*/DriverRxRetransmissions=\1/p'''

--- a/plugins/wifi_llapi/cases/D051_tx_retransmissions.yaml
+++ b/plugins/wifi_llapi/cases/D051_tx_retransmissions.yaml
@@ -1,25 +1,217 @@
-id: d051-blocked-tx-retransmissions
-name: D051 Tx_Retransmissions Blocked
+id: wifi-llapi-D051-tx-retransmissions
+name: Tx_Retransmissions — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
+version: '1.1'
 source:
   row: 53
   object: WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
   api: Tx_Retransmissions
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions?"
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
-llapi_support: Blocked
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
       selector: COM1
+    STA:
+      role: sta
+      transport: serial
+      selector: COM0
+      config:
+      - iface: 5g
+        mode: sta
+        ssid: TestPilot_BTM
+        key: testpilot6g
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+test_environment: 'Topology:
+
+  - DUT: COM1 (AP role)
+
+  - STA: COM0 (station role for this case; do not rely on the old A0/B0 heuristic)
+
+  Transport:
+
+  - serialwrap attach COM0 / COM1
+
+  Live band mapping:
+
+  - 5G: DUT wl0 / AP1 / SSID.4 / TestPilot_BTM
+
+  - 6G: DUT wl1 / AP3 / SSID.6 / TestPilot_BTM
+
+  - 2.4G: DUT wl2 / AP5 / SSID.8 / TestPilot_24G
+
+  Preconditions:
+
+  - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
+
+  - use the validated 5G single-band WPA3 baseline for this case
+
+  '
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
+  \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
+  \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
+  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ assoclist\n"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
+  \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\
+  \ WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
+  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
+  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
+  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
+  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
+  \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan\
+  \ 192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
+  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null\
+  \ || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0\
+  \ set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf\
+  \ 'ctrl_interface=/var/run/wpa_supplicant\nupdate_config=1\nsae_pwe=2\nnetwork={\n\
+  ssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
+  \ /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\nSTA 5G connect verify:\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
+  \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\
+  \  wl -i wl0 assoclist\n"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live wl0
+  IPv4 address.
+
+
+  2) Capture baseline DUT LLAPI Tx_Retransmissions and the matching driver `tx pkts
+  retries` counter for the same STA.
+
+
+  3) From the DUT bridge IP, run a best-effort large-packet ping burst toward the
+  resolved STA IP to exercise AP-to-STA retransmission behavior.
+
+
+  4) Capture verify DUT LLAPI Tx_Retransmissions and the matching driver `tx pkts
+  retries` counter, then compare baseline-to-verify deltas.
+
+  '
 steps:
-- id: step_5g_blocked
-  target: dut
-  action: skip
-  command: "echo blocked"
-  description: "Tx_Retransmissions — needs deterministic retry trigger"
+- id: step1_resolve_assoc
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+  capture: assoc_entry
+- id: step2_resolve_probe_target
+  phase: baseline
+  action: exec
+  target: STA
+  command: ifconfig wl0 | awk '/inet addr:/ {gsub("addr:","",$2); print "StaIp=" $2;
+    exit} $1=="inet" {print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_api_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions?"
+  depends_on: step2_resolve_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
+    *\([0-9][0-9]*\).*/DriverTxRetransmissions=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  command: PROBE_OUT=$(ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}} 2>&1); printf
+    '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" | awk '/packets transmitted/ {print
+    "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
+    *\([0-9][0-9]*\).*/DriverTxRetransmissions=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
-- field: skip
-  operator: skip
-  value: "Tx_Retransmissions — needs deterministic retry trigger"
+- field: assoc_entry.MACAddress
+  operator: regex
+  value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
+  description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The 5G STA wl0 interface must expose an IPv4 address for the DUT-originated
+    trigger.
+- field: trigger_probe.TriggerTxPackets
+  operator: '>'
+  value: '0'
+  description: The DUT trigger step must actually transmit a downlink burst toward
+    the resolved STA IP.
+- field: drv_before_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Baseline driver sampling must target the same live AssociatedDevice
+    MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC
+    resolved in step1.
+- delta:
+    baseline: api_before_5g.Tx_Retransmissions
+    verify: api_after_5g.Tx_Retransmissions
+  operator: delta_nonzero
+  description: 5G API Tx_Retransmissions must grow after the DUT-originated trigger
+    workload.
+- delta:
+    baseline: api_before_5g.Tx_Retransmissions
+    verify: api_after_5g.Tx_Retransmissions
+  reference_delta:
+    baseline: drv_before_5g.DriverTxRetransmissions
+    verify: drv_after_5g.DriverTxRetransmissions
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API Tx_Retransmissions delta must stay within ±10% of the driver
+    delta.
+verification_command:
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions?"
+- ifconfig wl0 | awk '/inet addr:/ {gsub("addr:","",$2); print "StaIp=" $2; exit}
+  $1=="inet" {print "StaIp=" $2; exit}'
+- ping -I br-lan -c 20 -s 1400 -W 1 <resolved STA wl0 IPv4>
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retries:
+  *\([0-9][0-9]*\).*/DriverTxRetransmissions=\1/p'''

--- a/plugins/wifi_llapi/cases/D051_tx_retransmissions.yaml
+++ b/plugins/wifi_llapi/cases/D051_tx_retransmissions.yaml
@@ -60,10 +60,10 @@ test_environment: 'Topology:
 setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
   \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
   \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
-  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ AP1/AP2 on COM0\n   - move COM0 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
   \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
-  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
-  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM0: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM1: wl -i wl0\
   \ assoclist\n"
 sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
   \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\

--- a/plugins/wifi_llapi/cases/D052_tx_retransmissionsfailed.yaml
+++ b/plugins/wifi_llapi/cases/D052_tx_retransmissionsfailed.yaml
@@ -1,26 +1,193 @@
-id: d052-blocked-tx-retransmissionsfailed
-name: D052 Tx_RetransmissionsFailed Blocked
+id: wifi-llapi-D052-tx-retransmissionsfailed
+name: Tx_RetransmissionsFailed — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
+version: '1.1'
 source:
   row: 54
   object: WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
   api: Tx_RetransmissionsFailed
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
-llapi_support: Blocked
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
       selector: COM1
+    STA:
+      role: sta
+      transport: serial
+      selector: COM0
+      config:
+      - iface: 5g
+        mode: sta
+        ssid: TestPilot_BTM
+        key: testpilot6g
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+test_environment: 'Topology:
+
+  - DUT: COM1 (AP role)
+
+  - STA: COM0 (station role for this case; do not rely on the old A0/B0 heuristic)
+
+  Transport:
+
+  - serialwrap attach COM0 / COM1
+
+  Live band mapping:
+
+  - 5G: DUT wl0 / AP1 / SSID.4 / TestPilot_BTM
+
+  - 6G: DUT wl1 / AP3 / SSID.6 / TestPilot_BTM
+
+  - 2.4G: DUT wl2 / AP5 / SSID.8 / TestPilot_24G
+
+  Preconditions:
+
+  - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
+
+  - use the validated 5G single-band WPA3 baseline for this case
+
+  '
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
+  \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
+  \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
+  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ assoclist\n"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
+  \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\
+  \ WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
+  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
+  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
+  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
+  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
+  \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan\
+  \ 192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
+  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null\
+  \ || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0\
+  \ set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf\
+  \ 'ctrl_interface=/var/run/wpa_supplicant\nupdate_config=1\nsae_pwe=2\nnetwork={\n\
+  ssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
+  \ /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\nSTA 5G connect verify:\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
+  \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\
+  \  wl -i wl0 assoclist\n"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and capture baseline DUT
+  LLAPI Tx_RetransmissionsFailed plus the matching driver `tx pkts retry exhausted`
+  counter for the same STA.
+
+
+  2) Hold an explicit manual/external trigger window so retry-exhaustion traffic can
+  be induced without pretending this workload is automated by the case itself.
+
+
+  3) Re-read DUT LLAPI Tx_RetransmissionsFailed and the matching driver `tx pkts retry
+  exhausted` counter, then compare baseline-to-verify deltas.
+
+  '
 steps:
-- id: step_5g_blocked
-  target: dut
-  action: skip
-  command: "echo blocked"
-  description: "Tx_RetransmissionsFailed — live probe showed 0, needs retry-exhaustion
-    workload"
+- id: step1_resolve_assoc
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+  capture: assoc_entry
+- id: step2_api_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"
+  depends_on: step1_resolve_assoc
+  capture: api_before_5g
+- id: step3_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retry
+    exhausted: *\([0-9][0-9]*\).*/DriverTxRetransmissionsFailed=\1/p'''
+  depends_on: step2_api_baseline
+  capture: drv_before_5g
+- id: step4_trigger_window
+  phase: trigger
+  action: wait
+  target: DUT
+  duration: 30
+  capture: manual_trigger_window
+  expected: Manual/external retry-exhaustion traffic occurs during this window.
+  description: Manual/external trigger window for Tx_RetransmissionsFailed delta evidence.
+- id: step5_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"
+  depends_on: step4_trigger_window
+  capture: api_after_5g
+- id: step6_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retry
+    exhausted: *\([0-9][0-9]*\).*/DriverTxRetransmissionsFailed=\1/p'''
+  depends_on: step5_api_verify
+  capture: drv_after_5g
 pass_criteria:
-- field: skip
-  operator: skip
-  value: "Tx_RetransmissionsFailed — live probe showed 0, needs retry-exhaustion workload"
+- field: assoc_entry.MACAddress
+  operator: regex
+  value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
+  description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- field: drv_before_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Baseline driver sampling must target the same live AssociatedDevice
+    MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC
+    resolved in step1.
+- delta:
+    baseline: api_before_5g.Tx_RetransmissionsFailed
+    verify: api_after_5g.Tx_RetransmissionsFailed
+  operator: delta_nonzero
+  description: 5G API Tx_RetransmissionsFailed must grow across the manual/external
+    trigger window.
+- delta:
+    baseline: api_before_5g.Tx_RetransmissionsFailed
+    verify: api_after_5g.Tx_RetransmissionsFailed
+  reference_delta:
+    baseline: drv_before_5g.DriverTxRetransmissionsFailed
+    verify: drv_after_5g.DriverTxRetransmissionsFailed
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API Tx_RetransmissionsFailed delta must stay within ±10% of the
+    driver delta.
+verification_command:
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"
+- echo "Manual/external trigger window — wait 30 seconds while retry-exhaustion traffic is induced."
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*tx pkts retry exhausted:
+  *\([0-9][0-9]*\).*/DriverTxRetransmissionsFailed=\1/p'''

--- a/plugins/wifi_llapi/cases/D052_tx_retransmissionsfailed.yaml
+++ b/plugins/wifi_llapi/cases/D052_tx_retransmissionsfailed.yaml
@@ -60,10 +60,10 @@ test_environment: 'Topology:
 setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
   \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
   \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
-  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ AP1/AP2 on COM0\n   - move COM0 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
   \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
-  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
-  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM0: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM1: wl -i wl0\
   \ assoclist\n"
 sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
   \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\

--- a/plugins/wifi_llapi/cases/D054_txerrors.yaml
+++ b/plugins/wifi_llapi/cases/D054_txerrors.yaml
@@ -56,20 +56,18 @@ test_environment: 'Topology:
 
   - use the validated 5G single-band WPA3 baseline for this case
 
-  - keep the workbook verdict open until a deterministic AP-side Tx error workload
-  exists
-
   '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
+  \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
+  \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
+  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ assoclist\n"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
+  \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\
+  \ WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
   \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
   \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
   \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
@@ -82,77 +80,96 @@ sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cl
   \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan\
+  \ 192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
   \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\\\
-  nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\\
-  nsae_password=\"testpilot6g\"\\nieee80211w=2\\nscan_ssid=1\\n}\\n' > /tmp/wpa_wl0.conf\n\
-  \  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
-  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0
-  reconnect\n  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i
-  wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist\n"
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null\
+  \ || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0\
+  \ set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf\
+  \ 'ctrl_interface=/var/run/wpa_supplicant\nupdate_config=1\nsae_pwe=2\nnetwork={\n\
+  ssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
+  \ /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\nSTA 5G connect verify:\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
+  \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\
+  \  wl -i wl0 assoclist\n"
 test_procedure: '1) Resolve COM1 wl0''s live STA MAC and require AP1 AssociatedDevice.1
   to point to that same station.
 
-  2) Query WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors directly on DUT, then cross-check
-  the same AssociatedDevice entry via WiFi.AccessPoint.1.AssociatedDevice.1.?.
 
-  3) Confirm wl0 sta_info for the same STA still exposes tx failures / retry counters
-  for the same driver station entry.
+  2) Capture baseline DUT LLAPI TxErrors and the matching driver `tx failures` counter
+  for the same STA.
 
-  4) Keep the manual verdict workbook-gated open: the current 5G live retest only
-  proves direct AssociatedDevice and driver equality under a zero-error checkpoint,
-  not deterministic Tx error injection.
+
+  3) Hold an explicit manual/external trigger window so AP-side Tx error activity
+  can be induced without pretending this workload is deterministic or automated by
+  the case itself.
+
+
+  4) Re-read DUT LLAPI TxErrors and the matching driver `tx failures` counter, then
+  compare baseline-to-verify deltas.
 
   '
 steps:
-- id: step1
+- id: step1_resolve_sta
+  phase: baseline
   action: exec
   target: STA
   command: cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'
   capture: sta_identity
-- id: step2
+- id: step2_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-  depends_on: step1
+  depends_on: step1_resolve_sta
   capture: assoc_entry
-- id: step3
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"
-  depends_on: step2
-  capture: result
-- id: step4
+  depends_on: step2_resolve_assoc
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | sed -n 
-    's/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/AssocMAC=\1/p;
-    s/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxErrors=\([0-9][0-9]*\).*/AssocTxErrors=\1/p'
-  depends_on: step3
-  capture: assoc_snapshot
-- id: step5
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx
+    failures: \([0-9][0-9]*\).*/DriverTxErrors=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger_window
+  phase: trigger
+  action: wait
+  target: DUT
+  duration: 30
+  capture: manual_trigger_window
+  expected: Manual/external AP-side Tx error activity occurs during this window.
+  description: Manual/external trigger window for TxErrors delta evidence.
+- id: step6_api_verify
+  phase: verify
   action: exec
   target: DUT
-  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); STA_MAC_LOWER=$(echo "$STA_MAC"
-    | tr ''A-F'' ''a-f''); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC && wl
-    -i wl0 sta_info $STA_MAC_LOWER | sed -n ''s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPkts=\1/p;
-    s/^[[:space:]]*tx failures: \([0-9][0-9]*\).*/DriverTxErrors=\1/p; s/^[[:space:]]*tx
-    pkts retries: \([0-9][0-9]*\).*/DriverRetries=\1/p; s/^[[:space:]]*tx pkts retry
-    exhausted: \([0-9][0-9]*\).*/DriverRetryExhausted=\1/p'''
-  depends_on: step4
-  capture: driver_capture
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"
+  depends_on: step5_trigger_window
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx
+    failures: \([0-9][0-9]*\).*/DriverTxErrors=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: sta_identity.StaMac
   operator: regex
   value: ^([0-9A-F]{2}:){5}[0-9A-F]{2}$
-  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side 
-    validation.
+  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side validation.
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
@@ -160,63 +177,36 @@ pass_criteria:
 - field: assoc_entry.MACAddress
   operator: equals
   reference: sta_identity.StaMac
-  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 
-    station used for this manual checkpoint.
-- field: result.TxErrors
-  operator: regex
-  value: ^[0-9]+$
-  description: TxErrors direct getter must produce a numeric counter for the 
-    live AssociatedDevice entry.
-- field: assoc_snapshot.AssocMAC
+  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 station
+    used for this manual delta case.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: AssociatedDevice snapshot evidence must come from the same AP1 
-    station entry.
-- field: result.TxErrors
-  operator: equals
-  reference: assoc_snapshot.AssocTxErrors
-  description: Direct getter TxErrors must match the same AssociatedDevice 
-    snapshot value.
-- field: driver_capture.DriverAssocMac
-  operator: equals
-  reference: assoc_entry.MACAddress
-  description: Driver evidence must target the same AssociatedDevice MAC 
+  description: Baseline driver evidence must target the same AssociatedDevice MAC
     resolved in step2.
-- field: driver_capture.DriverTxPkts
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must expose a concrete tx total packet counter for 
-    the same STA.
-- field: driver_capture.DriverTxErrors
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must expose a concrete tx failures counter for the 
-    same STA.
-- field: result.TxErrors
+- field: drv_after_5g.DriverAssocMac
   operator: equals
-  reference: driver_capture.DriverTxErrors
-  description: TxErrors must match wl0 sta_info tx failures for the same 
-    AssociatedDevice entry.
-- field: driver_capture.DriverRetries
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must still expose tx pkts retries for the same STA 
-    as supporting context.
-- field: driver_capture.DriverRetryExhausted
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must still expose tx pkts retry exhausted for the 
-    same STA as supporting context.
+  reference: assoc_entry.MACAddress
+  description: Verify driver evidence must target the same AssociatedDevice MAC resolved
+    in step2.
+- delta:
+    baseline: api_before_5g.TxErrors
+    verify: api_after_5g.TxErrors
+  operator: delta_nonzero
+  description: TxErrors must increase across the manual/external trigger window.
+- delta:
+    baseline: api_before_5g.TxErrors
+    verify: api_after_5g.TxErrors
+  reference_delta:
+    baseline: drv_before_5g.DriverTxErrors
+    verify: drv_after_5g.DriverTxErrors
+  operator: delta_match
+  tolerance_pct: 10
+  description: TxErrors delta must stay within ±10% of the driver tx failures delta.
 verification_command:
 - cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"
-- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | sed -n 
-  's/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/AssocMAC=\1/p;
-  s/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxErrors=\([0-9][0-9]*\).*/AssocTxErrors=\1/p'
-- 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-  ''s/.*MACAddress="\([^"]*\)".*/\1/p''); STA_MAC_LOWER=$(echo "$STA_MAC" | tr ''A-F''
-  ''a-f''); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC && wl -i wl0 sta_info
-  $STA_MAC_LOWER | sed -n ''s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPkts=\1/p;
-  s/^[[:space:]]*tx failures: \([0-9][0-9]*\).*/DriverTxErrors=\1/p; s/^[[:space:]]*tx
-  pkts retries: \([0-9][0-9]*\).*/DriverRetries=\1/p; s/^[[:space:]]*tx pkts retry
-  exhausted: \([0-9][0-9]*\).*/DriverRetryExhausted=\1/p'''
+- echo "Manual/external trigger window — wait 30 seconds while AP-side Tx error activity is induced."
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx failures:
+  \([0-9][0-9]*\).*/DriverTxErrors=\1/p'''

--- a/plugins/wifi_llapi/cases/D054_txerrors.yaml
+++ b/plugins/wifi_llapi/cases/D054_txerrors.yaml
@@ -87,9 +87,8 @@ sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cl
   \ || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect\
   \ 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0\
   \ set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf\
-  \ 'ctrl_interface=/var/run/wpa_supplicant\nupdate_config=1\nsae_pwe=2\nnetwork={\n\
-  ssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
-  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
+  \ 'ctrl_interface=/var/run/wpa_supplicant\\nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\nsae_password=\"testpilot6g\"\\nieee80211w=2\\nscan_ssid=1\\n}\\n'\
+  \ > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c\
   \ /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\nSTA 5G connect verify:\n\
   \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
   \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\

--- a/plugins/wifi_llapi/cases/D054_txerrors.yaml
+++ b/plugins/wifi_llapi/cases/D054_txerrors.yaml
@@ -60,10 +60,10 @@ test_environment: 'Topology:
 setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure\
   \ AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential\
   \ pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local\
-  \ AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
+  \ AP1/AP2 on COM0\n   - move COM0 br-lan off 192.168.1.0/24 to avoid bridge self-hit\
   \ side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect\
-  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0\
-  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0\
+  \ wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM0: iw dev wl0\
+  \ link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM1: wl -i wl0\
   \ assoclist\n"
 sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli\
   \ WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli\
@@ -93,7 +93,7 @@ sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cl
   \  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0\
   \ link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n\
   \  wl -i wl0 assoclist\n"
-test_procedure: '1) Resolve COM1 wl0''s live STA MAC and require AP1 AssociatedDevice.1
+test_procedure: '1) Resolve COM0 wl0''s live STA MAC and require AP1 AssociatedDevice.1
   to point to that same station.
 
 
@@ -168,7 +168,7 @@ pass_criteria:
 - field: sta_identity.StaMac
   operator: regex
   value: ^([0-9A-F]{2}:){5}[0-9A-F]{2}$
-  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side validation.
+  description: COM0 wl0 must resolve to a concrete live STA MAC before DUT-side validation.
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
@@ -176,7 +176,7 @@ pass_criteria:
 - field: assoc_entry.MACAddress
   operator: equals
   reference: sta_identity.StaMac
-  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 station
+  description: AP1 AssociatedDevice.1 must correspond to the same COM0 wl0 station
     used for this manual delta case.
 - field: drv_before_5g.DriverAssocMac
   operator: equals

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
@@ -36,7 +36,7 @@ def test_official_case_command_lengths_fit_transport_budget_summary():
                     if isinstance(item, str) and len(item) > threshold:
                         violations.append(f"{yaml_path.name}:{field}[{index}]:{len(item)}")
 
-    assert len(violations) == 941, (
+    assert len(violations) == 949, (
         "Official-case >120-char command inventory changed; "
         "review whether this was an intended calibration update.\n"
         + "\n".join(violations[:40])

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -5503,29 +5503,36 @@ def test_d037_retransmissions_evaluate_delta_examples():
     assert plugin.evaluate(case_data, mismatch_results) is False
 
 
-def test_pending_counter_stub_associateddevice_cases_use_supported_contracts():
+def test_wave2_associateddevice_delta_cases_use_supported_contracts():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     plugin = _load_plugin()
     discoverable_ids = {case["id"] for case in plugin.discover_cases()}
     assert {
         "wifi-llapi-D038-rx-retransmissions",
-        "wifi-llapi-D042-rxunicastpacketcount",
+        "wifi-llapi-D051-tx-retransmissions",
+        "wifi-llapi-D052-tx-retransmissionsfailed",
     }.issubset(discoverable_ids)
 
     counter_cases = {
         "D038_rx_retransmissions.yaml": {
             "id": "wifi-llapi-D038-rx-retransmissions",
-                "row": 38,
+            "row": 38,
             "api": "Rx_Retransmissions",
+            "probe_field": "dut_ip.DutIp",
+            "trigger_command": "ping -I wl0 -c 20 -s 1400 -W 1 {{dut_ip.DutIp}}",
+            "driver_before": "drv_before_5g.DriverRxRetransmissions",
+            "driver_after": "drv_after_5g.DriverRxRetransmissions",
             "driver_token": "DriverRxRetransmissions=",
-            "driver_field": "driver_counter.DriverRxRetransmissions",
         },
-        "D042_rxunicastpacketcount.yaml": {
-            "id": "wifi-llapi-D042-rxunicastpacketcount",
-                "row": 42,
-            "api": "RxUnicastPacketCount",
-            "driver_token": "DriverRxUnicastPacketCount=",
-            "driver_field": "driver_counter.DriverRxUnicastPacketCount",
+        "D051_tx_retransmissions.yaml": {
+            "id": "wifi-llapi-D051-tx-retransmissions",
+            "row": 53,
+            "api": "Tx_Retransmissions",
+            "probe_field": "sta_ip.StaIp",
+            "trigger_command": "ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}}",
+            "driver_before": "drv_before_5g.DriverTxRetransmissions",
+            "driver_after": "drv_after_5g.DriverTxRetransmissions",
+            "driver_token": "DriverTxRetransmissions=",
         },
     }
 
@@ -5538,51 +5545,142 @@ def test_pending_counter_stub_associateddevice_cases_use_supported_contracts():
         assert "aliases" not in raw_case
         assert case_data["id"] == meta["id"]
         assert case_data["source"]["row"] == meta["row"]
+        assert case_data["llapi_support"] == "Support"
         assert case_data["bands"] == ["5g"]
         assert links == {"5g"}
-        assert case_data["hlapi_command"] == f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
+        assert case_data["hlapi_command"] == (
+            f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
+        )
+        assert [step["phase"] for step in case_data["steps"]] == [
+            "baseline",
+            "baseline",
+            "baseline",
+            "baseline",
+            "trigger",
+            "verify",
+            "verify",
+        ]
         assert "MACAddress?" in commands
+        assert meta["trigger_command"] in commands
         assert "DriverAssocMac=" in commands
         assert meta["driver_token"] in commands
         assert any(
-            criterion["field"] == f'result.{meta["api"]}'
-            and criterion["operator"] == "equals"
+            criterion["field"] == meta["probe_field"] and criterion["operator"] == "regex"
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion["field"] == "trigger_probe.TriggerTxPackets"
+            and criterion["operator"] == ">"
             and str(criterion["value"]) == "0"
             for criterion in case_data["pass_criteria"]
         )
         assert any(
-            criterion["field"] == "driver_counter.DriverAssocMac"
+            criterion["field"] == "drv_before_5g.DriverAssocMac"
             and criterion["operator"] == "equals"
             and criterion["reference"] == "assoc_entry.MACAddress"
             for criterion in case_data["pass_criteria"]
         )
         assert any(
-            criterion["field"] == meta["driver_field"]
-            and criterion["operator"] == ">"
-            and str(criterion["value"]) == "0"
+            criterion["field"] == "drv_after_5g.DriverAssocMac"
+            and criterion["operator"] == "equals"
+            and criterion["reference"] == "assoc_entry.MACAddress"
             for criterion in case_data["pass_criteria"]
         )
-        _cstub_rr = {
-            "D038_rx_retransmissions.yaml": ("Fail", "N/A", "N/A"),
-            "D042_rxunicastpacketcount.yaml": ("Not Supported", "Not Supported", "Not Supported"),
+        assert any(
+            criterion.get("operator") == "delta_nonzero"
+            and criterion.get("delta")
+            == {
+                "baseline": f'api_before_5g.{meta["api"]}',
+                "verify": f'api_after_5g.{meta["api"]}',
+            }
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion.get("operator") == "delta_match"
+            and criterion.get("delta")
+            == {
+                "baseline": f'api_before_5g.{meta["api"]}',
+                "verify": f'api_after_5g.{meta["api"]}',
+            }
+            and criterion.get("reference_delta")
+            == {
+                "baseline": meta["driver_before"],
+                "verify": meta["driver_after"],
+            }
+            and criterion.get("tolerance_pct") == 10
+            for criterion in case_data["pass_criteria"]
+        )
+        assert not any(
+            criterion.get("field") == f'result.{meta["api"]}'
+            and criterion.get("operator") == "equals"
+            and str(criterion.get("value")) == "0"
+            for criterion in case_data["pass_criteria"]
+        )
+
+    d052_raw = yaml.safe_load(
+        (cases_dir / "D052_tx_retransmissionsfailed.yaml").read_text(encoding="utf-8")
+    )
+    d052 = load_case(cases_dir / "D052_tx_retransmissionsfailed.yaml")
+    d052_commands = "\n".join(str(step.get("command", "")) for step in d052["steps"])
+
+    assert "aliases" not in d052_raw
+    assert d052["id"] == "wifi-llapi-D052-tx-retransmissionsfailed"
+    assert d052["source"]["row"] == 54
+    assert d052["llapi_support"] == "Support"
+    assert d052["hlapi_command"] == (
+        'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"'
+    )
+    assert "manual" in d052["test_procedure"].lower()
+    assert "external" in d052["test_procedure"].lower()
+    assert [step["phase"] for step in d052["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "verify",
+        "verify",
+    ]
+    assert d052["steps"][3]["action"] == "wait"
+    assert d052["steps"][3]["duration"] == 30
+    assert "DriverTxRetransmissionsFailed=" in d052_commands
+    assert any(
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.Tx_RetransmissionsFailed",
+            "verify": "api_after_5g.Tx_RetransmissionsFailed",
         }
-        exp5, exp6, exp24 = _cstub_rr[filename]
+        for criterion in d052["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_5g.DriverTxRetransmissionsFailed",
+            "verify": "drv_after_5g.DriverTxRetransmissionsFailed",
+        }
+        for criterion in d052["pass_criteria"]
+    )
 
 
-def test_pending_counter_stub_associateddevice_cases_evaluate_live_examples():
+def test_wave2_associateddevice_delta_cases_evaluate_live_examples():
     plugin = _load_plugin()
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
 
     counter_cases = {
         "D038_rx_retransmissions.yaml": {
-            "api": "Rx_Retransmissions",
-            "driver_output": "DriverRxRetransmissions=21",
-            "driver_fail_output": "DriverRxRetransmissions=0",
+            "api_before": "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions=11",
+            "api_after": "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions=17",
+            "probe_output": "DutIp=192.168.88.1",
+            "driver_before": "DriverRxRetransmissions=121",
+            "driver_after": "DriverRxRetransmissions=127",
         },
-        "D042_rxunicastpacketcount.yaml": {
-            "api": "RxUnicastPacketCount",
-            "driver_output": "DriverRxUnicastPacketCount=114",
-            "driver_fail_output": "DriverRxUnicastPacketCount=0",
+        "D051_tx_retransmissions.yaml": {
+            "api_before": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions=11",
+            "api_after": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions=17",
+            "probe_output": "StaIp=192.168.88.2",
+            "driver_before": "DriverTxRetransmissions=121",
+            "driver_after": "DriverTxRetransmissions=127",
         },
     }
 
@@ -5590,48 +5688,130 @@ def test_pending_counter_stub_associateddevice_cases_evaluate_live_examples():
         case_data = load_case(cases_dir / filename)
         pass_results = {
             "steps": {
-                "step1": {
+                "step1_resolve_assoc": {
                     "success": True,
                     "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
                     "timing": 0.01,
                 },
-                "step2": {
+                "step2_resolve_probe_target": {
                     "success": True,
-                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=0',
+                    "output": meta["probe_output"],
                     "timing": 0.01,
                 },
-                "step3": {
+                "step3_api_baseline": {
                     "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_output"]}',
+                    "output": meta["api_before"],
+                    "timing": 0.01,
+                },
+                "step4_drv_baseline": {
+                    "success": True,
+                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_before"]}',
+                    "timing": 0.01,
+                },
+                "step5_trigger": {
+                    "success": True,
+                    "output": "20 packets transmitted, 20 received, 0% packet loss\nTriggerTxPackets=20",
+                    "timing": 1.5,
+                },
+                "step6_api_verify": {
+                    "success": True,
+                    "output": meta["api_after"],
+                    "timing": 0.01,
+                },
+                "step7_drv_verify": {
+                    "success": True,
+                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_after"]}',
                     "timing": 0.01,
                 },
             }
         }
         assert plugin.evaluate(case_data, pass_results) is True
 
-        fail_results = {
+        zero_delta_results = {
             "steps": {
                 **pass_results["steps"],
-                "step3": {
+                "step6_api_verify": {
                     "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_fail_output"]}',
+                    "output": meta["api_before"],
                     "timing": 0.01,
                 },
             }
         }
-        assert plugin.evaluate(case_data, fail_results) is False
+        assert plugin.evaluate(case_data, zero_delta_results) is False
 
         mismatch_results = {
             "steps": {
                 **pass_results["steps"],
-                "step3": {
+                "step7_drv_verify": {
                     "success": True,
-                    "output": f'DriverAssocMac=AA:AA:AA:AA:AA:AA\n{meta["driver_output"]}',
+                    "output": "DriverAssocMac=2C:59:17:00:04:85\n"
+                    + meta["driver_after"].replace("127", "150"),
                     "timing": 0.01,
                 },
             }
         }
         assert plugin.evaluate(case_data, mismatch_results) is False
+
+    d052 = load_case(cases_dir / "D052_tx_retransmissionsfailed.yaml")
+    d052_pass_results = {
+        "steps": {
+            "step1_resolve_assoc": {
+                "success": True,
+                "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
+                "timing": 0.01,
+            },
+            "step2_api_baseline": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=3",
+                "timing": 0.01,
+            },
+            "step3_drv_baseline": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=30",
+                "timing": 0.01,
+            },
+            "step4_trigger_window": {
+                "success": True,
+                "output": "ManualTriggerWindow=30",
+                "timing": 30.0,
+            },
+            "step5_api_verify": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=9",
+                "timing": 0.01,
+            },
+            "step6_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=36",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(d052, d052_pass_results) is True
+
+    d052_zero_delta_results = {
+        "steps": {
+            **d052_pass_results["steps"],
+            "step5_api_verify": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=3",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(d052, d052_zero_delta_results) is False
+
+    d052_mismatch_results = {
+        "steps": {
+            **d052_pass_results["steps"],
+            "step6_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=45",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(d052, d052_mismatch_results) is False
 
 
 def test_pending_counter_pass_associateddevice_cases_use_supported_contracts():
@@ -7323,7 +7503,7 @@ def test_d050_supportedvhtmcs_evaluate_live_examples():
     assert plugin.evaluate(d050, d050_wrong_sta_results) is False
 
 
-def test_d054_txerrors_uses_same_sta_driver_contract():
+def test_d054_txerrors_uses_manual_delta_contract():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     plugin = _load_plugin()
     discoverable_ids = {case["id"] for case in plugin.discover_cases()}
@@ -7344,11 +7524,20 @@ def test_d054_txerrors_uses_same_sta_driver_contract():
     assert "cat /sys/class/net/wl0/address" in d054_commands
     assert "MACAddress?" in d054_commands
     assert 'TxErrors?"' in d054_commands
-    assert "AssocTxErrors=" in d054_commands
-    assert "DriverTxPkts=" in d054_commands
+    assert "manual" in d054["test_procedure"].lower()
+    assert "external" in d054["test_procedure"].lower()
     assert "DriverTxErrors=" in d054_commands
-    assert "DriverRetries=" in d054_commands
-    assert "DriverRetryExhausted=" in d054_commands
+    assert [step["phase"] for step in d054["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "verify",
+        "verify",
+    ]
+    assert d054["steps"][4]["action"] == "wait"
+    assert d054["steps"][4]["duration"] == 30
     assert any(
         criterion["field"] == "sta_identity.StaMac"
         and criterion["operator"] == "regex"
@@ -7362,27 +7551,33 @@ def test_d054_txerrors_uses_same_sta_driver_contract():
         for criterion in d054["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "result.TxErrors"
-        and criterion["operator"] == "regex"
-        and criterion["value"] == r"^[0-9]+$"
-        for criterion in d054["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.TxErrors"
-        and criterion["operator"] == "equals"
-        and criterion["reference"] == "assoc_snapshot.AssocTxErrors"
-        for criterion in d054["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_capture.DriverAssocMac"
+        criterion["field"] == "drv_before_5g.DriverAssocMac"
         and criterion["operator"] == "equals"
         and criterion["reference"] == "assoc_entry.MACAddress"
         for criterion in d054["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "result.TxErrors"
+        criterion["field"] == "drv_after_5g.DriverAssocMac"
         and criterion["operator"] == "equals"
-        and criterion["reference"] == "driver_capture.DriverTxErrors"
+        and criterion["reference"] == "assoc_entry.MACAddress"
+        for criterion in d054["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.TxErrors",
+            "verify": "api_after_5g.TxErrors",
+        }
+        for criterion in d054["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_5g.DriverTxErrors",
+            "verify": "drv_after_5g.DriverTxErrors",
+        }
         for criterion in d054["pass_criteria"]
     )
 
@@ -7394,65 +7589,75 @@ def test_d054_txerrors_evaluate_live_examples():
 
     d054_results = {
         "steps": {
-            "step1": {
+            "step1_resolve_sta": {
                 "success": True,
                 "output": "StaMac=2C:59:17:00:04:85",
                 "timing": 0.01,
             },
-            "step2": {
+            "step2_resolve_assoc": {
                 "success": True,
                 "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
                 "timing": 0.01,
             },
-            "step3": {
+            "step3_api_baseline": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors=0",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors=2",
                 "timing": 0.01,
             },
-            "step4": {
+            "step4_drv_baseline": {
                 "success": True,
-                "output": "AssocMAC=2C:59:17:00:04:85\nAssocTxErrors=0",
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxErrors=20",
                 "timing": 0.01,
             },
-            "step5": {
+            "step5_trigger_window": {
                 "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxPkts=14207\nDriverTxErrors=0\nDriverRetries=29226\nDriverRetryExhausted=0",
+                "output": "ManualTriggerWindow=30",
+                "timing": 30.0,
+            },
+            "step6_api_verify": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors=8",
+                "timing": 0.01,
+            },
+            "step7_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxErrors=26",
                 "timing": 0.01,
             },
         }
     }
     assert plugin.evaluate(d054, d054_results) is True
 
-    d054_missing_snapshot_results = {
+    d054_zero_delta_results = {
         "steps": {
             **d054_results["steps"],
-            "step4": {
+            "step6_api_verify": {
                 "success": True,
-                "output": "AssocMAC=2C:59:17:00:04:85",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors=2",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(d054, d054_missing_snapshot_results) is False
+    assert plugin.evaluate(d054, d054_zero_delta_results) is False
 
-    d054_wrong_driver_results = {
+    d054_wrong_driver_delta_results = {
         "steps": {
             **d054_results["steps"],
-            "step5": {
+            "step7_drv_verify": {
                 "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxPkts=14207\nDriverTxErrors=1\nDriverRetries=29226\nDriverRetryExhausted=0",
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxErrors=40",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(d054, d054_wrong_driver_results) is False
+    assert plugin.evaluate(d054, d054_wrong_driver_delta_results) is False
 
     d054_wrong_driver_assoc_results = {
         "steps": {
             **d054_results["steps"],
-            "step5": {
+            "step7_drv_verify": {
                 "success": True,
-                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverTxPkts=14207\nDriverTxErrors=0\nDriverRetries=29226\nDriverRetryExhausted=0",
+                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverTxErrors=26",
                 "timing": 0.01,
             },
         }
@@ -7462,7 +7667,7 @@ def test_d054_txerrors_evaluate_live_examples():
     d054_wrong_sta_results = {
         "steps": {
             **d054_results["steps"],
-            "step1": {
+            "step1_resolve_sta": {
                 "success": True,
                 "output": "StaMac=AA:AA:AA:AA:AA:AA",
                 "timing": 0.01,
@@ -17103,6 +17308,7 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
     [
         ("D034_noise_accesspoint_associateddevice.yaml", 2, "DriverNoise="),
         ("D037_retransmissions.yaml", 3, "DriverRetransmissions="),
+        ("D038_rx_retransmissions.yaml", 3, "DriverRxRetransmissions="),
         ("D039_rxbytes.yaml", 2, "DriverRxBytes="),
         ("D040_rxmulticastpacketcount.yaml", 3, "DriverRxMulticastPacketCount="),
         ("D044_signalnoiseratio.yaml", 2, "DriverSignalNoiseRatio="),
@@ -17111,7 +17317,9 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
         ("D046_signalstrengthbychain.yaml", 3, "DriverSignalStrengthByChain="),
         ("D048_supportedhemcs.yaml", 4, "DriverHeMcsLinePresent="),
         ("D050_supportedvhtmcs.yaml", 4, "DriverVhtSetPresent="),
-        ("D054_txerrors.yaml", 4, "DriverTxErrors="),
+        ("D051_tx_retransmissions.yaml", 3, "DriverTxRetransmissions="),
+        ("D052_tx_retransmissionsfailed.yaml", 2, "DriverTxRetransmissionsFailed="),
+        ("D054_txerrors.yaml", 3, "DriverTxErrors="),
         ("D049_supportedmcs.yaml", 2, "DriverMCSSetPresent="),
         ("D056_txpacketcount.yaml", 2, "DriverTxPacketCount="),
         ("D059_uplinkbandwidth.yaml", 3, "DriverUplinkBandwidth="),
@@ -17161,16 +17369,24 @@ def test_sanitize_cli_fragment_preserves_nested_quotes_for_associateddevice_driv
         "D047_supportedhe160mcs.yaml",
         "D048_supportedhemcs.yaml",
         "D050_supportedvhtmcs.yaml",
-        "D054_txerrors.yaml",
+        "D052_tx_retransmissionsfailed.yaml",
     }:
-        assert len(verification_commands) == 3 + len(expected_fragments)
-        assert verification_commands[0] == "cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'"
-        if filename == "D054_txerrors.yaml":
-            assert verification_commands[1] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"'
-            assert "AssocTxErrors=" in verification_commands[2]
+        expected_length = 2 + len(expected_fragments) if filename == "D052_tx_retransmissionsfailed.yaml" else 3 + len(expected_fragments)
+        assert len(verification_commands) == expected_length
+        if filename == "D052_tx_retransmissionsfailed.yaml":
+            assert verification_commands[0] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"'
+            assert "wait 30 seconds" in verification_commands[1]
+            assert verification_commands[2:] == expected_fragments
         else:
+            assert verification_commands[0] == "cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'"
             assert verification_commands[1].startswith('OUT=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.')
             assert "SiblingAssocMac=" in verification_commands[2]
+            assert verification_commands[3:] == expected_fragments
+    elif filename == "D054_txerrors.yaml":
+        assert len(verification_commands) == 3 + len(expected_fragments)
+        assert verification_commands[0] == "cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'"
+        assert verification_commands[1] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"'
+        assert "wait 30 seconds" in verification_commands[2]
         assert verification_commands[3:] == expected_fragments
     elif filename == "D062_vendoroui.yaml":
         assert len(verification_commands) == 3 + len(expected_fragments)
@@ -17271,18 +17487,21 @@ def test_d054_txerrors_verification_fragments_preserve_snapshot_and_driver_check
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d054 = load_case(cases_dir / "D054_txerrors.yaml")
 
-    step3_command = d054["steps"][2]["command"]
-    step5_command = d054["steps"][4]["command"]
+    step1_command = d054["steps"][0]["command"]
+    step4_command = d054["steps"][3]["command"]
+    step7_command = d054["steps"][6]["command"]
     verification_commands = plugin._extract_cli_fragments(d054["verification_command"])
 
-    assert step3_command == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"'
-    assert plugin._sanitize_cli_fragment(step5_command) == step5_command
-    assert plugin._extract_cli_fragments(step5_command) == [step5_command]
+    assert step1_command == "cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'"
+    assert plugin._sanitize_cli_fragment(step4_command) == step4_command
+    assert plugin._extract_cli_fragments(step4_command) == [step4_command]
+    assert plugin._sanitize_cli_fragment(step7_command) == step7_command
+    assert plugin._extract_cli_fragments(step7_command) == [step7_command]
     assert len(verification_commands) == 4
-    assert verification_commands[0] == "cat /sys/class/net/wl0/address | tr 'a-f' 'A-F' | sed 's/^/StaMac=/'"
-    assert verification_commands[1] == step3_command
-    assert "AssocTxErrors=" in verification_commands[2]
-    assert verification_commands[3] == step5_command
+    assert verification_commands[0] == step1_command
+    assert verification_commands[1] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors?"'
+    assert "wait 30 seconds" in verification_commands[2]
+    assert verification_commands[3] == step7_command
 
 
 def test_d055_txmulticastpacketcount_verification_fragments_preserve_delivery_and_driver_checks():
@@ -24236,8 +24455,6 @@ _SKIP_BLOCKED_CASES = [
     ("D579_packetsreceived_associateddevice_affiliatedsta.yaml", 582, "Skip"),
     ("D580_errorssent_associateddevice_affiliatedsta.yaml", 583, "Skip"),
     ("D581_signalstrength_associateddevice_affiliatedsta.yaml", 584, "Skip"),
-    ("D051_tx_retransmissions.yaml", 53, "Blocked"),
-    ("D052_tx_retransmissionsfailed.yaml", 54, "Blocked"),
 ]
 _SKIP_BLOCKED_IDS = [t[0].split(".")[0] for t in _SKIP_BLOCKED_CASES]
 

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -18915,19 +18915,6 @@ def test_d077_macfilteraddresslist_accesspoint_entry_add_fragment_executes():
                 "DriverTxSupportedVhtMCS=9,9,9,9",
             ],
         ),
-        (
-            "D054_txerrors.yaml",
-            "\n".join(
-                [
-                    'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-                    "WiFi.AccessPoint.1.AssociatedDevice.1.TxErrors=0",
-                ]
-            ),
-            [
-                "AssocMAC=2C:59:17:00:04:85",
-                "AssocTxErrors=0",
-            ],
-        ),
     ],
 )
 def test_associateddevice_sibling_sed_fragments_execute(
@@ -18951,6 +18938,37 @@ def test_associateddevice_sibling_sed_fragments_execute(
 
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.strip().splitlines() == expected_lines
+
+
+def test_d054_driver_txerrors_command_extracts_sta_info_fields():
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+    case_data = load_case(cases_dir / "D054_txerrors.yaml")
+    step4_command = case_data["steps"][3]["command"]
+    sed_script = step4_command.split("| sed -n ", 1)[1]
+    driver_output = "\n".join(
+        [
+            "rate of last tx pkt: 866000 Kbps",
+            "    tx failures: 26",
+            "idle 0 seconds",
+        ]
+    )
+
+    proc = subprocess.run(
+        [
+            "sh",
+            "-lc",
+            f'STA_MAC="2C:59:17:00:04:85"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; cat <<\'EOF\' | sed -n {sed_script}\n{driver_output}\nEOF',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip().splitlines() == [
+        "DriverAssocMac=2C:59:17:00:04:85",
+        "DriverTxErrors=26",
+    ]
 
 
 def test_run_sta_band_connect_sequence_keeps_6g_ctrl_alive(monkeypatch):


### PR DESCRIPTION
## Summary
- migrate the remaining Wave 2 AssociatedDevice Stage A cases `D038`, `D051`, `D052`, and `D054` to delta validation
- replace blocked/equality-era runtime contracts with explicit baseline/trigger/verify coverage and aligned runtime tests
- sync OpenSpec task state so Wave 1 merge and Wave 2 task `8.1` match the current repo state

## Design
- `docs/superpowers/specs/2026-04-27-issue-38-counter-delta-validation-design.md`

## Case-list diff
- `D038_rx_retransmissions.yaml`
  - before: fail-shaped `equals '0'` + driver `rx total pkts retried`
  - after: 5G uplink-trigger delta case with `delta_nonzero` + `delta_match`
- `D051_tx_retransmissions.yaml`
  - before: blocked placeholder
  - after: 5G downlink-trigger delta case with `delta_nonzero` + `delta_match`
- `D052_tx_retransmissionsfailed.yaml`
  - before: blocked placeholder
  - after: honest manual/external trigger-window delta case with `delta_nonzero` + `delta_match`
- `D054_txerrors.yaml`
  - before: same-STA zero-checkpoint equality case
  - after: honest manual/external trigger-window delta case with `delta_nonzero` + `delta_match`

## Emulated smoke / validation
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py -k 'wave2_associateddevice_delta_cases or d054_txerrors_uses_manual_delta_contract or d054_txerrors_evaluate_live_examples or sanitize_cli_fragment_preserves_nested_quotes_for_associateddevice_driver_checks or d054_txerrors_verification_fragments_preserve_snapshot_and_driver_checks or skip_blocked' plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q`
- `openspec validate wifi-llapi-counter-delta-validation --strict`

## Notes
- `D052` and `D054` intentionally use explicit manual/external trigger windows rather than fake deterministic automation.

Refs #38
