### PR TITLE
feat: 遷移 Wave 3 AssociatedDevice traffic delta cases

### DIFF
--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -101,7 +101,7 @@
 
 ## 9. Wave 3 — Stage B Migration (~50 cases)
 
-- [ ] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D031, D039, D040, D041, D042, D053, D055, D056, D057
+- [ ] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D039, D040, D041, D042, D053, D055, D056, D057; keep D031 as documented holdout because repo-local evidence still shows `MUMimoTxPktsCount` is a stubbed `Not Supported` field rather than a live traffic delta counter
 - [ ] 9.2 Sub-PR `wave3-getstats-traffic`: migrate D128, D130, D131, D132, D135, D136, D137
 - [ ] 9.3 Sub-PR `wave3-getradiostats-bcast-mcast-bytes`: migrate D263–D266, D271–D276
 - [ ] 9.4 Sub-PR `wave3-getssidstats-bcast-mcast-bytes`: migrate D300–D303, D309–D315

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -101,7 +101,7 @@
 
 ## 9. Wave 3 — Stage B Migration (~50 cases)
 
-- [ ] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D039, D040, D041, D042, D053, D055, D056, D057; keep D031 as documented holdout because repo-local evidence still shows `MUMimoTxPktsCount` is a stubbed `Not Supported` field rather than a live traffic delta counter
+- [x] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D039, D040, D041, D042, D053, D055, D056, D057; keep D031 as documented holdout because repo-local evidence still shows `MUMimoTxPktsCount` is a stubbed `Not Supported` field rather than a live traffic delta counter
 - [ ] 9.2 Sub-PR `wave3-getstats-traffic`: migrate D128, D130, D131, D132, D135, D136, D137
 - [ ] 9.3 Sub-PR `wave3-getradiostats-bcast-mcast-bytes`: migrate D263–D266, D271–D276
 - [ ] 9.4 Sub-PR `wave3-getssidstats-bcast-mcast-bytes`: migrate D300–D303, D309–D315

--- a/plugins/wifi_llapi/cases/D039_rxbytes.yaml
+++ b/plugins/wifi_llapi/cases/D039_rxbytes.yaml
@@ -97,22 +97,31 @@ steps:
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2_resolve_probe_target
+- id: step2_prepare_probe_target
+  phase: baseline
+  action: exec
+  target: STA
+  command:
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_resolve_probe_target
   phase: baseline
   action: exec
   target: DUT
   command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
     exit}'
-  depends_on: step1_resolve_assoc
+  depends_on: step2_prepare_probe_target
   capture: dut_ip
-- id: step3_api_baseline
+- id: step4_api_baseline
   phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
-  depends_on: step2_resolve_probe_target
+  depends_on: step3_resolve_probe_target
   capture: api_before_5g
-- id: step4_drv_baseline
+- id: step5_drv_baseline
   phase: baseline
   action: exec
   target: DUT
@@ -120,24 +129,24 @@ steps:
     DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
     '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
     && $2=="bytes:" {print "DriverRxBytes=" $3}'
-  depends_on: step3_api_baseline
+  depends_on: step4_api_baseline
   capture: drv_before_5g
-- id: step5_trigger
+- id: step6_trigger
   phase: trigger
   action: exec
   target: STA
   command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
     | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
-  depends_on: step4_drv_baseline
+  depends_on: step5_drv_baseline
   capture: trigger_probe
-- id: step6_api_verify
+- id: step7_api_verify
   phase: verify
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
-  depends_on: step5_trigger
+  depends_on: step6_trigger
   capture: api_after_5g
-- id: step7_drv_verify
+- id: step8_drv_verify
   phase: verify
   action: exec
   target: DUT
@@ -145,13 +154,17 @@ steps:
     DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
     '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
     && $2=="bytes:" {print "DriverRxBytes=" $3}'
-  depends_on: step6_api_verify
+  depends_on: step7_api_verify
   capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The STA wl0 interface must expose an IPv4 address before the uplink trigger.
 - field: dut_ip.DutIp
   operator: regex
   value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
@@ -184,6 +197,8 @@ pass_criteria:
   description: 5G API RxBytes delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
+- ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+- ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
 - ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
 - ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
 - STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;

--- a/plugins/wifi_llapi/cases/D039_rxbytes.yaml
+++ b/plugins/wifi_llapi/cases/D039_rxbytes.yaml
@@ -54,113 +54,139 @@ test_environment: 'Topology:
 
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
 
-  - use the validated 5G single-band WPA3 baseline for this case
-
-  '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
-  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
-  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
-  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
-  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
-  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
-  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
-  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  - use the validated 5G single-band WPA3 baseline for this case'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
-  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
-  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"\
-  testpilot6g\"\nieee80211w=2\nscan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant
-  -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\n\
-  STA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n\
-  \  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n\
-  DUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
+  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve the DUT br-lan IPv4 address.
 
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes on DUT.
 
-  3) Cross-check the same STA against iw dev wl0 station dump `rx bytes`.
+  2) Capture baseline DUT LLAPI RxBytes and the matching driver `rx bytes` counter for the same STA.
 
-  4) Pass when RxBytes is a positive integer and matches the driver rx-bytes count
-  for the same STA.
 
-  '
+  3) From the STA wl0 interface, run a bounded ping burst toward the resolved DUT bridge IP to exercise STA-to-DUT traffic.
+
+
+  4) Capture verify DUT LLAPI RxBytes and the matching driver `rx bytes` counter, then compare baseline-to-verify deltas.'
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_resolve_probe_target
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
+    exit}'
+  depends_on: step1_resolve_assoc
+  capture: dut_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
-  depends_on: step1
-  capture: result
-- id: step3
+  depends_on: step2_resolve_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: STA_MAC=$(ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 
-    's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-    'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-    mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1;
-    print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-    $1=="rx" && $2=="bytes:" {print "DriverRxBytes=" $3}'
-  depends_on: step2
-  capture: driver_counter
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo
+    DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
+    '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
+    && $2=="bytes:" {print "DriverRxBytes=" $3}'
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo
+    DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
+    '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
+    && $2=="bytes:" {print "DriverRxBytes=" $3}'
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.RxBytes
+- field: dut_ip.DutIp
   operator: regex
-  value: ^[0-9]+$
-  description: RxBytes should be a live non-negative integer counter.
-- field: result.RxBytes
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The DUT br-lan interface must expose an IPv4 address for the STA-originated trigger.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: RxBytes should be positive once the 5G STA has completed 
-    association traffic.
-- field: driver_counter.DriverAssocMac
+  description: The STA trigger step must actually transmit an uplink burst toward the resolved DUT bridge IP.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver sampling must target the same live AssociatedDevice MAC 
-    resolved in step1.
-- field: driver_counter.DriverRxBytes
-  operator: '>'
-  value: '0'
-  description: iw station dump must report a positive rx-bytes count for the 
-    same STA.
-- field: result.RxBytes
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
   operator: equals
-  reference: driver_counter.DriverRxBytes
-  description: LLAPI RxBytes must match iw station dump rx bytes for the same 
-    STA.
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- delta:
+    baseline: api_before_5g.RxBytes
+    verify: api_after_5g.RxBytes
+  operator: delta_nonzero
+  description: 5G API RxBytes must grow after the STA-originated trigger workload.
+- delta:
+    baseline: api_before_5g.RxBytes
+    verify: api_after_5g.RxBytes
+  reference_delta:
+    baseline: drv_before_5g.DriverRxBytes
+    verify: drv_after_5g.DriverRxBytes
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API RxBytes delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxBytes?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-  'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-  mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1; 
-  print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-  $1=="rx" && $2=="bytes:" {print "DriverRxBytes=" $3}'
+- ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
+- ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
+- STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1;
+  print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx" && $2=="bytes:" {print "DriverRxBytes="
+  $3}'

--- a/plugins/wifi_llapi/cases/D040_rxmulticastpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D040_rxmulticastpacketcount.yaml
@@ -8,8 +8,7 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: ubus-cli 
-  "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
 llapi_support: Support
 implemented_by: pWHM
 bands:
@@ -55,118 +54,137 @@ test_environment: 'Topology:
 
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
 
-  - use the validated 5G single-band WPA3 baseline for this case
-
-  '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
-  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
-  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
-  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
-  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
-  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
-  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
-  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  - use the validated 5G single-band WPA3 baseline for this case'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
-  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
-  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"\
-  testpilot6g\"\nieee80211w=2\nscan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant
-  -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\n\
-  STA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n\
-  \  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n\
-  DUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
+  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and assign a concrete wl0 IPv4 address for the multicast/broadcast
+  probe.
 
-  2) From COM1, generate a small broadcast/multicast probe on wl0.
 
-  3) Read WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount on DUT.
+  2) Capture baseline DUT LLAPI RxMulticastPacketCount and the matching driver `rx mcast/bcast pkts` counter for the same
+  STA.
 
-  4) Cross-check the same STA against wl0 sta_info `rx mcast/bcast pkts`.
 
-  5) The workbook expects Fail: after the probe, LLAPI RxMulticastPacketCount still
-  reads 0 while the driver counter becomes non-zero.
+  3) From COM0 wl0, send a bounded broadcast ping burst and keep explicit evidence that packets were transmitted.
 
-  '
+
+  4) Capture verify DUT LLAPI RxMulticastPacketCount and the matching driver `rx mcast/bcast pkts` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_prepare_probe_target
+  phase: baseline
   action: exec
   target: STA
-  command: PROBE_OUT=$(ping -I wl0 -b -c 5 -W 1 192.168.1.255 2>&1); if ! printf
-    '%s\n' "$PROBE_OUT" | grep -q 'packets transmitted'; then PROBE_OUT=$(ping 
-    -I wl0 -c 5 -W 1 224.0.0.1 2>&1); fi; printf '%s\n' "$PROBE_OUT"; printf 
-    '%s\n' "$PROBE_OUT" | awk '/packets transmitted/ {print "ProbeTxPackets=" 
-    $1; exit}'
-  depends_on: step1
-  capture: probe
-- id: step3
+  command:
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
-  depends_on: step2
-  capture: result
-- id: step4
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
+  depends_on: step2_prepare_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: STA_MAC=$(ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 
-    's/.*MACAddress="\([^"]*\)".*/\1/p'); [ -n "$STA_MAC" ] && echo 
-    DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | awk '/rx 
-    mcast\/bcast pkts:/ {print "DriverRxMulticastPacketCount=" $4}'
-  depends_on: step3
-  capture: driver_counter
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl
+    -i wl0 sta_info $STA_MAC | awk '/rx mcast\/bcast pkts:/ {print "DriverRxMulticastPacketCount=" $4}'
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: PROBE_OUT=$(ping -I wl0 -b -c 5 -W 1 192.168.1.255 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl
+    -i wl0 sta_info $STA_MAC | awk '/rx mcast\/bcast pkts:/ {print "DriverRxMulticastPacketCount=" $4}'
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.RxMulticastPacketCount
-  operator: equals
-  value: '0'
-  description: Workbook v4.0.3 marks this API as Fail; LLAPI 
-    RxMulticastPacketCount still reads 0.
-- field: probe.ProbeTxPackets
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The STA wl0 interface must expose an IPv4 address before the broadcast trigger.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: The COM1 probe step must actually transmit multicast/broadcast 
-    packets on wl0 in this run.
-- field: driver_counter.DriverAssocMac
+  description: The STA multicast/broadcast trigger must actually transmit packets in this run.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver sampling must target the same live AssociatedDevice MAC 
-    resolved in step1.
-- field: driver_counter.DriverRxMulticastPacketCount
-  operator: '>'
-  value: '0'
-  description: After the broadcast/multicast probe, wl0 sta_info must report 
-    non-zero rx mcast/bcast pkts for the same STA.
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- delta:
+    baseline: api_before_5g.RxMulticastPacketCount
+    verify: api_after_5g.RxMulticastPacketCount
+  operator: delta_nonzero
+  description: 5G API RxMulticastPacketCount must grow after the STA multicast/broadcast trigger workload.
+- delta:
+    baseline: api_before_5g.RxMulticastPacketCount
+    verify: api_after_5g.RxMulticastPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverRxMulticastPacketCount
+    verify: drv_after_5g.DriverRxMulticastPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API RxMulticastPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p'); [ -n "$STA_MAC" ] && echo 
-  DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | awk '/rx mcast\/bcast
-  pkts:/ {print "DriverRxMulticastPacketCount=" $4}'
+- ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+- ping -I wl0 -b -c 5 -W 1 192.168.1.255
+- STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0
+  sta_info $STA_MAC | awk '/rx mcast\/bcast pkts:/ {print "DriverRxMulticastPacketCount=" $4}'

--- a/plugins/wifi_llapi/cases/D041_rxpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D041_rxpacketcount.yaml
@@ -98,22 +98,31 @@ steps:
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2_resolve_probe_target
+- id: step2_prepare_probe_target
+  phase: baseline
+  action: exec
+  target: STA
+  command:
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_resolve_probe_target
   phase: baseline
   action: exec
   target: DUT
   command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
     exit}'
-  depends_on: step1_resolve_assoc
+  depends_on: step2_prepare_probe_target
   capture: dut_ip
-- id: step3_api_baseline
+- id: step4_api_baseline
   phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
-  depends_on: step2_resolve_probe_target
+  depends_on: step3_resolve_probe_target
   capture: api_before_5g
-- id: step4_drv_baseline
+- id: step5_drv_baseline
   phase: baseline
   action: exec
   target: DUT
@@ -121,24 +130,24 @@ steps:
     DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
     '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
     && $2=="packets:" {print "DriverRxPacketCount=" $3}'
-  depends_on: step3_api_baseline
+  depends_on: step4_api_baseline
   capture: drv_before_5g
-- id: step5_trigger
+- id: step6_trigger
   phase: trigger
   action: exec
   target: STA
   command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
     | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
-  depends_on: step4_drv_baseline
+  depends_on: step5_drv_baseline
   capture: trigger_probe
-- id: step6_api_verify
+- id: step7_api_verify
   phase: verify
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
-  depends_on: step5_trigger
+  depends_on: step6_trigger
   capture: api_after_5g
-- id: step7_drv_verify
+- id: step8_drv_verify
   phase: verify
   action: exec
   target: DUT
@@ -146,13 +155,17 @@ steps:
     DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
     '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
     && $2=="packets:" {print "DriverRxPacketCount=" $3}'
-  depends_on: step6_api_verify
+  depends_on: step7_api_verify
   capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The STA wl0 interface must expose an IPv4 address before the uplink trigger.
 - field: dut_ip.DutIp
   operator: regex
   value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
@@ -185,6 +198,8 @@ pass_criteria:
   description: 5G API RxPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
+- ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+- ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
 - ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
 - ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
 - STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;

--- a/plugins/wifi_llapi/cases/D041_rxpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D041_rxpacketcount.yaml
@@ -54,113 +54,140 @@ test_environment: 'Topology:
 
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
 
-  - use the validated 5G single-band WPA3 baseline for this case
-
-  '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
-  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
-  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
-  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
-  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
-  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
-  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
-  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  - use the validated 5G single-band WPA3 baseline for this case'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
-  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
-  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"\
-  testpilot6g\"\nieee80211w=2\nscan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant
-  -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n  sleep 3\n\
-  STA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n\
-  \  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n\
-  DUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
+  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve the DUT br-lan IPv4 address.
 
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount on DUT.
 
-  3) Cross-check the same STA against iw dev wl0 station dump `rx packets`.
+  2) Capture baseline DUT LLAPI RxPacketCount and the matching driver `rx packets` counter for the same STA.
 
-  4) Pass when RxPacketCount is a positive integer and matches the driver rx-packet
-  count for the same STA.
 
-  '
+  3) From the STA wl0 interface, run a bounded ping burst toward the resolved DUT bridge IP to exercise STA-to-DUT traffic.
+
+
+  4) Capture verify DUT LLAPI RxPacketCount and the matching driver `rx packets` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_resolve_probe_target
+  phase: baseline
+  action: exec
+  target: DUT
+  command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
+    exit}'
+  depends_on: step1_resolve_assoc
+  capture: dut_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
-  depends_on: step1
-  capture: result
-- id: step3
+  depends_on: step2_resolve_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: STA_MAC=$(ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 
-    's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-    'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-    mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1;
-    print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-    $1=="rx" && $2=="packets:" {print "DriverRxPacketCount=" $3}'
-  depends_on: step2
-  capture: driver_counter
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo
+    DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
+    '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
+    && $2=="packets:" {print "DriverRxPacketCount=" $3}'
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo
+    DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC"
+    '$1=="Station" && $2==mac {matched=1; print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx"
+    && $2=="packets:" {print "DriverRxPacketCount=" $3}'
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.RxPacketCount
+- field: dut_ip.DutIp
   operator: regex
-  value: ^[0-9]+$
-  description: RxPacketCount should be a live non-negative integer counter.
-- field: result.RxPacketCount
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The DUT br-lan interface must expose an IPv4 address for the STA-originated trigger.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: RxPacketCount should be positive once the 5G STA has completed 
-    association traffic.
-- field: driver_counter.DriverAssocMac
+  description: The STA trigger step must actually transmit an uplink burst toward the resolved DUT bridge IP.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver sampling must target the same live AssociatedDevice MAC 
-    resolved in step1.
-- field: driver_counter.DriverRxPacketCount
-  operator: '>'
-  value: '0'
-  description: iw station dump must report a positive rx-packet count for the 
-    same STA.
-- field: result.RxPacketCount
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
   operator: equals
-  reference: driver_counter.DriverRxPacketCount
-  description: LLAPI RxPacketCount must match iw station dump rx packets for the
-    same STA.
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- delta:
+    baseline: api_before_5g.RxPacketCount
+    verify: api_after_5g.RxPacketCount
+  operator: delta_nonzero
+  description: 5G API RxPacketCount must grow after the STA-originated trigger workload.
+- delta:
+    baseline: api_before_5g.RxPacketCount
+    verify: api_after_5g.RxPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverRxPacketCount
+    verify: drv_after_5g.DriverRxPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API RxPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxPacketCount?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-  'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-  mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1; 
-  print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-  $1=="rx" && $2=="packets:" {print "DriverRxPacketCount=" $3}'
+- ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
+- ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
+- STA_MAC="{{assoc_entry.MACAddress}}"; STA_MAC_LOWER=$(echo "$STA_MAC" | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
+  [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1;
+  print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && $1=="rx" && $2=="packets:" {print "DriverRxPacketCount="
+  $3}'

--- a/plugins/wifi_llapi/cases/D042_rxunicastpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D042_rxunicastpacketcount.yaml
@@ -1,5 +1,5 @@
 id: wifi-llapi-D042-rxunicastpacketcount
-name: "RxUnicastPacketCount — WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
+name: RxUnicastPacketCount — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
 version: '1.1'
 source:
   row: 42
@@ -8,10 +8,11 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"'
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
 llapi_support: Support
 implemented_by: pWHM
-bands: ["5g"]
+bands:
+- 5g
 topology:
   devices:
     DUT:
@@ -31,147 +32,157 @@ topology:
   - from: STA
     to: DUT
     band: 5g
-test_environment: |
-  Topology:
+test_environment: 'Topology:
+
   - DUT: COM1 (AP role)
+
   - STA: COM0 (station role for this case; do not rely on the old A0/B0 heuristic)
+
   Transport:
+
   - serialwrap attach COM0 / COM1
+
   Live band mapping:
+
   - 5G: DUT wl0 / AP1 / SSID.4 / TestPilot_BTM
+
   - 6G: DUT wl1 / AP3 / SSID.6 / TestPilot_BTM
+
   - 2.4G: DUT wl2 / AP5 / SSID.8 / TestPilot_24G
+
   Preconditions:
+
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
-  - use the validated 5G single-band WPA3 baseline for this case
-setup_steps: |
-  1) DUT 5G baseline:
-     - enable Radio.1 / SSID.4 / AP1
-     - configure AP1 as WPA3-Personal with MFP required
-     - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g
-  2) STA 5G preparation:
-     - disable local AP1/AP2 on COM1
-     - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects
-     - reset wl0 and its wpa_supplicant control socket
-     - connect wl0 to TestPilot_BTM with SAE
-  3) Association evidence:
-     - COM1: iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status
-     - COM0: wl -i wl0 assoclist
-sta_env_setup: |
-  DUT 5G AP baseline:
-    ubus-cli WiFi.Radio.1.Enable=1
-    ubus-cli WiFi.Radio.1.BeaconPeriod=100
-    ubus-cli WiFi.Radio.1.DTIMPeriod=3
-    ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1
-    ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1
-    ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto
-    ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1
-    ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1
-    ubus-cli WiFi.Radio.1.OfdmaEnable=1
-    ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0
-    ubus-cli WiFi.Radio.1.OperatingStandards=ax
-    ubus-cli WiFi.Radio.1.RxChainCtrl=-1
-    ubus-cli WiFi.Radio.1.TxChainCtrl=-1
-    ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0
-    ubus-cli WiFi.Radio.1.Sensing.Enable=1
-    ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0
-    ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0
-    ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0
-    ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0
-    ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0
-    ubus-cli WiFi.Radio.1.LongRetryLimit=6
-    ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1
-    ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1
-    ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM
-    ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=
-    ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=
-    ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal
-    ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g
-    ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required
-    ubus-cli WiFi.AccessPoint.1.Enable=1
-  STA 5G preparation:
-    ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up
-    ubus-cli WiFi.AccessPoint.1.Enable=0
-    ubus-cli WiFi.AccessPoint.2.Enable=0
-    wpa_cli terminate 2>/dev/null || true
-    rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true
-    iw dev wl0.1 del 2>/dev/null || true
-    iw dev wl0 disconnect 2>/dev/null || true
-    iw dev wl1 disconnect 2>/dev/null || true
-    iw dev wl2 disconnect 2>/dev/null || true
-    iw dev wl0 set type managed
-    ifconfig wl0 up
-    mkdir -p /var/run/wpa_supplicant
-    printf 'ctrl_interface=/var/run/wpa_supplicant
-  update_config=1
-  sae_pwe=2
-  network={
-  ssid="TestPilot_BTM"
-  key_mgmt=SAE
-  sae_password="testpilot6g"
-  ieee80211w=2
-  scan_ssid=1
-  }
-  ' > /tmp/wpa_wl0.conf
-    wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant
-    sleep 3
-  STA 5G connect verify:
-    wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect
-    sleep 10
-    iw dev wl0 link
-    wpa_cli -p /var/run/wpa_supplicant -i wl0 status
-  DUT association evidence:
-    wl -i wl0 assoclist
-test_procedure: |
-  1) Confirm the 5G STA is associated to AP1 and resolve its live MAC address.
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount on DUT. The workbook expects this case to fail: the LLAPI stays 0 even though driver `rx ucast pkts` is non-zero for the same STA.
-  3) Cross-check the same STA against wl0 sta_info `rx ucast pkts`.
+
+  - use the validated 5G single-band WPA3 baseline for this case'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
+  \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\n\
+  update_config=1\nsae_pwe=2\nnetwork={\nssid=\"TestPilot_BTM\"\nkey_mgmt=SAE\nsae_password=\"testpilot6g\"\nieee80211w=2\n\
+  scan_ssid=1\n}\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve the DUT br-lan IPv4 address.
+
+
+  2) Capture baseline DUT LLAPI RxUnicastPacketCount and the matching driver `rx ucast pkts` counter for the same STA.
+
+
+  3) From the STA wl0 interface, run a bounded ping burst toward the resolved DUT bridge IP to exercise STA-to-DUT unicast
+  traffic.
+
+
+  4) Capture verify DUT LLAPI RxUnicastPacketCount and the matching driver `rx ucast pkts` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_resolve_assoc
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2
+- id: step2_resolve_probe_target
+  phase: baseline
   action: exec
   target: DUT
-  command: ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
-  depends_on: step1
-  capture: result
-- id: step3
+  command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
+    exit}'
+  depends_on: step1_resolve_assoc
+  capture: dut_ip
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p''); [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC;
-    [ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts:
-    *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
-  depends_on: step2
-  capture: driver_counter
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
+  depends_on: step2_resolve_probe_target
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts: *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts: *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.RxUnicastPacketCount
-  operator: equals
+- field: dut_ip.DutIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The DUT br-lan interface must expose an IPv4 address for the STA-originated trigger.
+- field: trigger_probe.TriggerTxPackets
+  operator: '>'
   value: '0'
-  description: 'Workbook v4.0.3 marks this API as Fail: LLAPI RxUnicastPacketCount
-    still reads 0.'
-- field: driver_counter.DriverAssocMac
+  description: The STA trigger step must actually transmit an uplink burst toward the resolved DUT bridge IP.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver counter sampling must use the same live AssociatedDevice 
-    MAC resolved in step1.
-- field: driver_counter.DriverRxUnicastPacketCount
-  operator: ">"
-  value: '0'
-  description: Driver counters must still show real RX unicast packets for the 
-    same STA.
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- field: drv_after_5g.DriverAssocMac
+  operator: equals
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step1.
+- delta:
+    baseline: api_before_5g.RxUnicastPacketCount
+    verify: api_after_5g.RxUnicastPacketCount
+  operator: delta_nonzero
+  description: 5G API RxUnicastPacketCount must grow after the STA-originated trigger workload.
+- delta:
+    baseline: api_before_5g.RxUnicastPacketCount
+    verify: api_after_5g.RxUnicastPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverRxUnicastPacketCount
+    verify: drv_after_5g.DriverRxUnicastPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API RxUnicastPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
-- 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"'
-- 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-  ''s/.*MACAddress="\([^"]*\)".*/\1/p'')'
-- '[ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC'
-- '[ -n "$STA_MAC" ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts:
-  *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
+- ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
+- ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0
+  sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts: *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''

--- a/plugins/wifi_llapi/cases/D042_rxunicastpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D042_rxunicastpacketcount.yaml
@@ -99,57 +99,70 @@ steps:
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
   capture: assoc_entry
-- id: step2_resolve_probe_target
+- id: step2_prepare_probe_target
+  phase: baseline
+  action: exec
+  target: STA
+  command:
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  depends_on: step1_resolve_assoc
+  capture: sta_ip
+- id: step3_resolve_probe_target
   phase: baseline
   action: exec
   target: DUT
   command: ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2;
     exit}'
-  depends_on: step1_resolve_assoc
+  depends_on: step2_prepare_probe_target
   capture: dut_ip
-- id: step3_api_baseline
+- id: step4_api_baseline
   phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
-  depends_on: step2_resolve_probe_target
+  depends_on: step3_resolve_probe_target
   capture: api_before_5g
-- id: step4_drv_baseline
+- id: step5_drv_baseline
   phase: baseline
   action: exec
   target: DUT
   command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
     wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts: *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
-  depends_on: step3_api_baseline
+  depends_on: step4_api_baseline
   capture: drv_before_5g
-- id: step5_trigger
+- id: step6_trigger
   phase: trigger
   action: exec
   target: STA
   command: PROBE_OUT=$(ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
     | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
-  depends_on: step4_drv_baseline
+  depends_on: step5_drv_baseline
   capture: trigger_probe
-- id: step6_api_verify
+- id: step7_api_verify
   phase: verify
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
-  depends_on: step5_trigger
+  depends_on: step6_trigger
   capture: api_after_5g
-- id: step7_drv_verify
+- id: step8_drv_verify
   phase: verify
   action: exec
   target: DUT
   command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
     wl -i wl0 sta_info $STA_MAC | sed -n ''s/.*rx ucast pkts: *\([0-9][0-9]*\).*/DriverRxUnicastPacketCount=\1/p'''
-  depends_on: step6_api_verify
+  depends_on: step7_api_verify
   capture: drv_after_5g
 pass_criteria:
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
   description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+- field: sta_ip.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The STA wl0 interface must expose an IPv4 address before the uplink trigger.
 - field: dut_ip.DutIp
   operator: regex
   value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
@@ -182,6 +195,8 @@ pass_criteria:
   description: 5G API RxUnicastPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxUnicastPacketCount?"
+- ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+- ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
 - ifconfig br-lan | awk '/inet addr:/ {gsub("addr:","",$2); print "DutIp=" $2; exit} $1=="inet" {print "DutIp=" $2; exit}'
 - ping -I wl0 -c 8 -s 1400 -W 1 <resolved DUT br-lan IPv4>
 - 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0

--- a/plugins/wifi_llapi/cases/D053_txbytes.yaml
+++ b/plugins/wifi_llapi/cases/D053_txbytes.yaml
@@ -1,5 +1,5 @@
 id: wifi-llapi-D053-txbytes
-name: "TxBytes — WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
+name: TxBytes — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
 version: '1.1'
 source:
   row: 53
@@ -8,7 +8,7 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"'
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"
 llapi_support: Support
 implemented_by: pWHM
 bands:
@@ -55,447 +55,405 @@ topology:
   - from: STA
     to: DUT
     band: 2.4g
-test_environment: |
-  Topology:
+test_environment: 'Topology:
+
   - DUT: COM0 (AP role)
+
   - STA: COM1 (STA role)
+
   Transport:
+
   - DUT/STA via serialwrap COM0 / COM1
+
   Baseline:
+
   - 5G = AP1 / wl0 / testpilot5G / WPA2-Personal
+
   - 6G = AP3 / wl1 / testpilot6G / WPA3-Personal / SAE
+
   - 2.4G = AP5 / wl2 / testpilot2G / WPA2-Personal
+
   Preconditions:
+
   - keep exactly one associated STA on the selected AP so AssociatedDevice.1 stays deterministic
+
   - let the runner own the per-band baseline; 6G must reuse the built-in ocv=0 repair path before the probe window
+
   - replay sequentially per band; do not rely on simultaneous multi-band STA association
+
   Notes:
+
   - workbook row 53 is TxBytes; stale row 55 belongs to TxRetransmissionsFailed
+
   - current 0403 source exposes AssociatedDevice.TxBytes and backs it with wl sta_info `tx total bytes`
-  - the live oracle for this case is: same STA MAC -> direct TxBytes getter -> same AssociatedDevice snapshot -> same-station wl sta_info tx total bytes
-setup_steps: |
-  1) Let the runner apply the deterministic baseline for the selected band.
+
+  - the live oracle for this case is: same STA MAC -> direct TxBytes getter -> same AssociatedDevice snapshot -> same-station
+  wl sta_info tx total bytes'
+setup_steps: '1) Let the runner apply the deterministic baseline for the selected band.
+
   2) Verify the STA interface is associated and that the DUT-side AssociatedDevice.1 MAC resolves to the same live STA.
-  3) Assign 192.168.1.3/24 to the STA interface, trigger outbound traffic with `ping -I wlX -c 8 -W 1 192.168.1.1`, then read TxBytes directly.
-  4) Cross-check the same AssociatedDevice snapshot and wl sta_info `tx total bytes` for the identical station.
-test_procedure: |
-  1) On each band, confirm the STA remains associated (`wpa_state=COMPLETED`) and capture the live STA MAC.
-  2) Resolve the matching DUT-side `AssociatedDevice.1.MACAddress`.
-  3) Trigger outbound STA traffic with `ifconfig wlX 192.168.1.3/24` and `ping -I wlX -c 8 -W 1 192.168.1.1`.
-  4) Capture the same `AssociatedDevice.1` snapshot first, then immediately re-read direct `TxBytes?` and `wl sta_info <sta-mac>` inside one DUT-side shell window.
-  5) Compare the direct getter to the same-window snapshot and the same-station `wl sta_info` counters.
+
+  3) Assign 192.168.1.3/24 to the STA interface, trigger outbound traffic with `ping -I wlX -c 8 -W 1 192.168.1.1`, then read
+  TxBytes directly.
+
+  4) Cross-check the same AssociatedDevice snapshot and wl sta_info `tx total bytes` for the identical station.'
+test_procedure: '1) On each supported band, resolve the live STA state, assign a concrete wlX IPv4 address, and require the
+  matching AssociatedDevice.1 entry to point to that same station.
+
+
+  2) Capture baseline DUT LLAPI TxBytes and the matching driver `tx total bytes` counter for the same STA.
+
+
+  3) From the DUT bridge IP, run a bounded ping burst toward the resolved STA IP to exercise AP-to-STA traffic.
+
+
+  4) Capture verify DUT LLAPI TxBytes and the matching driver `tx total bytes` counter, then compare baseline-to-verify deltas
+  for 5G, 6G, and 2.4G.'
 steps:
 - id: step1_5g_sta_ready
+  phase: baseline
   action: exec
   target: STA
   band: 5g
   command:
-  - iw dev wl0 link
-  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 
-    's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p; 
-    s/^bssid=/bssid=/p; s/^freq=/freq=/p'
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
   - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
   capture: sta_ready_5g
 - id: step2_5g_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
   band: 5g
-  command: >-
-    ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f' | sed 's/^/AssocMac5g=/'
-  capture: assoc_entry_5g
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/AssocMac5g=/'
   depends_on: step1_5g_sta_ready
-- id: step3_5g_ip_prep
+  capture: assoc_entry_5g
+- id: step3_5g_api_baseline
+  phase: baseline
   action: exec
-  target: STA
+  target: DUT
   band: 5g
-  command:
-  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
-  - ip -4 addr show dev wl0 | awk '/inet / {print "StaIp5g=" $2}'
-  capture: traffic_prep_5g
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"
   depends_on: step2_5g_assoc_entry
-- id: step4_5g_ping_trigger
-  action: exec
-  target: STA
-  band: 5g
-  command: >-
-    OUT=$(ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1); RC=$?; printf '%s\n' "$OUT"; printf
-    'PingReturnCode5g=%s\n' "$RC"; printf '%s\n' "$OUT" | sed -n 's/^\([0-9][0-9]*\)
-    packets transmitted, \([0-9][0-9]*\) received.*/PingTx5g=\1\nPingRx5g=\2/p'
-  capture: ping_5g
-  depends_on: step3_5g_ip_prep
-- id: step5_5g_tight_capture
+  capture: api_before_5g
+- id: step4_5g_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
   band: 5g
-  command: >-
-    SNAP=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" 2>&1); printf '%s\n'
-    "$SNAP" | awk -F= '/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-    "", $2); print "AssocMac5g=" tolower($2)} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxBytes=/
-    {print "AssocTxBytes5g=" $2} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxPacketCount=/
-    {print "AssocTxPacketCount5g=" $2}'; STA_MAC=$(printf '%s\n' "$SNAP" | sed -n
-    's/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f'); ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?" |
-    sed -n 's/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes5g=\1/p';
-    [ -n "$STA_MAC" ] && echo DriverAssocMac5g=$STA_MAC && wl -i wl0 sta_info $STA_MAC
-    | sed -n 's/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes5g=\1/p;
-    s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount5g=\1/p'
-  capture: capture_5g
-  depends_on: step4_5g_ping_trigger
-- id: step6_6g_sta_ready
+  command: 'STA_MAC="{{assoc_entry_5g.AssocMac5g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac5g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes5g=\1/p'''
+  depends_on: step3_5g_api_baseline
+  capture: drv_before_5g
+- id: step5_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_5g.StaIp5g}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n'
+    "$PROBE_OUT" | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step4_5g_drv_baseline
+  capture: trigger_5g
+- id: step6_5g_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"
+  depends_on: step5_5g_trigger
+  capture: api_after_5g
+- id: step7_5g_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'STA_MAC="{{assoc_entry_5g.AssocMac5g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac5g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes5g=\1/p'''
+  depends_on: step6_5g_api_verify
+  capture: drv_after_5g
+- id: step8_6g_sta_ready
+  phase: baseline
   action: exec
   target: STA
   band: 6g
   command:
-  - iw dev wl1 link
-  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 
-    's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p; 
-    s/^bssid=/bssid=/p; s/^freq=/freq=/p'
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
   - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
-  capture: sta_ready_6g
-- id: step7_6g_assoc_entry
-  action: exec
-  target: DUT
-  band: 6g
-  command: >-
-    ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f' | sed 's/^/AssocMac6g=/'
-  capture: assoc_entry_6g
-  depends_on: step6_6g_sta_ready
-- id: step8_6g_ip_prep
-  action: exec
-  target: STA
-  band: 6g
-  command:
   - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
-  - ip -4 addr show dev wl1 | awk '/inet / {print "StaIp6g=" $2}'
-  capture: traffic_prep_6g
-  depends_on: step7_6g_assoc_entry
-- id: step9_6g_ping_trigger
-  action: exec
-  target: STA
-  band: 6g
-  command: >-
-    OUT=$(ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1); RC=$?; printf '%s\n' "$OUT"; printf
-    'PingReturnCode6g=%s\n' "$RC"; printf '%s\n' "$OUT" | sed -n 's/^\([0-9][0-9]*\)
-    packets transmitted, \([0-9][0-9]*\) received.*/PingTx6g=\1\nPingRx6g=\2/p'
-  capture: ping_6g
-  depends_on: step8_6g_ip_prep
-- id: step10_6g_tight_capture
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step9_6g_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
   band: 6g
-  command: >-
-    SNAP=$(ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.?" 2>&1); printf '%s\n'
-    "$SNAP" | awk -F= '/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-    "", $2); print "AssocMac6g=" tolower($2)} /^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxBytes=/
-    {print "AssocTxBytes6g=" $2} /^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxPacketCount=/
-    {print "AssocTxPacketCount6g=" $2}'; STA_MAC=$(printf '%s\n' "$SNAP" | sed -n
-    's/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f'); ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes?" |
-    sed -n 's/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes6g=\1/p';
-    [ -n "$STA_MAC" ] && echo DriverAssocMac6g=$STA_MAC && wl -i wl1 sta_info $STA_MAC
-    | sed -n 's/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes6g=\1/p;
-    s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount6g=\1/p'
-  capture: capture_6g
-  depends_on: step9_6g_ping_trigger
-- id: step11_24g_sta_ready
+  command: ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/AssocMac6g=/'
+  depends_on: step8_6g_sta_ready
+  capture: assoc_entry_6g
+- id: step10_6g_api_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes?"
+  depends_on: step9_6g_assoc_entry
+  capture: api_before_6g
+- id: step11_6g_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'STA_MAC="{{assoc_entry_6g.AssocMac6g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac6g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl1 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes6g=\1/p'''
+  depends_on: step10_6g_api_baseline
+  capture: drv_before_6g
+- id: step12_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_6g.StaIp6g}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n'
+    "$PROBE_OUT" | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step11_6g_drv_baseline
+  capture: trigger_6g
+- id: step13_6g_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes?"
+  depends_on: step12_6g_trigger
+  capture: api_after_6g
+- id: step14_6g_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'STA_MAC="{{assoc_entry_6g.AssocMac6g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac6g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl1 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes6g=\1/p'''
+  depends_on: step13_6g_api_verify
+  capture: drv_after_6g
+- id: step15_24g_sta_ready
+  phase: baseline
   action: exec
   target: STA
   band: 2.4g
   command:
-  - iw dev wl2 link
-  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 
-    's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p; 
-    s/^bssid=/bssid=/p; s/^freq=/freq=/p'
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
   - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
-  capture: sta_ready_24g
-- id: step12_24g_assoc_entry
-  action: exec
-  target: DUT
-  band: 2.4g
-  command: >-
-    ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f' | sed 's/^/AssocMac24g=/'
-  capture: assoc_entry_24g
-  depends_on: step11_24g_sta_ready
-- id: step13_24g_ip_prep
-  action: exec
-  target: STA
-  band: 2.4g
-  command:
   - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
-  - ip -4 addr show dev wl2 | awk '/inet / {print "StaIp24g=" $2}'
-  capture: traffic_prep_24g
-  depends_on: step12_24g_assoc_entry
-- id: step14_24g_ping_trigger
-  action: exec
-  target: STA
-  band: 2.4g
-  command: >-
-    OUT=$(ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1); RC=$?; printf '%s\n' "$OUT"; printf
-    'PingReturnCode24g=%s\n' "$RC"; printf '%s\n' "$OUT" | sed -n 's/^\([0-9][0-9]*\)
-    packets transmitted, \([0-9][0-9]*\) received.*/PingTx24g=\1\nPingRx24g=\2/p'
-  capture: ping_24g
-  depends_on: step13_24g_ip_prep
-- id: step15_24g_tight_capture
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step16_24g_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
   band: 2.4g
-  command: >-
-    SNAP=$(ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.?" 2>&1); printf '%s\n'
-    "$SNAP" | awk -F= '/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-    "", $2); print "AssocMac24g=" tolower($2)} /^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxBytes=/
-    {print "AssocTxBytes24g=" $2} /^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxPacketCount=/
-    {print "AssocTxPacketCount24g=" $2}'; STA_MAC=$(printf '%s\n' "$SNAP" | sed -n
-    's/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f'); ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes?" |
-    sed -n 's/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes24g=\1/p';
-    [ -n "$STA_MAC" ] && echo DriverAssocMac24g=$STA_MAC && wl -i wl2 sta_info $STA_MAC
-    | sed -n 's/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes24g=\1/p;
-    s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount24g=\1/p'
-  capture: capture_24g
-  depends_on: step14_24g_ping_trigger
+  command: ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/AssocMac24g=/'
+  depends_on: step15_24g_sta_ready
+  capture: assoc_entry_24g
+- id: step17_24g_api_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes?"
+  depends_on: step16_24g_assoc_entry
+  capture: api_before_24g
+- id: step18_24g_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'STA_MAC="{{assoc_entry_24g.AssocMac24g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac24g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl2 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes24g=\1/p'''
+  depends_on: step17_24g_api_baseline
+  capture: drv_before_24g
+- id: step19_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_24g.StaIp24g}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n'
+    "$PROBE_OUT" | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step18_24g_drv_baseline
+  capture: trigger_24g
+- id: step20_24g_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes?"
+  depends_on: step19_24g_trigger
+  capture: api_after_24g
+- id: step21_24g_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'STA_MAC="{{assoc_entry_24g.AssocMac24g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac24g=$STA_MAC; [ -n "$STA_MAC"
+    ] && wl -i wl2 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes24g=\1/p'''
+  depends_on: step20_24g_api_verify
+  capture: drv_after_24g
 pass_criteria:
 - field: sta_ready_5g.wpa_state
   operator: equals
   value: COMPLETED
-  band: 5g
-  description: 5G STA must remain associated before probing TxBytes.
+  description: 5g STA must remain associated before the downlink trigger.
 - field: sta_ready_5g.ssid
   operator: equals
   value: testpilot5G
-  band: 5g
-  description: 5G STA must stay on the documented testpilot5G baseline.
+  description: 5g STA must remain on the documented baseline SSID.
 - field: sta_ready_5g.StaMac5g
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  band: 5g
-  description: 5G STA MAC must resolve before DUT-side validation.
+  description: 5g STA MAC must resolve before DUT-side validation.
+- field: sta_ready_5g.StaIp5g
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: 5g STA interface must expose an IPv4 address for the DUT-originated trigger.
 - field: assoc_entry_5g.AssocMac5g
   operator: equals
   reference: sta_ready_5g.StaMac5g
-  band: 5g
-  description: 5G AssociatedDevice.1 must resolve to the same live STA MAC.
-- field: ping_5g.PingTx5g
-  operator: equals
-  value: '8'
-  band: 5g
-  description: 5G traffic trigger must attempt eight outbound packets from the 
-    STA interface.
-- field: capture_5g.AssocMac5g
+  description: AssociatedDevice.1 for 5g must resolve to the same live STA MAC.
+- field: trigger_5g.TriggerTxPackets5g
+  operator: '>'
+  value: '0'
+  description: 5g DUT trigger must actually transmit packets toward the resolved STA IP.
+- field: drv_before_5g.DriverAssocMac5g
   operator: equals
   reference: assoc_entry_5g.AssocMac5g
-  band: 5g
-  description: 5G tight capture must stay on the same AssociatedDevice entry.
-- field: capture_5g.AssocTxBytes5g
-  operator: '>'
-  value: '0'
-  band: 5g
-  description: 5G AssociatedDevice snapshot must expose a positive 
-    transmitted-byte counter.
-- field: capture_5g.TxBytes5g
-  operator: equals
-  reference: capture_5g.AssocTxBytes5g
-  band: 5g
-  description: 5G direct getter must match the same-window AssociatedDevice 
-    snapshot value.
-- field: capture_5g.AssocTxPacketCount5g
-  operator: '>'
-  value: '0'
-  band: 5g
-  description: 5G snapshot must show positive transmitted packets for the same 
-    AssociatedDevice entry.
-- field: capture_5g.DriverAssocMac5g
+  description: Baseline driver sampling for 5g must target the same AssociatedDevice MAC.
+- field: drv_after_5g.DriverAssocMac5g
   operator: equals
   reference: assoc_entry_5g.AssocMac5g
-  band: 5g
-  description: 5G driver capture must target the same AssociatedDevice MAC.
-- field: capture_5g.DriverTxBytes5g
-  operator: equals
-  reference: capture_5g.TxBytes5g
-  band: 5g
-  description: 5G wl0 sta_info tx total bytes must exact-close the LLAPI getter.
-- field: capture_5g.DriverTxPacketCount5g
-  operator: '>'
-  value: '0'
-  band: 5g
-  description: 5G wl0 sta_info must report positive tx total packets for the 
-    same STA.
+  description: Verify driver sampling for 5g must target the same AssociatedDevice MAC.
+- delta:
+    baseline: api_before_5g.TxBytes
+    verify: api_after_5g.TxBytes
+  operator: delta_nonzero
+  description: 5g API TxBytes must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_5g.TxBytes
+    verify: api_after_5g.TxBytes
+  reference_delta:
+    baseline: drv_before_5g.DriverTxBytes5g
+    verify: drv_after_5g.DriverTxBytes5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g API TxBytes delta must stay within ±10% of the driver delta.
 - field: sta_ready_6g.wpa_state
   operator: equals
   value: COMPLETED
-  band: 6g
-  description: 6G STA must remain associated before probing TxBytes.
+  description: 6g STA must remain associated before the downlink trigger.
 - field: sta_ready_6g.ssid
   operator: equals
   value: testpilot6G
-  band: 6g
-  description: 6G STA must stay on the documented testpilot6G baseline.
+  description: 6g STA must remain on the documented baseline SSID.
 - field: sta_ready_6g.StaMac6g
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  band: 6g
-  description: 6G STA MAC must resolve before DUT-side validation.
+  description: 6g STA MAC must resolve before DUT-side validation.
+- field: sta_ready_6g.StaIp6g
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: 6g STA interface must expose an IPv4 address for the DUT-originated trigger.
 - field: assoc_entry_6g.AssocMac6g
   operator: equals
   reference: sta_ready_6g.StaMac6g
-  band: 6g
-  description: 6G AssociatedDevice.1 must resolve to the same live STA MAC.
-- field: ping_6g.PingTx6g
-  operator: equals
-  value: '8'
-  band: 6g
-  description: 6G traffic trigger must attempt eight outbound packets from the 
-    STA interface.
-- field: capture_6g.AssocMac6g
+  description: AssociatedDevice.1 for 6g must resolve to the same live STA MAC.
+- field: trigger_6g.TriggerTxPackets6g
+  operator: '>'
+  value: '0'
+  description: 6g DUT trigger must actually transmit packets toward the resolved STA IP.
+- field: drv_before_6g.DriverAssocMac6g
   operator: equals
   reference: assoc_entry_6g.AssocMac6g
-  band: 6g
-  description: 6G tight capture must stay on the same AssociatedDevice entry.
-- field: capture_6g.AssocTxBytes6g
-  operator: '>'
-  value: '0'
-  band: 6g
-  description: 6G AssociatedDevice snapshot must expose a positive 
-    transmitted-byte counter.
-- field: capture_6g.TxBytes6g
-  operator: equals
-  reference: capture_6g.AssocTxBytes6g
-  band: 6g
-  description: 6G direct getter must match the same-window AssociatedDevice 
-    snapshot value.
-- field: capture_6g.AssocTxPacketCount6g
-  operator: '>'
-  value: '0'
-  band: 6g
-  description: 6G snapshot must show positive transmitted packets for the same 
-    AssociatedDevice entry.
-- field: capture_6g.DriverAssocMac6g
+  description: Baseline driver sampling for 6g must target the same AssociatedDevice MAC.
+- field: drv_after_6g.DriverAssocMac6g
   operator: equals
   reference: assoc_entry_6g.AssocMac6g
-  band: 6g
-  description: 6G driver capture must target the same AssociatedDevice MAC.
-- field: capture_6g.DriverTxBytes6g
-  operator: equals
-  reference: capture_6g.TxBytes6g
-  band: 6g
-  description: 6G wl1 sta_info tx total bytes must exact-close the LLAPI getter.
-- field: capture_6g.DriverTxPacketCount6g
-  operator: '>'
-  value: '0'
-  band: 6g
-  description: 6G wl1 sta_info must report positive tx total packets for the 
-    same STA.
+  description: Verify driver sampling for 6g must target the same AssociatedDevice MAC.
+- delta:
+    baseline: api_before_6g.TxBytes
+    verify: api_after_6g.TxBytes
+  operator: delta_nonzero
+  description: 6g API TxBytes must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_6g.TxBytes
+    verify: api_after_6g.TxBytes
+  reference_delta:
+    baseline: drv_before_6g.DriverTxBytes6g
+    verify: drv_after_6g.DriverTxBytes6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g API TxBytes delta must stay within ±10% of the driver delta.
 - field: sta_ready_24g.wpa_state
   operator: equals
   value: COMPLETED
-  band: 2.4g
-  description: 2.4G STA must remain associated before probing TxBytes.
+  description: 24g STA must remain associated before the downlink trigger.
 - field: sta_ready_24g.ssid
   operator: equals
   value: testpilot2G
-  band: 2.4g
-  description: 2.4G STA must stay on the documented testpilot2G baseline.
+  description: 24g STA must remain on the documented baseline SSID.
 - field: sta_ready_24g.StaMac24g
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  band: 2.4g
-  description: 2.4G STA MAC must resolve before DUT-side validation.
+  description: 24g STA MAC must resolve before DUT-side validation.
+- field: sta_ready_24g.StaIp24g
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: 24g STA interface must expose an IPv4 address for the DUT-originated trigger.
 - field: assoc_entry_24g.AssocMac24g
   operator: equals
   reference: sta_ready_24g.StaMac24g
-  band: 2.4g
-  description: 2.4G AssociatedDevice.1 must resolve to the same live STA MAC.
-- field: ping_24g.PingTx24g
-  operator: equals
-  value: '8'
-  band: 2.4g
-  description: 2.4G traffic trigger must attempt eight outbound packets from the
-    STA interface.
-- field: capture_24g.AssocMac24g
+  description: AssociatedDevice.1 for 24g must resolve to the same live STA MAC.
+- field: trigger_24g.TriggerTxPackets24g
+  operator: '>'
+  value: '0'
+  description: 24g DUT trigger must actually transmit packets toward the resolved STA IP.
+- field: drv_before_24g.DriverAssocMac24g
   operator: equals
   reference: assoc_entry_24g.AssocMac24g
-  band: 2.4g
-  description: 2.4G tight capture must stay on the same AssociatedDevice entry.
-- field: capture_24g.AssocTxBytes24g
-  operator: '>'
-  value: '0'
-  band: 2.4g
-  description: 2.4G AssociatedDevice snapshot must expose a positive 
-    transmitted-byte counter.
-- field: capture_24g.TxBytes24g
-  operator: equals
-  reference: capture_24g.AssocTxBytes24g
-  band: 2.4g
-  description: 2.4G direct getter must match the same-window AssociatedDevice 
-    snapshot value.
-- field: capture_24g.AssocTxPacketCount24g
-  operator: '>'
-  value: '0'
-  band: 2.4g
-  description: 2.4G snapshot must show positive transmitted packets for the same
-    AssociatedDevice entry.
-- field: capture_24g.DriverAssocMac24g
+  description: Baseline driver sampling for 24g must target the same AssociatedDevice MAC.
+- field: drv_after_24g.DriverAssocMac24g
   operator: equals
   reference: assoc_entry_24g.AssocMac24g
-  band: 2.4g
-  description: 2.4G driver capture must target the same AssociatedDevice MAC.
-- field: capture_24g.DriverTxBytes24g
-  operator: equals
-  reference: capture_24g.TxBytes24g
-  band: 2.4g
-  description: 2.4G wl2 sta_info tx total bytes must exact-close the LLAPI 
-    getter.
-- field: capture_24g.DriverTxPacketCount24g
-  operator: '>'
-  value: '0'
-  band: 2.4g
-  description: 2.4G wl2 sta_info must report positive tx total packets for the 
-    same STA.
+  description: Verify driver sampling for 24g must target the same AssociatedDevice MAC.
+- delta:
+    baseline: api_before_24g.TxBytes
+    verify: api_after_24g.TxBytes
+  operator: delta_nonzero
+  description: 24g API TxBytes must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_24g.TxBytes
+    verify: api_after_24g.TxBytes
+  reference_delta:
+    baseline: drv_before_24g.DriverTxBytes24g
+    verify: drv_after_24g.DriverTxBytes24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g API TxBytes delta must stay within ±10% of the driver delta.
 verification_command:
-- wpa_cli -p /var/run/wpa_supplicant -i wl0 status
-- cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
-- ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
-- ping -I wl0 -c 8 -W 1 192.168.1.1
-- 'SNAP=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" 2>&1); printf ''%s\n''
-  "$SNAP" | awk -F= ''/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-  "", $2); print "AssocMac5g=" tolower($2)} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxBytes=/
-  {print "AssocTxBytes5g=" $2} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxPacketCount=/
-  {print "AssocTxPacketCount5g=" $2}''; STA_MAC=$(printf ''%s\n'' "$SNAP" | sed -n
-  ''s/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p''
-  | tr ''A-F'' ''a-f''); ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"
-  | sed -n ''s/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes5g=\1/p'';
-  [ -n "$STA_MAC" ] && echo DriverAssocMac5g=$STA_MAC && wl -i wl0 sta_info $STA_MAC
-  | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes5g=\1/p;
-  s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount5g=\1/p'''
-- wpa_cli -p /var/run/wpa_supplicant -i wl1 status
-- cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
-- ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
-- ping -I wl1 -c 8 -W 1 192.168.1.1
-- 'SNAP=$(ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.?" 2>&1); printf ''%s\n''
-  "$SNAP" | awk -F= ''/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-  "", $2); print "AssocMac6g=" tolower($2)} /^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxBytes=/
-  {print "AssocTxBytes6g=" $2} /^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxPacketCount=/
-  {print "AssocTxPacketCount6g=" $2}''; STA_MAC=$(printf ''%s\n'' "$SNAP" | sed -n
-  ''s/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p''
-  | tr ''A-F'' ''a-f''); ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes?"
-  | sed -n ''s/^WiFi\.AccessPoint\.3\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes6g=\1/p'';
-  [ -n "$STA_MAC" ] && echo DriverAssocMac6g=$STA_MAC && wl -i wl1 sta_info $STA_MAC
-  | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes6g=\1/p;
-  s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount6g=\1/p'''
-- wpa_cli -p /var/run/wpa_supplicant -i wl2 status
-- cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
-- ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
-- ping -I wl2 -c 8 -W 1 192.168.1.1
-- 'SNAP=$(ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.?" 2>&1); printf ''%s\n''
-  "$SNAP" | awk -F= ''/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/,
-  "", $2); print "AssocMac24g=" tolower($2)} /^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxBytes=/
-  {print "AssocTxBytes24g=" $2} /^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxPacketCount=/
-  {print "AssocTxPacketCount24g=" $2}''; STA_MAC=$(printf ''%s\n'' "$SNAP" | sed -n
-  ''s/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.MACAddress="\([^"]*\)".*/\1/p''
-  | tr ''A-F'' ''a-f''); ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes?"
-  | sed -n ''s/^WiFi\.AccessPoint\.5\.AssociatedDevice\.1\.TxBytes=\([0-9][0-9]*\)$/TxBytes24g=\1/p'';
-  [ -n "$STA_MAC" ] && echo DriverAssocMac24g=$STA_MAC && wl -i wl2 sta_info $STA_MAC
-  | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes24g=\1/p;
-  s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount24g=\1/p'''
+- wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"
+- PROBE_OUT=$(ping -I br-lan -c 8 -W 1 <resolved wl0 IPv4> 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" |
+  awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+- 'STA_MAC="{{assoc_entry_5g.AssocMac5g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac5g=$STA_MAC; [ -n "$STA_MAC" ] && wl -i
+  wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes5g=\1/p'''
+- wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+- ubus-cli "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes?"
+- PROBE_OUT=$(ping -I br-lan -c 8 -W 1 <resolved wl1 IPv4> 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" |
+  awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+- 'STA_MAC="{{assoc_entry_6g.AssocMac6g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac6g=$STA_MAC; [ -n "$STA_MAC" ] && wl -i
+  wl1 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes6g=\1/p'''
+- wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+- ubus-cli "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes?"
+- PROBE_OUT=$(ping -I br-lan -c 8 -W 1 <resolved wl2 IPv4> 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT" |
+  awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+- 'STA_MAC="{{assoc_entry_24g.AssocMac24g}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac24g=$STA_MAC; [ -n "$STA_MAC" ] && wl
+  -i wl2 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total bytes: \([0-9][0-9]*\).*/DriverTxBytes24g=\1/p'''

--- a/plugins/wifi_llapi/cases/D055_txmulticastpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D055_txmulticastpacketcount.yaml
@@ -8,8 +8,7 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: ubus-cli 
-  "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
 llapi_support: Support
 implemented_by: pWHM
 bands:
@@ -57,127 +56,113 @@ test_environment: 'Topology:
 
   - use the validated 5G single-band WPA3 baseline for this case
 
-  - preserve the workbook verdict as To be tested until multicast-counter behavior
-  is re-verified on separately calibrated bands
-
-  '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
-  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
-  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
-  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
-  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
-  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
-  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
-  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  - preserve the workbook verdict as To be tested until multicast-counter behavior is re-verified on separately calibrated
+  bands'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
-  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\\\
-  nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\\
-  nsae_password=\"testpilot6g\"\\nieee80211w=2\\nscan_ssid=1\\n}\\n' > /tmp/wpa_wl0.conf\n\
-  \  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
-  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0
-  reconnect\n  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i
-  wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Resolve COM1 wl0''s live STA MAC and baseline RX counters, then
-  require AP1 AssociatedDevice.1 to point to that same station.
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\\\
+  nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\nsae_password=\"testpilot6g\"\\nieee80211w=2\\\
+  nscan_ssid=1\\n}\\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Resolve the live 5G STA MAC and baseline RX counters, then require AP1 AssociatedDevice.1 to point to
+  that same station.
 
-  2) From DUT, send a bounded broadcast ping on br-lan and confirm the active STA''s
-  wl0 RX counters increase during this checkpoint.
 
-  3) Re-read WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount and the
-  same AssociatedDevice snapshot on DUT.
+  2) Capture baseline DUT LLAPI TxMulticastPacketCount and the matching driver `tx mcast/bcast pkts` counter for the same
+  STA.
 
-  4) Cross-check wl0 sta_info `tx mcast/bcast pkts` for the same STA.
 
-  5) Keep the workbook verdict open: the current 5G retest shows delivered broadcast
-  traffic on COM1 while both LLAPI and wl0 sta_info Tx multicast counters remain zero.
+  3) From DUT, send a bounded broadcast ping on br-lan and confirm the active STA wl0 RX counters increase during this checkpoint.
 
-  '
+
+  4) Capture verify DUT LLAPI TxMulticastPacketCount and the matching driver `tx mcast/bcast pkts` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_sta_identity
+  phase: baseline
   action: exec
   target: STA
   command:
   - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'
-  - ifconfig wl0 | sed -n 's/.*RX 
-    packets:\([0-9][0-9]*\).*/StaRxPacketsBefore=\1/p; s/.*RX 
-    bytes:\([0-9][0-9]*\).*/StaRxBytesBefore=\1/p'
+  - ifconfig wl0 | sed -n 's/.*RX packets:\([0-9][0-9]*\).*/StaRxPacketsBefore=\1/p; s/.*RX bytes:\([0-9][0-9]*\).*/StaRxBytesBefore=\1/p'
   capture: sta_identity
-- id: step2
+- id: step2_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
-  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-    's/.*MACAddress="\([^"]*\)".*/\1/p' | tr 'A-F' 'a-f' | sed 
-    's/^/MACAddress=/'
-  depends_on: step1
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/MACAddress=/'
+  depends_on: step1_sta_identity
   capture: assoc_entry
-- id: step3
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: OUT=$(ping -b -I br-lan -c 10 -W 1 192.168.1.255 2>&1); printf '%s\n'
-    "$OUT"; printf '%s\n' "$OUT" | awk '/packets transmitted/ {print 
-    "ProbeTxPackets=" $1; exit}'
-  depends_on: step2
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
+  depends_on: step2_assoc_entry
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx mcast\/bcast pkts: \([0-9][0-9]*\).*/DriverTxMulticastPacketCount=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  command: OUT=$(ping -b -I br-lan -c 10 -W 1 192.168.1.255 2>&1); printf '%s\n' "$OUT"; printf '%s\n' "$OUT" | awk '/packets
+    transmitted/ {print "ProbeTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
   capture: probe
-- id: step4
+- id: step6_sta_after
+  phase: verify
   action: exec
   target: STA
-  command: ifconfig wl0 | sed -n 's/.*RX 
-    packets:\([0-9][0-9]*\).*/StaRxPacketsAfter=\1/p; s/.*RX 
-    bytes:\([0-9][0-9]*\).*/StaRxBytesAfter=\1/p'
-  depends_on: step3
+  command: ifconfig wl0 | sed -n 's/.*RX packets:\([0-9][0-9]*\).*/StaRxPacketsAfter=\1/p; s/.*RX bytes:\([0-9][0-9]*\).*/StaRxBytesAfter=\1/p'
+  depends_on: step5_trigger
   capture: sta_after
-- id: step5
+- id: step7_api_verify
+  phase: verify
   action: exec
   target: DUT
-  command: ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
-  depends_on: step4
-  capture: result
-- id: step6
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
+  depends_on: step6_sta_after
+  capture: api_after_5g
+- id: step8_drv_verify
+  phase: verify
   action: exec
   target: DUT
-  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | awk -F= 
-    '/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/, "", 
-    $2); print "AssocMAC=" tolower($2)} 
-    /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxMulticastPacketCount=/ {print
-    "AssocTxMulticastPacketCount=" $2}'
-  depends_on: step5
-  capture: assoc_snapshot
-- id: step7
-  action: exec
-  target: DUT
-  command: 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
-    | sed -n ''s/.*MACAddress="\([^"]*\)".*/\1/p'' | tr ''A-F'' ''a-f''); [ -n "$STA_MAC"
-    ] && echo DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx
-    mcast\/bcast pkts: \([0-9][0-9]*\).*/DriverTxMulticastPacketCount=\1/p; s/^[[:space:]]*tx
-    mcast\/bcast bytes: \([0-9][0-9]*\).*/DriverTxMulticastBytes=\1/p'''
-  depends_on: step6
-  capture: driver_counter
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx mcast\/bcast pkts: \([0-9][0-9]*\).*/DriverTxMulticastPacketCount=\1/p'''
+  depends_on: step7_api_verify
+  capture: drv_after_5g
 pass_criteria:
 - field: sta_identity.StaMac
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side 
-    validation.
+  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side validation.
 - field: assoc_entry.MACAddress
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
@@ -185,71 +170,47 @@ pass_criteria:
 - field: assoc_entry.MACAddress
   operator: equals
   reference: sta_identity.StaMac
-  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 
-    station used for this manual checkpoint.
+  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 station used for this manual checkpoint.
 - field: probe.ProbeTxPackets
   operator: '>'
   value: '0'
-  description: DUT broadcast probe must actually transmit packets during this 
-    checkpoint.
+  description: DUT broadcast probe must actually transmit packets during this checkpoint.
 - field: sta_after.StaRxPacketsAfter
   operator: '>'
   reference: sta_identity.StaRxPacketsBefore
-  description: COM1 wl0 must receive additional packets after the DUT broadcast 
-    probe.
+  description: COM1 wl0 must receive additional packets after the DUT broadcast probe.
 - field: sta_after.StaRxBytesAfter
   operator: '>'
   reference: sta_identity.StaRxBytesBefore
   description: COM1 wl0 RX bytes must increase after the DUT broadcast probe.
-- field: result.TxMulticastPacketCount
-  operator: equals
-  value: '0'
-  description: LLAPI TxMulticastPacketCount still reads 0 during this 
-    checkpoint.
-- field: assoc_snapshot.AssocMAC
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: AssociatedDevice snapshot evidence must come from the same AP1 
-    station entry.
-- field: result.TxMulticastPacketCount
-  operator: equals
-  reference: assoc_snapshot.AssocTxMulticastPacketCount
-  description: Direct getter TxMulticastPacketCount must match the same 
-    AssociatedDevice snapshot value.
-- field: driver_counter.DriverAssocMac
+  description: Baseline driver evidence must target the same AssociatedDevice MAC resolved in step2.
+- field: drv_after_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver evidence must target the same AssociatedDevice MAC 
-    resolved in step2.
-- field: driver_counter.DriverTxMulticastPacketCount
-  operator: equals
-  value: '0'
-  description: wl0 sta_info tx mcast/bcast pkts still reads 0 for the same STA 
-    even after the broadcast probe.
-- field: driver_counter.DriverTxMulticastBytes
-  operator: equals
-  value: '0'
-  description: wl0 sta_info tx mcast/bcast bytes still reads 0 for the same STA 
-    even after the broadcast probe.
+  description: Verify driver evidence must target the same AssociatedDevice MAC resolved in step2.
+- delta:
+    baseline: api_before_5g.TxMulticastPacketCount
+    verify: api_after_5g.TxMulticastPacketCount
+  operator: delta_nonzero
+  description: LLAPI TxMulticastPacketCount must grow after the DUT broadcast probe.
+- delta:
+    baseline: api_before_5g.TxMulticastPacketCount
+    verify: api_after_5g.TxMulticastPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverTxMulticastPacketCount
+    verify: drv_after_5g.DriverTxMulticastPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: LLAPI TxMulticastPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'
-- ifconfig wl0 | sed -n 's/.*RX 
-  packets:\([0-9][0-9]*\).*/StaRxPacketsBefore=\1/p; s/.*RX 
-  bytes:\([0-9][0-9]*\).*/StaRxBytesBefore=\1/p'
-- OUT=$(ping -b -I br-lan -c 10 -W 1 192.168.1.255 2>&1); printf '%s\n' "$OUT"; 
-  printf '%s\n' "$OUT" | awk '/packets transmitted/ {print "ProbeTxPackets=" $1;
-  exit}'
-- ifconfig wl0 | sed -n 's/.*RX 
-  packets:\([0-9][0-9]*\).*/StaRxPacketsAfter=\1/p; s/.*RX 
-  bytes:\([0-9][0-9]*\).*/StaRxBytesAfter=\1/p'
+- ifconfig wl0 | sed -n 's/.*RX packets:\([0-9][0-9]*\).*/StaRxPacketsBefore=\1/p; s/.*RX bytes:\([0-9][0-9]*\).*/StaRxBytesBefore=\1/p'
+- OUT=$(ping -b -I br-lan -c 10 -W 1 192.168.1.255 2>&1); printf '%s\n' "$OUT"; printf '%s\n' "$OUT" | awk '/packets transmitted/
+  {print "ProbeTxPackets=" $1; exit}'
+- ifconfig wl0 | sed -n 's/.*RX packets:\([0-9][0-9]*\).*/StaRxPacketsAfter=\1/p; s/.*RX bytes:\([0-9][0-9]*\).*/StaRxBytesAfter=\1/p'
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"
-- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | awk -F= 
-  '/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/ {gsub(/"/, "", $2);
-  print "AssocMAC=" tolower($2)} 
-  /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxMulticastPacketCount=/ {print 
-  "AssocTxMulticastPacketCount=" $2}'
-- 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-  ''s/.*MACAddress="\([^"]*\)".*/\1/p'' | tr ''A-F'' ''a-f''); [ -n "$STA_MAC" ] &&
-  echo DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx
-  mcast\/bcast pkts: \([0-9][0-9]*\).*/DriverTxMulticastPacketCount=\1/p; s/^[[:space:]]*tx
-  mcast\/bcast bytes: \([0-9][0-9]*\).*/DriverTxMulticastBytes=\1/p'''
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0
+  sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx mcast\/bcast pkts: \([0-9][0-9]*\).*/DriverTxMulticastPacketCount=\1/p'''

--- a/plugins/wifi_llapi/cases/D056_txpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D056_txpacketcount.yaml
@@ -54,112 +54,151 @@ test_environment: 'Topology:
 
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
 
-  - use the validated 5G single-band WPA3 baseline for this case
-
-  '
-setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure
-  AP1 as WPA3-Personal with MFP required\n   - keep the validated live SSID/credential
-  pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable local
-  AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit
-  side effects\n   - reset wl0 and its wpa_supplicant control socket\n   - connect
-  wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1: iw dev wl0 link
-  ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist\n"
-sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli
-  WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli
-  WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
-  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n\
-  \  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n\
-  \  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
-  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n\
-  \  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n\
-  \  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n\
-  \  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n\
-  \  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
+  - use the validated 5G single-band WPA3 baseline for this case'
+setup_steps: "1) DUT 5G baseline:\n   - enable Radio.1 / SSID.4 / AP1\n   - configure AP1 as WPA3-Personal with MFP required\n\
+  \   - keep the validated live SSID/credential pair as TestPilot_BTM / testpilot6g\n2) STA 5G preparation:\n   - disable\
+  \ local AP1/AP2 on COM1\n   - move COM1 br-lan off 192.168.1.0/24 to avoid bridge self-hit side effects\n   - reset wl0\
+  \ and its wpa_supplicant control socket\n   - connect wl0 to TestPilot_BTM with SAE\n3) Association evidence:\n   - COM1:\
+  \ iw dev wl0 link ; wpa_cli -p /var/run/wpa_supplicant -i wl0 status\n   - COM0: wl -i wl0 assoclist"
+sta_env_setup: "DUT 5G AP baseline:\n  ubus-cli WiFi.Radio.1.Enable=1\n  ubus-cli WiFi.Radio.1.BeaconPeriod=100\n  ubus-cli\
+  \ WiFi.Radio.1.DTIMPeriod=3\n  ubus-cli WiFi.Radio.1.DriverConfig.FragmentationThreshold=-1\n  ubus-cli WiFi.Radio.1.DriverConfig.RtsThreshold=-1\n\
+  \  ubus-cli WiFi.Radio.1.DriverConfig.TPCMode=Auto\n  ubus-cli WiFi.Radio.1.ExplicitBeamFormingEnabled=1\n  ubus-cli WiFi.Radio.1.ImplicitBeamFormingEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.OfdmaEnable=1\n  ubus-cli WiFi.Radio.1.ObssCoexistenceEnable=0\n  ubus-cli WiFi.Radio.1.OperatingStandards=ax\n\
+  \  ubus-cli WiFi.Radio.1.RxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.TxChainCtrl=-1\n  ubus-cli WiFi.Radio.1.Vendor.Brcm.RegulatoryDomainRev=0\n\
+  \  ubus-cli WiFi.Radio.1.Sensing.Enable=1\n  ubus-cli WiFi.Radio.1.IEEE80211ax.BssColorPartial=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.NonSRGOBSSPDMaxOffset=0\n\
+  \  ubus-cli WiFi.Radio.1.IEEE80211ax.PSRDisallowed=0\n  ubus-cli WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMaxOffset=0\n  ubus-cli\
+  \ WiFi.Radio.1.IEEE80211ax.SRGOBSSPDMinOffset=0\n  ubus-cli WiFi.Radio.1.LongRetryLimit=6\n  ubus-cli WiFi.Radio.1.MultiUserMIMOEnabled=1\n\
+  \  ubus-cli WiFi.Radio.1.TargetWakeTimeEnable=1\n  ubus-cli WiFi.SSID.4.SSID=TestPilot_BTM\n  ubus-cli WiFi.AccessPoint.1.IEEE80211u.QoSMapSet=\n\
   \  ubus-cli WiFi.AccessPoint.2.IEEE80211u.QoSMapSet=\n  ubus-cli WiFi.AccessPoint.1.Security.ModeEnabled=WPA3-Personal\n\
   \  ubus-cli WiFi.AccessPoint.1.Security.SAEPassphrase=testpilot6g\n  ubus-cli WiFi.AccessPoint.1.Security.MFPConfig=Required\n\
-  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan
-  192.168.88.1 netmask 255.255.255.0 up\n  ubus-cli WiFi.AccessPoint.1.Enable=0\n\
-  \  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
-  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null
-  || true\n  iw dev wl0 disconnect 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null
-  || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev wl0 set type managed\n\
-  \  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\\\
-  nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\\
-  nsae_password=\"testpilot6g\"\\nieee80211w=2\\nscan_ssid=1\\n}\\n' > /tmp/wpa_wl0.conf\n\
-  \  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
-  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0
-  reconnect\n  sleep 10\n  iw dev wl0 link\n  wpa_cli -p /var/run/wpa_supplicant -i
-  wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist\n"
-test_procedure: '1) Confirm the 5G STA is associated to AP1 and resolve its live MAC
-  address.
+  \  ubus-cli WiFi.AccessPoint.1.Enable=1\nSTA 5G preparation:\n  ifconfig br-lan 192.168.88.1 netmask 255.255.255.0 up\n\
+  \  ubus-cli WiFi.AccessPoint.1.Enable=0\n  ubus-cli WiFi.AccessPoint.2.Enable=0\n  wpa_cli terminate 2>/dev/null || true\n\
+  \  rm -f /var/run/wpa_supplicant/wl0 2>/dev/null || true\n  iw dev wl0.1 del 2>/dev/null || true\n  iw dev wl0 disconnect\
+  \ 2>/dev/null || true\n  iw dev wl1 disconnect 2>/dev/null || true\n  iw dev wl2 disconnect 2>/dev/null || true\n  iw dev\
+  \ wl0 set type managed\n  ifconfig wl0 up\n  mkdir -p /var/run/wpa_supplicant\n  printf 'ctrl_interface=/var/run/wpa_supplicant\\\
+  nupdate_config=1\\nsae_pwe=2\\nnetwork={\\nssid=\"TestPilot_BTM\"\\nkey_mgmt=SAE\\nsae_password=\"testpilot6g\"\\nieee80211w=2\\\
+  nscan_ssid=1\\n}\\n' > /tmp/wpa_wl0.conf\n  wpa_supplicant -B -D nl80211 -i wl0 -c /tmp/wpa_wl0.conf -C /var/run/wpa_supplicant\n\
+  \  sleep 3\nSTA 5G connect verify:\n  wpa_cli -p /var/run/wpa_supplicant -i wl0 reconnect\n  sleep 10\n  iw dev wl0 link\n\
+  \  wpa_cli -p /var/run/wpa_supplicant -i wl0 status\nDUT association evidence:\n  wl -i wl0 assoclist"
+test_procedure: '1) Resolve the live 5G STA state, assign a concrete wl0 IPv4 address, and require AP1 AssociatedDevice.1
+  to point to that same station.
 
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.TxPacketCount on DUT.
 
-  3) Cross-check the same STA against iw dev wl0 station dump `tx packets:`.
+  2) Capture baseline DUT LLAPI TxPacketCount and the matching driver `tx total pkts` counter for the same STA.
 
-  4) Pass when TxPacketCount is a positive integer and matches the driver packet counter
-  for the same STA.
 
-  '
+  3) From the DUT bridge IP, run a bounded ping burst toward the resolved STA IP to exercise AP-to-STA traffic.
+
+
+  4) Capture verify DUT LLAPI TxPacketCount and the matching driver `tx total pkts` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
-  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?"
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/MACAddress=/'
+  depends_on: step1_sta_ready
   capture: assoc_entry
-- id: step2
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
   command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxPacketCount?"
-  depends_on: step1
-  capture: result
-- id: step3
+  depends_on: step2_assoc_entry
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: STA_MAC=$(ubus-cli 
-    "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 
-    's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-    'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-    mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1;
-    print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-    $1=="tx" && $2=="packets:" {print "DriverTxPacketCount=" $3}'
-  depends_on: step2
-  capture: driver_counter
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  command: PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_5g.StaIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxPacketCount?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
+- field: sta_ready_5g.wpa_state
+  operator: equals
+  value: COMPLETED
+  description: The 5G STA must remain associated before the downlink trigger.
+- field: sta_ready_5g.ssid
+  operator: equals
+  value: TestPilot_BTM
+  description: The 5G STA must remain on the documented baseline SSID.
+- field: sta_ready_5g.StaMac
+  operator: regex
+  value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
+  description: The 5G STA MAC must resolve before DUT-side validation.
+- field: sta_ready_5g.StaIp
+  operator: regex
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The 5G STA interface must expose an IPv4 address for the DUT-originated trigger.
 - field: assoc_entry.MACAddress
-  operator: regex
-  value: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
-  description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
-- field: result.TxPacketCount
-  operator: regex
-  value: ^[0-9]+$
-  description: TxPacketCount should be a live non-negative integer.
-- field: result.TxPacketCount
+  operator: equals
+  reference: sta_ready_5g.StaMac
+  description: AP1 AssociatedDevice.1 must resolve to the same live STA MAC.
+- field: trigger_probe.TriggerTxPackets
   operator: '>'
   value: '0'
-  description: TxPacketCount should be positive for the associated 5G STA.
-- field: driver_counter.DriverAssocMac
+  description: The DUT trigger step must actually transmit a downlink burst toward the resolved STA IP.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver packet sampling must target the same AssociatedDevice MAC 
-    resolved in step1.
-- field: driver_counter.DriverTxPacketCount
-  operator: '>'
-  value: '0'
-  description: iw station dump must report a positive tx packet count for the 
-    same STA.
-- field: result.TxPacketCount
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step2.
+- field: drv_after_5g.DriverAssocMac
   operator: equals
-  reference: driver_counter.DriverTxPacketCount
-  description: LLAPI TxPacketCount must match iw station dump tx packets for the
-    same STA.
+  reference: assoc_entry.MACAddress
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step2.
+- delta:
+    baseline: api_before_5g.TxPacketCount
+    verify: api_after_5g.TxPacketCount
+  operator: delta_nonzero
+  description: 5G API TxPacketCount must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_5g.TxPacketCount
+    verify: api_after_5g.TxPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverTxPacketCount
+    verify: drv_after_5g.DriverTxPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API TxPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
 - ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxPacketCount?"
-- STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed 
-  -n 's/.*MACAddress="\([^"]*\)".*/\1/p'); STA_MAC_LOWER=$(echo "$STA_MAC" | tr 
-  'A-F' 'a-f'); [ -n "$STA_MAC" ] && iw dev wl0 station dump | awk -v 
-  mac="$STA_MAC_LOWER" -v sta="$STA_MAC" '$1=="Station" && $2==mac {matched=1; 
-  print "DriverAssocMac=" sta; next} $1=="Station" {matched=0} matched && 
-  $1=="tx" && $2=="packets:" {print "DriverTxPacketCount=" $3}'
+- PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_5g.StaIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+  | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0
+  sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount=\1/p'''

--- a/plugins/wifi_llapi/cases/D057_txunicastpacketcount.yaml
+++ b/plugins/wifi_llapi/cases/D057_txunicastpacketcount.yaml
@@ -1,5 +1,5 @@
 id: wifi-llapi-D057-txunicastpacketcount
-name: "TxUnicastPacketCount — WiFi.AccessPoint.{i}.AssociatedDevice.{i}."
+name: TxUnicastPacketCount — WiFi.AccessPoint.{i}.AssociatedDevice.{i}.
 version: '1.1'
 source:
   row: 57
@@ -8,10 +8,11 @@ source:
 platform:
   prplos: 4.0.3
   bdk: 6.3.1
-hlapi_command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"'
+hlapi_command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"
 llapi_support: Support
 implemented_by: pWHM
-bands: ["5g"]
+bands:
+- 5g
 topology:
   devices:
     DUT:
@@ -33,151 +34,160 @@ topology:
   - from: STA
     to: DUT
     band: 5g
-test_environment: |
-  Topology:
+test_environment: 'Topology:
+
   - DUT: COM1 (AP role)
+
   - STA: COM0 (STA role)
+
   Transport:
+
   - serialwrap attach COM0 / COM1
+
   Baseline:
+
   - 5G = AP1 / wl0 / testpilot5G / WPA2-Personal
+
   Preconditions:
+
   - keep only one associated station on AP1 so AssociatedDevice.1 stays deterministic
+
   - use the validated generic 5G WPA2 baseline for this case
+
   - workbook row 57 is TxUnicastPacketCount; stale row 59 is UplinkBandwidth
-  - clean-start replay of the old TestPilot_BTM / SAE custom env left COM0 wpa_supplicant at `wpaie set error (-7)` with `wpa_state=DISCONNECTED` even though COM1 wl0 was beaconing the SSID, so this case now relies on the stable auto-baseline path instead of the non-reproducible custom WPA3 setup
-  - current 5G retest resolves the same live STA on AP1 while TxPacketCount is positive but TxUnicastPacketCount stays 0
-setup_steps: |
-  1) Let the runner apply the deterministic 5G auto-baseline from band-baselines.yaml.
+
+  - clean-start replay of the old TestPilot_BTM / SAE custom env left COM0 wpa_supplicant at `wpaie set error (-7)` with `wpa_state=DISCONNECTED`
+  even though COM1 wl0 was beaconing the SSID, so this case now relies on the stable auto-baseline path instead of the non-reproducible
+  custom WPA3 setup
+
+  - current 5G retest resolves the same live STA on AP1 while TxPacketCount is positive but TxUnicastPacketCount stays 0'
+setup_steps: '1) Let the runner apply the deterministic 5G auto-baseline from band-baselines.yaml.
+
   2) Verify COM0 wl0 is connected to testpilot5G and COM1 wl0 assoclist resolves the same STA MAC.
-  3) Read AP1 AssociatedDevice.1.TxUnicastPacketCount directly, then compare it with the same entry's TxPacketCount and COM1 wl0 sta_info counters.
-test_procedure: |
-  1) Resolve COM1 wl0's live STA MAC and require AP1 AssociatedDevice.1 to point to that same station.
-  2) Read WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount directly on DUT, then cross-check the same AssociatedDevice snapshot for both TxUnicastPacketCount and sibling TxPacketCount.
-  3) Cross-check wl0 sta_info for the same STA and capture both `tx total pkts` and `tx ucast pkts`.
-  4) The current 5G retest is fail-shaped: TxUnicastPacketCount stays 0 while the same entry's TxPacketCount and wl0 sta_info tx ucast pkts remain positive.
+
+  3) Read AP1 AssociatedDevice.1.TxUnicastPacketCount directly, then compare it with the same entry''s TxPacketCount and COM1
+  wl0 sta_info counters.'
+test_procedure: '1) Resolve the live 5G STA state, assign a concrete wl0 IPv4 address, and require AP1 AssociatedDevice.1
+  to point to that same station.
+
+
+  2) Capture baseline DUT LLAPI TxUnicastPacketCount and the matching driver `tx ucast pkts` counter for the same STA.
+
+
+  3) From the DUT bridge IP, run a bounded ping burst toward the resolved STA IP to exercise AP-to-STA unicast traffic.
+
+
+  4) Capture verify DUT LLAPI TxUnicastPacketCount and the matching driver `tx ucast pkts` counter, then compare baseline-to-verify
+  deltas.'
 steps:
-- id: step1
+- id: step1_sta_ready
+  phase: baseline
   action: exec
   target: STA
-  command: cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'
-  capture: sta_identity
-- id: step2
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_assoc_entry
+  phase: baseline
   action: exec
   target: DUT
-  command: >-
-    ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p'
-    | tr 'A-F' 'a-f' | sed 's/^/MACAddress=/'
-  depends_on: step1
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr
+    'A-F' 'a-f' | sed 's/^/MACAddress=/'
+  depends_on: step1_sta_ready
   capture: assoc_entry
-- id: step3
+- id: step3_api_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"'
-  depends_on: step2
-  capture: result
-- id: step4
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"
+  depends_on: step2_assoc_entry
+  capture: api_before_5g
+- id: step4_drv_baseline
+  phase: baseline
   action: exec
   target: DUT
-  command: >-
-    ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | awk -F= '/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/
-    {gsub(/"/, "", $2); print "AssocMAC=" tolower($2)} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxUnicastPacketCount=/
-    {print "AssocTxUnicastPacketCount=" $2} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxPacketCount=/
-    {print "AssocTxPacketCount=" $2}'
-  depends_on: step3
-  capture: assoc_snapshot
-- id: step5
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx ucast pkts: \([0-9][0-9]*\).*/DriverTxUnicastPacketCount=\1/p'''
+  depends_on: step3_api_baseline
+  capture: drv_before_5g
+- id: step5_trigger
+  phase: trigger
   action: exec
   target: DUT
-  command: >-
-    STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-    's/.*MACAddress="\([^"]*\)".*/\1/p' | tr 'A-F' 'a-f'); [ -n "$STA_MAC" ] && echo
-    DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | sed -n 's/^[[:space:]]*tx
-    total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount=\1/p; s/^[[:space:]]*tx ucast
-    pkts: \([0-9][0-9]*\).*/DriverTxUnicastPacketCount=\1/p; s/^[[:space:]]*tx total
-    bytes: \([0-9][0-9]*\).*/DriverTxBytes=\1/p; s/^[[:space:]]*tx ucast bytes: \([0-9][0-9]*\).*/DriverTxUnicastBytes=\1/p'
-  depends_on: step4
-  capture: driver_capture
+  command: PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_5g.StaIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+    | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+  depends_on: step4_drv_baseline
+  capture: trigger_probe
+- id: step6_api_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"
+  depends_on: step5_trigger
+  capture: api_after_5g
+- id: step7_drv_verify
+  phase: verify
+  action: exec
+  target: DUT
+  command: 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] &&
+    wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx ucast pkts: \([0-9][0-9]*\).*/DriverTxUnicastPacketCount=\1/p'''
+  depends_on: step6_api_verify
+  capture: drv_after_5g
 pass_criteria:
-- field: sta_identity.StaMac
+- field: sta_ready_5g.wpa_state
+  operator: equals
+  value: COMPLETED
+  description: The 5G STA must remain associated before the downlink trigger.
+- field: sta_ready_5g.ssid
+  operator: equals
+  value: testpilot5G
+  description: The 5G STA must remain on the documented baseline SSID.
+- field: sta_ready_5g.StaMac
   operator: regex
   value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  description: COM1 wl0 must resolve to a concrete live STA MAC before DUT-side 
-    validation.
-- field: assoc_entry.MACAddress
+  description: The 5G STA MAC must resolve before DUT-side validation.
+- field: sta_ready_5g.StaIp
   operator: regex
-  value: ^([0-9a-f]{2}:){5}[0-9a-f]{2}$
-  description: AP1 AssociatedDevice.1 must first resolve to the live 5G STA MAC.
+  value: ^([0-9]{1,3}\.){3}[0-9]{1,3}$
+  description: The 5G STA interface must expose an IPv4 address for the DUT-originated trigger.
 - field: assoc_entry.MACAddress
   operator: equals
-  reference: sta_identity.StaMac
-  description: AP1 AssociatedDevice.1 must correspond to the same COM1 wl0 
-    station used for this manual checkpoint.
-- field: result.TxUnicastPacketCount
-  operator: regex
-  value: ^[0-9]+$
-  description: TxUnicastPacketCount direct getter must produce a numeric counter
-    for the live AssociatedDevice entry.
-- field: result.TxUnicastPacketCount
-  operator: equals
+  reference: sta_ready_5g.StaMac
+  description: AP1 AssociatedDevice.1 must resolve to the same live STA MAC.
+- field: trigger_probe.TriggerTxPackets
+  operator: '>'
   value: '0'
-  description: The current 5G live retest shows TxUnicastPacketCount still reads
-    0 for the same AssociatedDevice entry.
-- field: assoc_snapshot.AssocMAC
+  description: The DUT trigger step must actually transmit a downlink burst toward the resolved STA IP.
+- field: drv_before_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: AssociatedDevice snapshot evidence must come from the same AP1 
-    station entry.
-- field: result.TxUnicastPacketCount
-  operator: equals
-  reference: assoc_snapshot.AssocTxUnicastPacketCount
-  description: Direct getter TxUnicastPacketCount must match the same 
-    AssociatedDevice snapshot value.
-- field: assoc_snapshot.AssocTxPacketCount
-  operator: '>'
-  value: '0'
-  description: The sibling TxPacketCount on the same AssociatedDevice entry must
-    remain positive during this checkpoint.
-- field: driver_capture.DriverAssocMac
+  description: Baseline driver sampling must target the same live AssociatedDevice MAC resolved in step2.
+- field: drv_after_5g.DriverAssocMac
   operator: equals
   reference: assoc_entry.MACAddress
-  description: Driver evidence must target the same AssociatedDevice MAC 
-    resolved in step2.
-- field: driver_capture.DriverTxPacketCount
-  operator: '>'
-  value: '0'
-  description: wl0 sta_info must report a positive tx total packet count for the
-    same STA.
-- field: assoc_snapshot.AssocTxPacketCount
-  operator: equals
-  reference: driver_capture.DriverTxPacketCount
-  description: The sibling TxPacketCount on the same AssociatedDevice entry must
-    match wl0 sta_info tx total pkts.
-- field: driver_capture.DriverTxUnicastPacketCount
-  operator: '>'
-  value: '0'
-  description: wl0 sta_info must report a positive tx ucast packet count for the
-    same STA.
-- field: driver_capture.DriverTxBytes
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must still expose tx total bytes as supporting 
-    context for the same STA.
-- field: driver_capture.DriverTxUnicastBytes
-  operator: regex
-  value: ^[0-9]+$
-  description: wl0 sta_info must still expose tx ucast bytes as supporting 
-    context for the same STA.
+  description: Verify driver sampling must target the same live AssociatedDevice MAC resolved in step2.
+- delta:
+    baseline: api_before_5g.TxUnicastPacketCount
+    verify: api_after_5g.TxUnicastPacketCount
+  operator: delta_nonzero
+  description: 5G API TxUnicastPacketCount must grow after the DUT-originated trigger workload.
+- delta:
+    baseline: api_before_5g.TxUnicastPacketCount
+    verify: api_after_5g.TxUnicastPacketCount
+  reference_delta:
+    baseline: drv_before_5g.DriverTxUnicastPacketCount
+    verify: drv_after_5g.DriverTxUnicastPacketCount
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5G API TxUnicastPacketCount delta must stay within ±10% of the driver delta.
 verification_command:
-- 'cat /sys/class/net/wl0/address | tr ''A-F'' ''a-f'' | sed ''s/^/StaMac=/'''
-- 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"'
-- 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.?" | awk -F= ''/^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.MACAddress=/
-  {gsub(/"/, "", $2); print "AssocMAC=" tolower($2)} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxUnicastPacketCount=/
-  {print "AssocTxUnicastPacketCount=" $2} /^WiFi\.AccessPoint\.1\.AssociatedDevice\.1\.TxPacketCount=/
-  {print "AssocTxPacketCount=" $2}'''
-- 'STA_MAC=$(ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n
-  ''s/.*MACAddress="\([^"]*\)".*/\1/p'' | tr ''A-F'' ''a-f''); [ -n "$STA_MAC" ] &&
-  echo DriverAssocMac=$STA_MAC && wl -i wl0 sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx
-  total pkts: \([0-9][0-9]*\).*/DriverTxPacketCount=\1/p; s/^[[:space:]]*tx ucast
-  pkts: \([0-9][0-9]*\).*/DriverTxUnicastPacketCount=\1/p; s/^[[:space:]]*tx total
-  bytes: \([0-9][0-9]*\).*/DriverTxBytes=\1/p; s/^[[:space:]]*tx ucast bytes: \([0-9][0-9]*\).*/DriverTxUnicastBytes=\1/p'''
+- wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p; s/^key_mgmt=/key_mgmt=/p'
+- ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress?" | sed -n 's/.*MACAddress="\([^"]*\)".*/\1/p' | tr 'A-F' 'a-f'
+  | sed 's/^/MACAddress=/'
+- PROBE_OUT=$(ping -I br-lan -c 8 -W 1 {{sta_ready_5g.StaIp}} 2>&1); printf '%s\n' "$PROBE_OUT"; printf '%s\n' "$PROBE_OUT"
+  | awk '/packets transmitted/ {print "TriggerTxPackets=" $1; exit}'
+- 'STA_MAC="{{assoc_entry.MACAddress}}"; [ -n "$STA_MAC" ] && echo DriverAssocMac=$STA_MAC; [ -n "$STA_MAC" ] && wl -i wl0
+  sta_info $STA_MAC | sed -n ''s/^[[:space:]]*tx ucast pkts: \([0-9][0-9]*\).*/DriverTxUnicastPacketCount=\1/p'''

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
@@ -36,7 +36,7 @@ def test_official_case_command_lengths_fit_transport_budget_summary():
                     if isinstance(item, str) and len(item) > threshold:
                         violations.append(f"{yaml_path.name}:{field}[{index}]:{len(item)}")
 
-    assert len(violations) == 949, (
+    assert len(violations) == 973, (
         "Official-case >120-char command inventory changed; "
         "review whether this was an intended calibration update.\n"
         + "\n".join(violations[:40])

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -5291,15 +5291,42 @@ def test_pending_counter_pass_associateddevice_cases_use_supported_contracts():
             "baseline",
             "baseline",
             "baseline",
+            "baseline",
             "trigger",
             "verify",
             "verify",
         ]
         assert "MACAddress?" in commands
+        assert "ifconfig wl0 192.168.1.3" in commands
+        assert 'print "StaIp="' in commands
         assert "DutIp=" in commands
         assert meta["trigger_command"] in commands
         assert "DriverAssocMac=" in commands
         assert meta["driver_token"] in commands
+        assert [step["capture"] for step in case_data["steps"] if step.get("capture")] == [
+            "assoc_entry",
+            "sta_ip",
+            "dut_ip",
+            "api_before_5g",
+            "drv_before_5g",
+            "trigger_probe",
+            "api_after_5g",
+            "drv_after_5g",
+        ]
+        assert case_data["steps"][1]["id"] == "step2_prepare_probe_target"
+        assert case_data["steps"][1]["target"] == "STA"
+        assert case_data["steps"][1]["command"] == [
+            "ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up",
+            "ip -4 addr show dev wl0 | awk '/inet / {sub(/\\/24$/, \"\", $2); print \"StaIp=\" $2; exit}'",
+        ]
+        assert case_data["steps"][2]["id"] == "step3_resolve_probe_target"
+        assert case_data["steps"][2]["depends_on"] == "step2_prepare_probe_target"
+        assert case_data["steps"][5]["id"] == "step6_trigger"
+        assert case_data["steps"][5]["depends_on"] == "step5_drv_baseline"
+        assert any(
+            criterion["field"] == "sta_ip.StaIp" and criterion["operator"] == "regex"
+            for criterion in case_data["pass_criteria"]
+        )
         assert any(
             criterion["field"] == "dut_ip.DutIp" and criterion["operator"] == "regex"
             for criterion in case_data["pass_criteria"]
@@ -5382,32 +5409,37 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
                     "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
                     "timing": 0.01,
                 },
-                "step2_resolve_probe_target": {
+                "step2_prepare_probe_target": {
+                    "success": True,
+                    "output": "StaIp=192.168.1.3",
+                    "timing": 0.01,
+                },
+                "step3_resolve_probe_target": {
                     "success": True,
                     "output": "DutIp=192.168.1.1",
                     "timing": 0.01,
                 },
-                "step3_api_baseline": {
+                "step4_api_baseline": {
                     "success": True,
                     "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
                     "timing": 0.01,
                 },
-                "step4_drv_baseline": {
+                "step5_drv_baseline": {
                     "success": True,
                     "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=100',
                     "timing": 0.01,
                 },
-                "step5_trigger": {
+                "step6_trigger": {
                     "success": True,
                     "output": '8 packets transmitted, 8 received, 0% packet loss\nTriggerTxPackets=8',
                     "timing": 0.01,
                 },
-                "step6_api_verify": {
+                "step7_api_verify": {
                     "success": True,
                     "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=16',
                     "timing": 0.01,
                 },
-                "step7_drv_verify": {
+                "step8_drv_verify": {
                     "success": True,
                     "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=106',
                     "timing": 0.01,
@@ -5419,7 +5451,7 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
         zero_results = {
             "steps": {
                 **pass_results["steps"],
-                "step6_api_verify": {
+                "step7_api_verify": {
                     "success": True,
                     "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
                     "timing": 0.01,
@@ -5431,7 +5463,7 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
         mismatch_results = {
             "steps": {
                 **pass_results["steps"],
-                "step7_drv_verify": {
+                "step8_drv_verify": {
                     "success": True,
                     "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=130',
                     "timing": 0.01,
@@ -5443,7 +5475,7 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
         assoc_mismatch_results = {
             "steps": {
                 **pass_results["steps"],
-                "step7_drv_verify": {
+                "step8_drv_verify": {
                     "success": True,
                     "output": f'DriverAssocMac=AA:AA:AA:AA:AA:AA\n{meta["driver_field"]}=106',
                     "timing": 0.01,
@@ -5451,6 +5483,18 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
             }
         }
         assert plugin.evaluate(case_data, assoc_mismatch_results) is False
+
+        missing_sta_ip_results = {
+            "steps": {
+                **pass_results["steps"],
+                "step2_prepare_probe_target": {
+                    "success": True,
+                    "output": "StaIp=",
+                    "timing": 0.01,
+                },
+            }
+        }
+        assert plugin.evaluate(case_data, missing_sta_ip_results) is False
 
 
 def test_d059_uplinkbandwidth_uses_positive_same_sta_contract():
@@ -16645,9 +16689,9 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
         ("D034_noise_accesspoint_associateddevice.yaml", 2, "DriverNoise="),
         ("D037_retransmissions.yaml", 3, "DriverRetransmissions="),
         ("D038_rx_retransmissions.yaml", 3, "DriverRxRetransmissions="),
-        ("D039_rxbytes.yaml", 3, "DriverRxBytes="),
+        ("D039_rxbytes.yaml", 4, "DriverRxBytes="),
         ("D040_rxmulticastpacketcount.yaml", 3, "DriverRxMulticastPacketCount="),
-        ("D042_rxunicastpacketcount.yaml", 3, "DriverRxUnicastPacketCount="),
+        ("D042_rxunicastpacketcount.yaml", 4, "DriverRxUnicastPacketCount="),
         ("D044_signalnoiseratio.yaml", 2, "DriverSignalNoiseRatio="),
         ("D043_securitymodeenabled.yaml", 2, "DriverSecurityModeEnabled="),
         ("D045_signalstrength_accesspoint_associateddevice.yaml", 2, "DriverSignalStrength="),

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -5015,70 +5015,106 @@ def test_pending_failure_shaped_associateddevice_cases_use_supported_contracts()
         "wifi-llapi-D040-rxmulticastpacketcount",
     }.issubset(discoverable_ids)
 
-    failure_cases = {
-        "D036_powersave.yaml": {
-            "id": "wifi-llapi-D036-powersave",
-            "row": 36,
-            "api": "PowerSave",
-            "driver_token": "DriverPowerSaveFlags=",
-            "driver_field": "driver_flags.DriverPowerSaveFlags",
-            "driver_operator": "contains",
-            "driver_value": "APSD_BE",
-        },
-        "D040_rxmulticastpacketcount.yaml": {
-            "id": "wifi-llapi-D040-rxmulticastpacketcount",
-                "row": 40,
-            "api": "RxMulticastPacketCount",
-            "driver_token": "DriverRxMulticastPacketCount=",
-            "driver_field": "driver_counter.DriverRxMulticastPacketCount",
-            "driver_operator": ">",
-            "driver_value": "0",
-        },
-    }
+    d036 = load_case(cases_dir / "D036_powersave.yaml")
+    assert any(
+        criterion["field"] == "result.PowerSave"
+        and criterion["operator"] == "equals"
+        and str(criterion["value"]) == "0"
+        for criterion in d036["pass_criteria"]
+    )
 
-    for filename, meta in failure_cases.items():
-        raw_case = yaml.safe_load((cases_dir / filename).read_text(encoding="utf-8"))
-        case_data = load_case(cases_dir / filename)
-        commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
-        links = {link["band"] for link in case_data["topology"]["links"]}
+    d040_raw = yaml.safe_load((cases_dir / "D040_rxmulticastpacketcount.yaml").read_text(encoding="utf-8"))
+    d040 = load_case(cases_dir / "D040_rxmulticastpacketcount.yaml")
+    d040_commands = "\n".join(str(step.get("command", "")) for step in d040["steps"])
+    d040_links = {link["band"] for link in d040["topology"]["links"]}
 
-        assert "aliases" not in raw_case
-        assert case_data["id"] == meta["id"]
-        assert case_data["source"]["row"] == meta["row"]
-        assert case_data["bands"] == ["5g"]
-        assert links == {"5g"}
-        assert case_data["hlapi_command"] == f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
-        assert "MACAddress?" in commands
-        assert "DriverAssocMac=" in commands
-        assert meta["driver_token"] in commands
-        assert any(
-            criterion["field"] == f'result.{meta["api"]}'
-            and criterion["operator"] == "equals"
-            and str(criterion["value"]) == "0"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == f'{meta["driver_field"].rsplit(".", 1)[0]}.DriverAssocMac'
-            and criterion["operator"] == "equals"
-            and criterion["reference"] == "assoc_entry.MACAddress"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == meta["driver_field"]
-            and criterion["operator"] == meta["driver_operator"]
-            and str(criterion["value"]) == meta["driver_value"]
-            for criterion in case_data["pass_criteria"]
-        )
-        if filename == "D040_rxmulticastpacketcount.yaml":
-            assert any(step.get("target") == "STA" for step in case_data["steps"])
-            assert "ProbeTxPackets=" in commands
-            assert any(
-                criterion["field"] == "probe.ProbeTxPackets"
-                and criterion["operator"] == ">"
-                and str(criterion["value"]) == "0"
-                for criterion in case_data["pass_criteria"]
-            )
-        
+    assert "aliases" not in d040_raw
+    assert d040["id"] == "wifi-llapi-D040-rxmulticastpacketcount"
+    assert d040["source"]["row"] == 40
+    assert d040["llapi_support"] == "Support"
+    assert d040["bands"] == ["5g"]
+    assert d040_links == {"5g"}
+    assert d040["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount?"'
+    assert [step["phase"] for step in d040["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "verify",
+        "verify",
+    ]
+    assert [step["capture"] for step in d040["steps"] if step.get("capture")] == [
+        "assoc_entry",
+        "sta_ip",
+        "api_before_5g",
+        "drv_before_5g",
+        "trigger_probe",
+        "api_after_5g",
+        "drv_after_5g",
+    ]
+    assert "ifconfig wl0 192.168.1.3" in d040_commands
+    assert "TriggerTxPackets=" in d040_commands
+    assert "DriverAssocMac=" in d040_commands
+    assert "DriverRxMulticastPacketCount=" in d040_commands
+    assert any(
+        criterion["field"] == "assoc_entry.MACAddress"
+        and criterion["operator"] == "regex"
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "sta_ip.StaIp"
+        and criterion["operator"] == "regex"
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "trigger_probe.TriggerTxPackets"
+        and criterion["operator"] == ">"
+        and str(criterion["value"]) == "0"
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "drv_before_5g.DriverAssocMac"
+        and criterion["operator"] == "equals"
+        and criterion["reference"] == "assoc_entry.MACAddress"
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion["field"] == "drv_after_5g.DriverAssocMac"
+        and criterion["operator"] == "equals"
+        and criterion["reference"] == "assoc_entry.MACAddress"
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.RxMulticastPacketCount",
+            "verify": "api_after_5g.RxMulticastPacketCount",
+        }
+        for criterion in d040["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.RxMulticastPacketCount",
+            "verify": "api_after_5g.RxMulticastPacketCount",
+        }
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_5g.DriverRxMulticastPacketCount",
+            "verify": "drv_after_5g.DriverRxMulticastPacketCount",
+        }
+        and criterion.get("tolerance_pct") == 10
+        for criterion in d040["pass_criteria"]
+    )
+    assert not any(
+        criterion.get("field") == "result.RxMulticastPacketCount"
+        and criterion.get("operator") == "equals"
+        and str(criterion.get("value")) == "0"
+        for criterion in d040["pass_criteria"]
+    )
 
 
 def test_pending_failure_shaped_associateddevice_cases_evaluate_live_examples():
@@ -5119,424 +5155,126 @@ def test_pending_failure_shaped_associateddevice_cases_evaluate_live_examples():
     }
     assert plugin.evaluate(d036, d036_fail_results) is False
 
-    d036_mismatch_results = {
-        "steps": {
-            **d036_results["steps"],
-            "step3": {
-                "success": True,
-                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverPowerSaveFlags=APSD_BE,APSD_BK,APSD_VI,APSD_VO",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d036, d036_mismatch_results) is False
-
     d040 = load_case(cases_dir / "D040_rxmulticastpacketcount.yaml")
     d040_results = {
-        "steps": {
-            "step1": {
-                "success": True,
-                "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-                "timing": 0.01,
-            },
-            "step2": {
-                "success": True,
-                "output": "5 packets transmitted, 0 received, 100% packet loss, time 4103ms\nProbeTxPackets=5",
-                "timing": 0.01,
-            },
-            "step3": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount=0",
-                "timing": 0.01,
-            },
-            "step4": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRxMulticastPacketCount=10",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d040, d040_results) is True
-
-    d040_fail_results = {
-        "steps": {
-            **d040_results["steps"],
-            "step2": {
-                "success": True,
-                "output": "",
-                "timing": 0.01,
-            },
-            "step4": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRxMulticastPacketCount=0",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d040, d040_fail_results) is False
-
-    d040_mismatch_results = {
-        "steps": {
-            **d040_results["steps"],
-            "step4": {
-                "success": True,
-                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverRxMulticastPacketCount=10",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d040, d040_mismatch_results) is False
-
-
-def test_d034_noise_associateddevice_uses_supported_contracts():
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-    plugin = _load_plugin()
-    discoverable_ids = {case["id"] for case in plugin.discover_cases()}
-    assert "wifi-llapi-D034-noise-accesspoint-associateddevice" in discoverable_ids
-
-    d034_raw = yaml.safe_load(
-        (cases_dir / "D034_noise_accesspoint_associateddevice.yaml").read_text(
-            encoding="utf-8"
-        )
-    )
-    d034 = load_case(cases_dir / "D034_noise_accesspoint_associateddevice.yaml")
-    d034_commands = "\n".join(str(step.get("command", "")) for step in d034["steps"])
-    d034_links = {link["band"] for link in d034["topology"]["links"]}
-    d034_sta_config = d034["topology"]["devices"]["STA"]["config"][0]
-
-    assert "aliases" not in d034_raw
-    assert d034["id"] == "wifi-llapi-D034-noise-accesspoint-associateddevice"
-    assert d034["source"]["row"] == 34
-    assert d034["bands"] == ["5g"]
-    assert d034_links == {"5g"}
-    assert d034_sta_config["ssid"] == "testpilot5G"
-    assert d034_sta_config["key"] == "00000000"
-    assert "sta_env_setup" not in d034
-    assert d034["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Noise?"'
-    assert "MACAddress?" in d034_commands
-    assert "DriverAssocMac=" in d034_commands
-    assert "DriverNoise=" in d034_commands
-    assert "DriverNoiseMin=" in d034_commands
-    assert "DriverNoiseMax=" in d034_commands
-    assert any(
-        criterion["field"] == "result.Noise"
-        and criterion["operator"] == "regex"
-        and criterion["value"] == "^-[0-9]+$"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.Noise"
-        and criterion["operator"] == "<"
-        and str(criterion["value"]) == "0"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_noise.DriverAssocMac"
-        and criterion["operator"] == "equals"
-        and criterion["reference"] == "assoc_entry.MACAddress"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_noise.DriverNoise"
-        and criterion["operator"] == "regex"
-        and criterion["value"] == "^-[0-9]+$"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_noise.DriverNoise"
-        and criterion["operator"] == "<"
-        and str(criterion["value"]) == "0"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.Noise"
-        and criterion["operator"] == ">="
-        and criterion["reference"] == "driver_noise.DriverNoiseMin"
-        for criterion in d034["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.Noise"
-        and criterion["operator"] == "<="
-        and criterion["reference"] == "driver_noise.DriverNoiseMax"
-        for criterion in d034["pass_criteria"]
-    )
-
-
-def test_d034_noise_associateddevice_evaluate_live_examples():
-    plugin = _load_plugin()
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-
-    d034 = load_case(cases_dir / "D034_noise_accesspoint_associateddevice.yaml")
-    d034_results = {
-        "steps": {
-            "step1": {
-                "success": True,
-                "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-                "timing": 0.01,
-            },
-            "step2": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Noise=-100",
-                "timing": 0.01,
-            },
-            "step3": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverNoise=-100\nDriverNoiseMin=-102\nDriverNoiseMax=-98",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d034, d034_results) is True
-
-    d034_fail_results = {
-        "steps": {
-            **d034_results["steps"],
-            "step3": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverNoise=-95\nDriverNoiseMin=-97\nDriverNoiseMax=-93",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d034, d034_fail_results) is False
-
-    d034_zero_results = {
-        "steps": {
-            **d034_results["steps"],
-            "step2": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Noise=0",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d034, d034_zero_results) is False
-
-    d034_mismatch_results = {
-        "steps": {
-            **d034_results["steps"],
-            "step3": {
-                "success": True,
-                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverNoise=-100\nDriverNoiseMin=-102\nDriverNoiseMax=-98",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d034, d034_mismatch_results) is False
-
-    d034_missing_driver_range_results = {
-        "steps": {
-            **d034_results["steps"],
-            "step3": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverNoise=-100",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d034, d034_missing_driver_range_results) is False
-
-
-def test_d037_retransmissions_uses_delta_contract():
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-    plugin = _load_plugin()
-    discoverable_ids = {case["id"] for case in plugin.discover_cases()}
-    assert "wifi-llapi-D037-retransmissions" in discoverable_ids
-
-    raw_case = yaml.safe_load((cases_dir / "D037_retransmissions.yaml").read_text(encoding="utf-8"))
-    case_data = load_case(cases_dir / "D037_retransmissions.yaml")
-
-    assert "Workbook v4.0.3 marks this API as Fail" not in case_data["test_procedure"]
-    assert "aliases" not in raw_case
-    assert case_data["id"] == "wifi-llapi-D037-retransmissions"
-    assert case_data["source"]["row"] == 37
-    assert case_data["bands"] == ["5g"]
-    assert case_data["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions?"'
-    assert [step["phase"] for step in case_data["steps"]] == [
-        "baseline",
-        "baseline",
-        "baseline",
-        "baseline",
-        "trigger",
-        "verify",
-        "verify",
-    ]
-    assert [step["capture"] for step in case_data["steps"] if step.get("capture")] == [
-        "assoc_entry",
-        "sta_ip",
-        "api_before_5g",
-        "drv_before_5g",
-        "trigger_probe",
-        "api_after_5g",
-        "drv_after_5g",
-    ]
-    assert "ifconfig wl0" in case_data["steps"][1]["command"]
-    assert "ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}}" in case_data["steps"][4]["command"]
-    assert any(
-        criterion["field"] == "assoc_entry.MACAddress"
-        and criterion["operator"] == "regex"
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "sta_ip.StaIp"
-        and criterion["operator"] == "regex"
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "trigger_probe.TriggerTxPackets"
-        and criterion["operator"] == ">"
-        and str(criterion["value"]) == "0"
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "drv_before_5g.DriverAssocMac"
-        and criterion["operator"] == "equals"
-        and criterion["reference"] == "assoc_entry.MACAddress"
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "drv_after_5g.DriverAssocMac"
-        and criterion["operator"] == "equals"
-        and criterion["reference"] == "assoc_entry.MACAddress"
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion.get("operator") == "delta_nonzero"
-        and criterion.get("delta")
-        == {
-            "baseline": "api_before_5g.Retransmissions",
-            "verify": "api_after_5g.Retransmissions",
-        }
-        for criterion in case_data["pass_criteria"]
-    )
-    assert any(
-        criterion.get("operator") == "delta_match"
-        and criterion.get("delta")
-        == {
-            "baseline": "api_before_5g.Retransmissions",
-            "verify": "api_after_5g.Retransmissions",
-        }
-        and criterion.get("reference_delta")
-        == {
-            "baseline": "drv_before_5g.DriverRetransmissions",
-            "verify": "drv_after_5g.DriverRetransmissions",
-        }
-        and criterion.get("tolerance_pct") == 10
-        for criterion in case_data["pass_criteria"]
-    )
-    assert not any(
-        criterion.get("field") == "result.Retransmissions"
-        and criterion.get("operator") == "equals"
-        and str(criterion.get("value")) == "0"
-        for criterion in case_data["pass_criteria"]
-    )
-
-
-def test_d037_retransmissions_evaluate_delta_examples():
-    plugin = _load_plugin()
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-    case_data = load_case(cases_dir / "D037_retransmissions.yaml")
-
-    pass_results = {
         "steps": {
             "step1_resolve_assoc": {
                 "success": True,
                 "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
                 "timing": 0.01,
             },
-            "step2_resolve_sta_ip": {
+            "step2_prepare_probe_target": {
                 "success": True,
-                "output": "StaIp=192.168.88.2",
+                "output": "StaIp=192.168.1.3",
                 "timing": 0.01,
             },
             "step3_api_baseline": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=10",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount=10",
                 "timing": 0.01,
             },
             "step4_drv_baseline": {
                 "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=100",
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRxMulticastPacketCount=10",
                 "timing": 0.01,
             },
             "step5_trigger": {
                 "success": True,
-                "output": "20 packets transmitted, 20 received, 0% packet loss\nTriggerTxPackets=20",
-                "timing": 1.5,
+                "output": "5 packets transmitted, 0 received, 100% packet loss, time 4103ms\nTriggerTxPackets=5",
+                "timing": 0.01,
             },
             "step6_api_verify": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=16",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount=15",
                 "timing": 0.01,
             },
             "step7_drv_verify": {
                 "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=106",
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRxMulticastPacketCount=15",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(case_data, pass_results) is True
+    assert plugin.evaluate(d040, d040_results) is True
 
-    zero_delta_results = {
+    d040_zero_results = {
         "steps": {
-            **pass_results["steps"],
+            **d040_results["steps"],
             "step6_api_verify": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Retransmissions=10",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.RxMulticastPacketCount=10",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(case_data, zero_delta_results) is False
+    assert plugin.evaluate(d040, d040_zero_results) is False
 
-    mismatch_results = {
+    d040_mismatch_results = {
         "steps": {
-            **pass_results["steps"],
+            **d040_results["steps"],
             "step7_drv_verify": {
                 "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRetransmissions=140",
+                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverRxMulticastPacketCount=30",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(case_data, mismatch_results) is False
+    assert plugin.evaluate(d040, d040_mismatch_results) is False
+
+    d040_assoc_mismatch_results = {
+        "steps": {
+            **d040_results["steps"],
+            "step7_drv_verify": {
+                "success": True,
+                "output": "DriverAssocMac=AA:AA:AA:AA:AA:AA\nDriverRxMulticastPacketCount=15",
+                "timing": 0.01,
+            },
+        }
+    }
+    assert plugin.evaluate(d040, d040_assoc_mismatch_results) is False
 
 
-def test_wave2_associateddevice_delta_cases_use_supported_contracts():
+def test_pending_counter_pass_associateddevice_cases_use_supported_contracts():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     plugin = _load_plugin()
     discoverable_ids = {case["id"] for case in plugin.discover_cases()}
     assert {
-        "wifi-llapi-D038-rx-retransmissions",
-        "wifi-llapi-D051-tx-retransmissions",
-        "wifi-llapi-D052-tx-retransmissionsfailed",
+        "wifi-llapi-D039-rxbytes",
+        "wifi-llapi-D041-rxpacketcount",
+        "wifi-llapi-D042-rxunicastpacketcount",
     }.issubset(discoverable_ids)
 
-    counter_cases = {
-        "D038_rx_retransmissions.yaml": {
-            "id": "wifi-llapi-D038-rx-retransmissions",
-            "row": 38,
-            "api": "Rx_Retransmissions",
-            "probe_field": "dut_ip.DutIp",
-            "trigger_command": "ping -I wl0 -c 20 -s 1400 -W 1 {{dut_ip.DutIp}}",
-            "driver_before": "drv_before_5g.DriverRxRetransmissions",
-            "driver_after": "drv_after_5g.DriverRxRetransmissions",
-            "driver_token": "DriverRxRetransmissions=",
+    pass_cases = {
+        "D039_rxbytes.yaml": {
+            "id": "wifi-llapi-D039-rxbytes",
+            "row": 39,
+            "api": "RxBytes",
+            "driver_before": "drv_before_5g.DriverRxBytes",
+            "driver_after": "drv_after_5g.DriverRxBytes",
+            "driver_token": "DriverRxBytes=",
+            "trigger_command": "ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}}",
         },
-        "D051_tx_retransmissions.yaml": {
-            "id": "wifi-llapi-D051-tx-retransmissions",
-            "row": 53,
-            "api": "Tx_Retransmissions",
-            "probe_field": "sta_ip.StaIp",
-            "trigger_command": "ping -I br-lan -c 20 -s 1400 -W 1 {{sta_ip.StaIp}}",
-            "driver_before": "drv_before_5g.DriverTxRetransmissions",
-            "driver_after": "drv_after_5g.DriverTxRetransmissions",
-            "driver_token": "DriverTxRetransmissions=",
+        "D041_rxpacketcount.yaml": {
+            "id": "wifi-llapi-D041-rxpacketcount",
+            "row": 41,
+            "api": "RxPacketCount",
+            "driver_before": "drv_before_5g.DriverRxPacketCount",
+            "driver_after": "drv_after_5g.DriverRxPacketCount",
+            "driver_token": "DriverRxPacketCount=",
+            "trigger_command": "ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}}",
+        },
+        "D042_rxunicastpacketcount.yaml": {
+            "id": "wifi-llapi-D042-rxunicastpacketcount",
+            "row": 42,
+            "api": "RxUnicastPacketCount",
+            "driver_before": "drv_before_5g.DriverRxUnicastPacketCount",
+            "driver_after": "drv_after_5g.DriverRxUnicastPacketCount",
+            "driver_token": "DriverRxUnicastPacketCount=",
+            "trigger_command": "ping -I wl0 -c 8 -s 1400 -W 1 {{dut_ip.DutIp}}",
         },
     }
 
-    for filename, meta in counter_cases.items():
+    for filename, meta in pass_cases.items():
         raw_case = yaml.safe_load((cases_dir / filename).read_text(encoding="utf-8"))
         case_data = load_case(cases_dir / filename)
         commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
@@ -5545,12 +5283,9 @@ def test_wave2_associateddevice_delta_cases_use_supported_contracts():
         assert "aliases" not in raw_case
         assert case_data["id"] == meta["id"]
         assert case_data["source"]["row"] == meta["row"]
-        assert case_data["llapi_support"] == "Support"
         assert case_data["bands"] == ["5g"]
         assert links == {"5g"}
-        assert case_data["hlapi_command"] == (
-            f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
-        )
+        assert case_data["hlapi_command"] == f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
         assert [step["phase"] for step in case_data["steps"]] == [
             "baseline",
             "baseline",
@@ -5561,11 +5296,12 @@ def test_wave2_associateddevice_delta_cases_use_supported_contracts():
             "verify",
         ]
         assert "MACAddress?" in commands
+        assert "DutIp=" in commands
         assert meta["trigger_command"] in commands
         assert "DriverAssocMac=" in commands
         assert meta["driver_token"] in commands
         assert any(
-            criterion["field"] == meta["probe_field"] and criterion["operator"] == "regex"
+            criterion["field"] == "dut_ip.DutIp" and criterion["operator"] == "regex"
             for criterion in case_data["pass_criteria"]
         )
         assert any(
@@ -5617,74 +5353,27 @@ def test_wave2_associateddevice_delta_cases_use_supported_contracts():
             for criterion in case_data["pass_criteria"]
         )
 
-    d052_raw = yaml.safe_load(
-        (cases_dir / "D052_tx_retransmissionsfailed.yaml").read_text(encoding="utf-8")
-    )
-    d052 = load_case(cases_dir / "D052_tx_retransmissionsfailed.yaml")
-    d052_commands = "\n".join(str(step.get("command", "")) for step in d052["steps"])
 
-    assert "aliases" not in d052_raw
-    assert d052["id"] == "wifi-llapi-D052-tx-retransmissionsfailed"
-    assert d052["source"]["row"] == 54
-    assert d052["llapi_support"] == "Support"
-    assert d052["hlapi_command"] == (
-        'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed?"'
-    )
-    assert "manual" in d052["test_procedure"].lower()
-    assert "external" in d052["test_procedure"].lower()
-    assert [step["phase"] for step in d052["steps"]] == [
-        "baseline",
-        "baseline",
-        "baseline",
-        "trigger",
-        "verify",
-        "verify",
-    ]
-    assert d052["steps"][3]["action"] == "wait"
-    assert d052["steps"][3]["duration"] == 30
-    assert "DriverTxRetransmissionsFailed=" in d052_commands
-    assert any(
-        criterion.get("operator") == "delta_nonzero"
-        and criterion.get("delta")
-        == {
-            "baseline": "api_before_5g.Tx_RetransmissionsFailed",
-            "verify": "api_after_5g.Tx_RetransmissionsFailed",
-        }
-        for criterion in d052["pass_criteria"]
-    )
-    assert any(
-        criterion.get("operator") == "delta_match"
-        and criterion.get("reference_delta")
-        == {
-            "baseline": "drv_before_5g.DriverTxRetransmissionsFailed",
-            "verify": "drv_after_5g.DriverTxRetransmissionsFailed",
-        }
-        for criterion in d052["pass_criteria"]
-    )
-
-
-def test_wave2_associateddevice_delta_cases_evaluate_live_examples():
+def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
     plugin = _load_plugin()
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
 
-    counter_cases = {
-        "D038_rx_retransmissions.yaml": {
-            "api_before": "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions=11",
-            "api_after": "WiFi.AccessPoint.1.AssociatedDevice.1.Rx_Retransmissions=17",
-            "probe_output": "DutIp=192.168.88.1",
-            "driver_before": "DriverRxRetransmissions=121",
-            "driver_after": "DriverRxRetransmissions=127",
+    pass_cases = {
+        "D039_rxbytes.yaml": {
+            "api": "RxBytes",
+            "driver_field": "DriverRxBytes",
         },
-        "D051_tx_retransmissions.yaml": {
-            "api_before": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions=11",
-            "api_after": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_Retransmissions=17",
-            "probe_output": "StaIp=192.168.88.2",
-            "driver_before": "DriverTxRetransmissions=121",
-            "driver_after": "DriverTxRetransmissions=127",
+        "D041_rxpacketcount.yaml": {
+            "api": "RxPacketCount",
+            "driver_field": "DriverRxPacketCount",
+        },
+        "D042_rxunicastpacketcount.yaml": {
+            "api": "RxUnicastPacketCount",
+            "driver_field": "DriverRxUnicastPacketCount",
         },
     }
 
-    for filename, meta in counter_cases.items():
+    for filename, meta in pass_cases.items():
         case_data = load_case(cases_dir / filename)
         pass_results = {
             "steps": {
@@ -5695,275 +5384,44 @@ def test_wave2_associateddevice_delta_cases_evaluate_live_examples():
                 },
                 "step2_resolve_probe_target": {
                     "success": True,
-                    "output": meta["probe_output"],
+                    "output": "DutIp=192.168.1.1",
                     "timing": 0.01,
                 },
                 "step3_api_baseline": {
                     "success": True,
-                    "output": meta["api_before"],
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
                     "timing": 0.01,
                 },
                 "step4_drv_baseline": {
                     "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_before"]}',
+                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=100',
                     "timing": 0.01,
                 },
                 "step5_trigger": {
                     "success": True,
-                    "output": "20 packets transmitted, 20 received, 0% packet loss\nTriggerTxPackets=20",
-                    "timing": 1.5,
+                    "output": '8 packets transmitted, 8 received, 0% packet loss\nTriggerTxPackets=8',
+                    "timing": 0.01,
                 },
                 "step6_api_verify": {
                     "success": True,
-                    "output": meta["api_after"],
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=16',
                     "timing": 0.01,
                 },
                 "step7_drv_verify": {
                     "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_after"]}',
+                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=106',
                     "timing": 0.01,
                 },
             }
         }
         assert plugin.evaluate(case_data, pass_results) is True
-
-        zero_delta_results = {
-            "steps": {
-                **pass_results["steps"],
-                "step6_api_verify": {
-                    "success": True,
-                    "output": meta["api_before"],
-                    "timing": 0.01,
-                },
-            }
-        }
-        assert plugin.evaluate(case_data, zero_delta_results) is False
-
-        mismatch_results = {
-            "steps": {
-                **pass_results["steps"],
-                "step7_drv_verify": {
-                    "success": True,
-                    "output": "DriverAssocMac=2C:59:17:00:04:85\n"
-                    + meta["driver_after"].replace("127", "150"),
-                    "timing": 0.01,
-                },
-            }
-        }
-        assert plugin.evaluate(case_data, mismatch_results) is False
-
-    d052 = load_case(cases_dir / "D052_tx_retransmissionsfailed.yaml")
-    d052_pass_results = {
-        "steps": {
-            "step1_resolve_assoc": {
-                "success": True,
-                "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-                "timing": 0.01,
-            },
-            "step2_api_baseline": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=3",
-                "timing": 0.01,
-            },
-            "step3_drv_baseline": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=30",
-                "timing": 0.01,
-            },
-            "step4_trigger_window": {
-                "success": True,
-                "output": "ManualTriggerWindow=30",
-                "timing": 30.0,
-            },
-            "step5_api_verify": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=9",
-                "timing": 0.01,
-            },
-            "step6_drv_verify": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=36",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d052, d052_pass_results) is True
-
-    d052_zero_delta_results = {
-        "steps": {
-            **d052_pass_results["steps"],
-            "step5_api_verify": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.Tx_RetransmissionsFailed=3",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d052, d052_zero_delta_results) is False
-
-    d052_mismatch_results = {
-        "steps": {
-            **d052_pass_results["steps"],
-            "step6_drv_verify": {
-                "success": True,
-                "output": "DriverAssocMac=2C:59:17:00:04:85\nDriverTxRetransmissionsFailed=45",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d052, d052_mismatch_results) is False
-
-
-def test_pending_counter_pass_associateddevice_cases_use_supported_contracts():
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-    plugin = _load_plugin()
-    discoverable_ids = {case["id"] for case in plugin.discover_cases()}
-    assert {
-        "wifi-llapi-D039-rxbytes",
-        "wifi-llapi-D041-rxpacketcount",
-        "wifi-llapi-D056-txpacketcount",
-    }.issubset(discoverable_ids)
-
-    pass_cases = {
-        "D039_rxbytes.yaml": {
-            "id": "wifi-llapi-D039-rxbytes",
-            "row": 39,
-            "api": "RxBytes",
-            "driver_token": "DriverRxBytes=",
-            "driver_field": "driver_counter.DriverRxBytes",
-        },
-        "D041_rxpacketcount.yaml": {
-            "id": "wifi-llapi-D041-rxpacketcount",
-            "row": 41,
-            "api": "RxPacketCount",
-            "driver_token": "DriverRxPacketCount=",
-            "driver_field": "driver_counter.DriverRxPacketCount",
-        },
-        "D056_txpacketcount.yaml": {
-            "id": "wifi-llapi-D056-txpacketcount",
-            "row": 56,
-            "api": "TxPacketCount",
-            "driver_token": "DriverTxPacketCount=",
-            "driver_field": "driver_counter.DriverTxPacketCount",
-        },
-    }
-
-    for filename, meta in pass_cases.items():
-        raw_case = yaml.safe_load((cases_dir / filename).read_text(encoding="utf-8"))
-        case_data = load_case(cases_dir / filename)
-        commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
-        links = {link["band"] for link in case_data["topology"]["links"]}
-
-        assert "aliases" not in raw_case
-        assert case_data["id"] == meta["id"]
-        assert case_data["source"]["row"] == meta["row"]
-        assert case_data["bands"] == ["5g"]
-        assert links == {"5g"}
-        assert case_data["hlapi_command"] == f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
-        assert "MACAddress?" in commands
-        assert "DriverAssocMac=" in commands
-        assert meta["driver_token"] in commands
-        assert any(
-            criterion["field"] == f'result.{meta["api"]}'
-            and criterion["operator"] == "regex"
-            and criterion["value"] == "^[0-9]+$"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == f'result.{meta["api"]}'
-            and criterion["operator"] == ">"
-            and str(criterion["value"]) == "0"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == "driver_counter.DriverAssocMac"
-            and criterion["operator"] == "equals"
-            and criterion["reference"] == "assoc_entry.MACAddress"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == meta["driver_field"]
-            and criterion["operator"] == ">"
-            and str(criterion["value"]) == "0"
-            for criterion in case_data["pass_criteria"]
-        )
-        assert any(
-            criterion["field"] == f'result.{meta["api"]}'
-            and criterion["operator"] == "equals"
-            and criterion["reference"] == meta["driver_field"]
-            for criterion in case_data["pass_criteria"]
-        )
-        _cpass_rr = {
-            "D039_rxbytes.yaml": ("Pass", "Pass", "Pass"),
-            "D041_rxpacketcount.yaml": ("Pass", "Pass", "Pass"),
-            "D056_txpacketcount.yaml": ("Pass", "Pass", "Pass"),
-        }
-        exp5, exp6, exp24 = _cpass_rr[filename]
-
-
-def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
-    plugin = _load_plugin()
-    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-
-    pass_cases = {
-        "D039_rxbytes.yaml": {
-            "api": "RxBytes",
-            "driver_output": "DriverRxBytes=723",
-            "driver_fail_output": "DriverRxBytes=0",
-        },
-        "D041_rxpacketcount.yaml": {
-            "api": "RxPacketCount",
-            "driver_output": "DriverRxPacketCount=7",
-            "driver_fail_output": "DriverRxPacketCount=0",
-        },
-        "D056_txpacketcount.yaml": {
-            "api": "TxPacketCount",
-            "driver_output": "DriverTxPacketCount=12956",
-            "driver_fail_output": "DriverTxPacketCount=0",
-        },
-    }
-
-    for filename, meta in pass_cases.items():
-        case_data = load_case(cases_dir / filename)
-        pass_results = {
-            "steps": {
-                "step1": {
-                    "success": True,
-                    "output": 'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-                    "timing": 0.01,
-                },
-                "step2": {
-                    "success": True,
-                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}={meta["driver_output"].split("=", 1)[1]}',
-                    "timing": 0.01,
-                },
-                "step3": {
-                    "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_output"]}',
-                    "timing": 0.01,
-                },
-            }
-        }
-        assert plugin.evaluate(case_data, pass_results) is True
-
-        fail_results = {
-            "steps": {
-                **pass_results["steps"],
-                "step3": {
-                    "success": True,
-                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_fail_output"]}',
-                    "timing": 0.01,
-                },
-            }
-        }
-        assert plugin.evaluate(case_data, fail_results) is False
 
         zero_results = {
             "steps": {
                 **pass_results["steps"],
-                "step2": {
+                "step6_api_verify": {
                     "success": True,
-                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=0',
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
                     "timing": 0.01,
                 },
             }
@@ -5973,14 +5431,26 @@ def test_pending_counter_pass_associateddevice_cases_evaluate_live_examples():
         mismatch_results = {
             "steps": {
                 **pass_results["steps"],
-                "step3": {
+                "step7_drv_verify": {
                     "success": True,
-                    "output": f'DriverAssocMac=AA:AA:AA:AA:AA:AA\n{meta["driver_output"]}',
+                    "output": f'DriverAssocMac=2C:59:17:00:04:85\n{meta["driver_field"]}=130',
                     "timing": 0.01,
                 },
             }
         }
         assert plugin.evaluate(case_data, mismatch_results) is False
+
+        assoc_mismatch_results = {
+            "steps": {
+                **pass_results["steps"],
+                "step7_drv_verify": {
+                    "success": True,
+                    "output": f'DriverAssocMac=AA:AA:AA:AA:AA:AA\n{meta["driver_field"]}=106',
+                    "timing": 0.01,
+                },
+            }
+        }
+        assert plugin.evaluate(case_data, assoc_mismatch_results) is False
 
 
 def test_d059_uplinkbandwidth_uses_positive_same_sta_contract():
@@ -7695,19 +7165,22 @@ def test_d055_txmulticastpacketcount_uses_same_sta_delivery_contract():
     assert d055["bands"] == ["5g"]
     assert d055_links == {"5g"}
     assert d055["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"'
-    assert "cat /sys/class/net/wl0/address" in d055_commands
-    assert "tr 'A-F' 'a-f'" in d055_commands
+    assert [step["phase"] for step in d055["steps"]] == [
+        "baseline",
+        "baseline",
+        "baseline",
+        "baseline",
+        "trigger",
+        "verify",
+        "verify",
+        "verify",
+    ]
     assert "StaRxPacketsBefore=" in d055_commands
     assert "StaRxBytesBefore=" in d055_commands
-    assert "MACAddress?" in d055_commands
-    assert "ping -b -I br-lan -c 10 -W 1 192.168.1.255" in d055_commands
     assert "ProbeTxPackets=" in d055_commands
     assert "StaRxPacketsAfter=" in d055_commands
     assert "StaRxBytesAfter=" in d055_commands
-    assert "AssocTxMulticastPacketCount=" in d055_commands
     assert "DriverTxMulticastPacketCount=" in d055_commands
-    assert "DriverTxMulticastBytes=" in d055_commands
-    assert 'AssocMAC=' in d055_commands
     assert any(
         criterion["field"] == "assoc_entry.MACAddress"
         and criterion["operator"] == "equals"
@@ -7733,33 +7206,39 @@ def test_d055_txmulticastpacketcount_uses_same_sta_delivery_contract():
         for criterion in d055["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "result.TxMulticastPacketCount"
-        and criterion["operator"] == "equals"
-        and str(criterion["value"]) == "0"
-        for criterion in d055["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.TxMulticastPacketCount"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "assoc_snapshot.AssocTxMulticastPacketCount"
-        for criterion in d055["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_counter.DriverAssocMac"
+        criterion["field"] == "drv_before_5g.DriverAssocMac"
         and criterion["operator"] == "equals"
         and criterion.get("reference") == "assoc_entry.MACAddress"
         for criterion in d055["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "driver_counter.DriverTxMulticastPacketCount"
+        criterion["field"] == "drv_after_5g.DriverAssocMac"
         and criterion["operator"] == "equals"
-        and str(criterion["value"]) == "0"
+        and criterion.get("reference") == "assoc_entry.MACAddress"
         for criterion in d055["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "driver_counter.DriverTxMulticastBytes"
-        and criterion["operator"] == "equals"
-        and str(criterion["value"]) == "0"
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_5g.TxMulticastPacketCount",
+            "verify": "api_after_5g.TxMulticastPacketCount",
+        }
+        for criterion in d055["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_5g.DriverTxMulticastPacketCount",
+            "verify": "drv_after_5g.DriverTxMulticastPacketCount",
+        }
+        for criterion in d055["pass_criteria"]
+    )
+    assert not any(
+        criterion.get("field") == "result.TxMulticastPacketCount"
+        and criterion.get("operator") == "equals"
+        and str(criterion.get("value")) == "0"
         for criterion in d055["pass_criteria"]
     )
 
@@ -7771,45 +7250,44 @@ def test_d055_txmulticastpacketcount_evaluate_live_examples():
 
     d055_results = {
         "steps": {
-            "step1": {
+            "step1_sta_identity": {
                 "success": True,
-                "output": "\n".join(
-                    [
-                        "StaMac=2c:59:17:00:04:85",
-                        "StaRxPacketsBefore=136067",
-                        "StaRxBytesBefore=15249537",
-                    ]
-                ),
+                "output": "StaMac=2c:59:17:00:04:85\nStaRxPacketsBefore=136067\nStaRxBytesBefore=15249537",
                 "timing": 0.01,
             },
-            "step2": {
+            "step2_assoc_entry": {
                 "success": True,
                 "output": "MACAddress=2c:59:17:00:04:85",
                 "timing": 0.01,
             },
-            "step3": {
+            "step3_api_baseline": {
+                "success": True,
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=10",
+                "timing": 0.01,
+            },
+            "step4_drv_baseline": {
+                "success": True,
+                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=10",
+                "timing": 0.01,
+            },
+            "step5_trigger": {
                 "success": True,
                 "output": "10 packets transmitted, 0 received, 100% packet loss, time 9034ms\nProbeTxPackets=10",
                 "timing": 0.01,
             },
-            "step4": {
+            "step6_sta_after": {
                 "success": True,
                 "output": "StaRxPacketsAfter=136077\nStaRxBytesAfter=15250517",
                 "timing": 0.01,
             },
-            "step5": {
+            "step7_api_verify": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=0",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=14",
                 "timing": 0.01,
             },
-            "step6": {
+            "step8_drv_verify": {
                 "success": True,
-                "output": "AssocMAC=2c:59:17:00:04:85\nAssocTxMulticastPacketCount=0",
-                "timing": 0.01,
-            },
-            "step7": {
-                "success": True,
-                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=0\nDriverTxMulticastBytes=0",
+                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=14",
                 "timing": 0.01,
             },
         }
@@ -7819,7 +7297,7 @@ def test_d055_txmulticastpacketcount_evaluate_live_examples():
     d055_no_delivery_results = {
         "steps": {
             **d055_results["steps"],
-            "step4": {
+            "step6_sta_after": {
                 "success": True,
                 "output": "StaRxPacketsAfter=136067\nStaRxBytesAfter=15249537",
                 "timing": 0.01,
@@ -7828,251 +7306,235 @@ def test_d055_txmulticastpacketcount_evaluate_live_examples():
     }
     assert plugin.evaluate(d055, d055_no_delivery_results) is False
 
-    d055_wrong_llapi_results = {
+    d055_zero_results = {
         "steps": {
             **d055_results["steps"],
-            "step5": {
+            "step7_api_verify": {
                 "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=3",
+                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=10",
                 "timing": 0.01,
             },
         }
     }
-    assert plugin.evaluate(d055, d055_wrong_llapi_results) is False
+    assert plugin.evaluate(d055, d055_zero_results) is False
 
     d055_wrong_driver_results = {
         "steps": {
             **d055_results["steps"],
-            "step7": {
+            "step8_drv_verify": {
                 "success": True,
-                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=2\nDriverTxMulticastBytes=196",
+                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=30",
                 "timing": 0.01,
             },
         }
     }
     assert plugin.evaluate(d055, d055_wrong_driver_results) is False
 
-    d055_wrong_assoc_results = {
-        "steps": {
-            **d055_results["steps"],
-            "step2": {
-                "success": True,
-                "output": "MACAddress=aa:aa:aa:aa:aa:aa",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d055, d055_wrong_assoc_results) is False
-
-    d055_mixed_case_llapi_results = {
-        "steps": {
-            **d055_results["steps"],
-            "step2": {
-                "success": True,
-                "output": "MACAddress=2c:59:17:00:04:85",
-                "timing": 0.01,
-            },
-            "step6": {
-                "success": True,
-                "output": "AssocMAC=2c:59:17:00:04:85\nAssocTxMulticastPacketCount=0",
-                "timing": 0.01,
-            },
-            "step7": {
-                "success": True,
-                "output": "DriverAssocMac=2c:59:17:00:04:85\nDriverTxMulticastPacketCount=0\nDriverTxMulticastBytes=0",
-                "timing": 0.01,
-            },
-        }
-    }
-    assert plugin.evaluate(d055, d055_mixed_case_llapi_results) is True
-
 
 def test_d057_txunicastpacketcount_uses_same_sta_failure_contract():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     plugin = _load_plugin()
     discoverable_ids = {case["id"] for case in plugin.discover_cases()}
-    assert "wifi-llapi-D057-txunicastpacketcount" in discoverable_ids
+    assert {
+        "wifi-llapi-D056-txpacketcount",
+        "wifi-llapi-D057-txunicastpacketcount",
+    }.issubset(discoverable_ids)
 
-    d057_raw = yaml.safe_load((cases_dir / "D057_txunicastpacketcount.yaml").read_text(encoding="utf-8"))
-    d057 = load_case(cases_dir / "D057_txunicastpacketcount.yaml")
-    d057_commands = "\n".join(str(step.get("command", "")) for step in d057["steps"])
-    d057_links = {link["band"] for link in d057["topology"]["links"]}
+    pass_cases = {
+        "D056_txpacketcount.yaml": {
+            "id": "wifi-llapi-D056-txpacketcount",
+            "row": 56,
+            "api": "TxPacketCount",
+            "driver_before": "drv_before_5g.DriverTxPacketCount",
+            "driver_after": "drv_after_5g.DriverTxPacketCount",
+            "driver_token": "DriverTxPacketCount=",
+            "ssid": "TestPilot_BTM",
+        },
+        "D057_txunicastpacketcount.yaml": {
+            "id": "wifi-llapi-D057-txunicastpacketcount",
+            "row": 57,
+            "api": "TxUnicastPacketCount",
+            "driver_before": "drv_before_5g.DriverTxUnicastPacketCount",
+            "driver_after": "drv_after_5g.DriverTxUnicastPacketCount",
+            "driver_token": "DriverTxUnicastPacketCount=",
+            "ssid": "testpilot5G",
+        },
+    }
 
-    assert "aliases" not in d057_raw
-    assert d057["id"] == "wifi-llapi-D057-txunicastpacketcount"
-    assert d057["source"]["row"] == 57
-    assert d057["llapi_support"] == "Support"
-    assert d057["bands"] == ["5g"]
-    assert d057_links == {"5g"}
-    assert d057["topology"]["devices"]["STA"]["config"][0]["ssid"] == "testpilot5G"
-    assert d057["topology"]["devices"]["STA"]["config"][0]["security"] == "WPA2-Personal"
-    assert "sta_env_setup" not in d057_raw
-    assert d057["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"'
-    assert "cat /sys/class/net/wl0/address" in d057_commands
-    assert "tr 'A-F' 'a-f'" in d057_commands
-    assert "MACAddress?" in d057_commands
-    assert 'TxUnicastPacketCount?"' in d057_commands
-    assert "AssocTxUnicastPacketCount=" in d057_commands
-    assert "AssocTxPacketCount=" in d057_commands
-    assert "DriverTxPacketCount=" in d057_commands
-    assert "DriverTxUnicastPacketCount=" in d057_commands
-    assert "DriverTxBytes=" in d057_commands
-    assert "DriverTxUnicastBytes=" in d057_commands
-    assert any(
-        criterion["field"] == "assoc_entry.MACAddress"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "sta_identity.StaMac"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.TxUnicastPacketCount"
-        and criterion["operator"] == "equals"
-        and str(criterion["value"]) == "0"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "result.TxUnicastPacketCount"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "assoc_snapshot.AssocTxUnicastPacketCount"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "assoc_snapshot.AssocTxPacketCount"
-        and criterion["operator"] == ">"
-        and str(criterion["value"]) == "0"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_capture.DriverAssocMac"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "assoc_entry.MACAddress"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_capture.DriverTxPacketCount"
-        and criterion["operator"] == ">"
-        and str(criterion["value"]) == "0"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "assoc_snapshot.AssocTxPacketCount"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "driver_capture.DriverTxPacketCount"
-        for criterion in d057["pass_criteria"]
-    )
-    assert any(
-        criterion["field"] == "driver_capture.DriverTxUnicastPacketCount"
-        and criterion["operator"] == ">"
-        and str(criterion["value"]) == "0"
-        for criterion in d057["pass_criteria"]
-    )
+    for filename, meta in pass_cases.items():
+        raw_case = yaml.safe_load((cases_dir / filename).read_text(encoding="utf-8"))
+        case_data = load_case(cases_dir / filename)
+        commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
+        links = {link["band"] for link in case_data["topology"]["links"]}
+
+        assert "aliases" not in raw_case
+        assert case_data["id"] == meta["id"]
+        assert case_data["source"]["row"] == meta["row"]
+        assert case_data["llapi_support"] == "Support"
+        assert case_data["bands"] == ["5g"]
+        assert links == {"5g"}
+        assert case_data["hlapi_command"] == f'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}?"'
+        assert [step["phase"] for step in case_data["steps"]] == [
+            "baseline",
+            "baseline",
+            "baseline",
+            "baseline",
+            "trigger",
+            "verify",
+            "verify",
+        ]
+        assert "wpa_state=" in commands
+        assert "StaIp=" in commands
+        assert "TriggerTxPackets=" in commands
+        assert "DriverAssocMac=" in commands
+        assert meta["driver_token"] in commands
+        assert any(
+            criterion["field"] == "sta_ready_5g.wpa_state"
+            and criterion["operator"] == "equals"
+            and criterion["value"] == "COMPLETED"
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion["field"] == "sta_ready_5g.ssid"
+            and criterion["operator"] == "equals"
+            and criterion["value"] == meta["ssid"]
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion["field"] == "assoc_entry.MACAddress"
+            and criterion["operator"] == "equals"
+            and criterion.get("reference") == "sta_ready_5g.StaMac"
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion["field"] == "trigger_probe.TriggerTxPackets"
+            and criterion["operator"] == ">"
+            and str(criterion["value"]) == "0"
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion.get("operator") == "delta_nonzero"
+            and criterion.get("delta")
+            == {
+                "baseline": f'api_before_5g.{meta["api"]}',
+                "verify": f'api_after_5g.{meta["api"]}',
+            }
+            for criterion in case_data["pass_criteria"]
+        )
+        assert any(
+            criterion.get("operator") == "delta_match"
+            and criterion.get("reference_delta")
+            == {
+                "baseline": meta["driver_before"],
+                "verify": meta["driver_after"],
+            }
+            for criterion in case_data["pass_criteria"]
+        )
+        assert not any(
+            criterion.get("field") == f'result.{meta["api"]}'
+            and criterion.get("operator") == "equals"
+            and str(criterion.get("value")) == "0"
+            for criterion in case_data["pass_criteria"]
+        )
 
 
 def test_d057_txunicastpacketcount_evaluate_live_examples():
     plugin = _load_plugin()
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
-    d057 = load_case(cases_dir / "D057_txunicastpacketcount.yaml")
 
-    d057_results = {
-        "steps": {
-            "step1": {
-                "success": True,
-                "output": "StaMac=2c:59:17:00:04:85",
-                "timing": 0.01,
-            },
-            "step2": {
-                "success": True,
-                "output": "MACAddress=2c:59:17:00:04:85",
-                "timing": 0.01,
-            },
-            "step3": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount=0",
-                "timing": 0.01,
-            },
-            "step4": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "AssocMAC=2c:59:17:00:04:85",
-                        "AssocTxUnicastPacketCount=0",
-                        "AssocTxPacketCount=90442",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step5": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "DriverAssocMac=2c:59:17:00:04:85",
-                        "DriverTxPacketCount=90442",
-                        "DriverTxUnicastPacketCount=90442",
-                        "DriverTxBytes=0",
-                        "DriverTxUnicastBytes=0",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-        }
+    pass_cases = {
+        "D056_txpacketcount.yaml": {
+            "api": "TxPacketCount",
+            "driver_field": "DriverTxPacketCount",
+            "ssid": "TestPilot_BTM",
+            "key_mgmt": "SAE",
+        },
+        "D057_txunicastpacketcount.yaml": {
+            "api": "TxUnicastPacketCount",
+            "driver_field": "DriverTxUnicastPacketCount",
+            "ssid": "testpilot5G",
+            "key_mgmt": "WPA2-PSK",
+        },
     }
-    assert plugin.evaluate(d057, d057_results) is True
 
-    d057_wrong_llapi_results = {
-        "steps": {
-            **d057_results["steps"],
-            "step3": {
-                "success": True,
-                "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount=7",
-                "timing": 0.01,
-            },
+    for filename, meta in pass_cases.items():
+        case_data = load_case(cases_dir / filename)
+        pass_results = {
+            "steps": {
+                "step1_sta_ready": {
+                    "success": True,
+                    "output": "ssid={ssid}\nkey_mgmt={key_mgmt}\nwpa_state=COMPLETED\nStaMac=2c:59:17:00:04:85\nStaIp=192.168.1.3".format(**meta),
+                    "timing": 0.01,
+                },
+                "step2_assoc_entry": {
+                    "success": True,
+                    "output": 'MACAddress=2c:59:17:00:04:85',
+                    "timing": 0.01,
+                },
+                "step3_api_baseline": {
+                    "success": True,
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
+                    "timing": 0.01,
+                },
+                "step4_drv_baseline": {
+                    "success": True,
+                    "output": f'DriverAssocMac=2c:59:17:00:04:85\n{meta["driver_field"]}=100',
+                    "timing": 0.01,
+                },
+                "step5_trigger": {
+                    "success": True,
+                    "output": '8 packets transmitted, 8 received, 0% packet loss\nTriggerTxPackets=8',
+                    "timing": 0.01,
+                },
+                "step6_api_verify": {
+                    "success": True,
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=16',
+                    "timing": 0.01,
+                },
+                "step7_drv_verify": {
+                    "success": True,
+                    "output": f'DriverAssocMac=2c:59:17:00:04:85\n{meta["driver_field"]}=106',
+                    "timing": 0.01,
+                },
+            }
         }
-    }
-    assert plugin.evaluate(d057, d057_wrong_llapi_results) is False
+        assert plugin.evaluate(case_data, pass_results) is True
 
-    d057_missing_total_results = {
-        "steps": {
-            **d057_results["steps"],
-            "step4": {
-                "success": True,
-                "output": "AssocMAC=2c:59:17:00:04:85\nAssocTxUnicastPacketCount=0\nAssocTxPacketCount=0",
-                "timing": 0.01,
-            },
+        zero_results = {
+            "steps": {
+                **pass_results["steps"],
+                "step6_api_verify": {
+                    "success": True,
+                    "output": f'WiFi.AccessPoint.1.AssociatedDevice.1.{meta["api"]}=10',
+                    "timing": 0.01,
+                },
+            }
         }
-    }
-    assert plugin.evaluate(d057, d057_missing_total_results) is False
+        assert plugin.evaluate(case_data, zero_results) is False
 
-    d057_wrong_driver_results = {
-        "steps": {
-            **d057_results["steps"],
-            "step5": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "DriverAssocMac=2c:59:17:00:04:85",
-                        "DriverTxPacketCount=90442",
-                        "DriverTxUnicastPacketCount=0",
-                        "DriverTxBytes=0",
-                        "DriverTxUnicastBytes=0",
-                    ]
-                ),
-                "timing": 0.01,
-            },
+        mismatch_results = {
+            "steps": {
+                **pass_results["steps"],
+                "step7_drv_verify": {
+                    "success": True,
+                    "output": f'DriverAssocMac=2c:59:17:00:04:85\n{meta["driver_field"]}=130',
+                    "timing": 0.01,
+                },
+            }
         }
-    }
-    assert plugin.evaluate(d057, d057_wrong_driver_results) is False
+        assert plugin.evaluate(case_data, mismatch_results) is False
 
-    d057_wrong_assoc_results = {
-        "steps": {
-            **d057_results["steps"],
-            "step2": {
-                "success": True,
-                "output": "MACAddress=aa:aa:aa:aa:aa:aa",
-                "timing": 0.01,
-            },
+        assoc_mismatch_results = {
+            "steps": {
+                **pass_results["steps"],
+                "step7_drv_verify": {
+                    "success": True,
+                    "output": f'DriverAssocMac=aa:aa:aa:aa:aa:aa\n{meta["driver_field"]}=106',
+                    "timing": 0.01,
+                },
+            }
         }
-    }
-    assert plugin.evaluate(d057, d057_wrong_assoc_results) is False
+        assert plugin.evaluate(case_data, assoc_mismatch_results) is False
 
 
 def test_d053_txbytes_contract():
@@ -8093,33 +7555,46 @@ def test_d053_txbytes_contract():
     assert d053["bands"] == ["5g", "6g", "2.4g"]
     assert d053_links == {"5g", "6g", "2.4g"}
     assert d053["hlapi_command"] == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes?"'
-    assert len(d053["steps"]) == 15
-    assert len(d053["pass_criteria"]) == 36
-    assert "PingTx5g=" in d053_commands
-    assert "PingTx6g=" in d053_commands
-    assert "PingTx24g=" in d053_commands
-    assert "AssocTxBytes5g=" in d053_commands
-    assert "AssocTxBytes6g=" in d053_commands
-    assert "AssocTxBytes24g=" in d053_commands
+    assert len(d053["steps"]) == 21
+    assert [step["phase"] for step in d053["steps"]] == [
+        "baseline", "baseline", "baseline", "baseline", "trigger", "verify", "verify",
+        "baseline", "baseline", "baseline", "baseline", "trigger", "verify", "verify",
+        "baseline", "baseline", "baseline", "baseline", "trigger", "verify", "verify",
+    ]
+    assert "TriggerTxPackets5g=" in d053_commands
+    assert "TriggerTxPackets6g=" in d053_commands
+    assert "TriggerTxPackets24g=" in d053_commands
     assert "DriverTxBytes5g=" in d053_commands
     assert "DriverTxBytes6g=" in d053_commands
     assert "DriverTxBytes24g=" in d053_commands
     assert any(
-        criterion["field"] == "assoc_entry_5g.AssocMac5g"
+        criterion["field"] == "sta_ready_5g.wpa_state"
         and criterion["operator"] == "equals"
-        and criterion.get("reference") == "sta_ready_5g.StaMac5g"
+        and criterion["value"] == "COMPLETED"
         for criterion in d053["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "capture_6g.TxBytes6g"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "capture_6g.AssocTxBytes6g"
+        criterion.get("field") == "assoc_entry_6g.AssocMac6g"
+        and criterion.get("operator") == "equals"
+        and criterion.get("reference") == "sta_ready_6g.StaMac6g"
         for criterion in d053["pass_criteria"]
     )
     assert any(
-        criterion["field"] == "capture_24g.DriverTxBytes24g"
-        and criterion["operator"] == "equals"
-        and criterion.get("reference") == "capture_24g.TxBytes24g"
+        criterion.get("operator") == "delta_nonzero"
+        and criterion.get("delta")
+        == {
+            "baseline": "api_before_24g.TxBytes",
+            "verify": "api_after_24g.TxBytes",
+        }
+        for criterion in d053["pass_criteria"]
+    )
+    assert any(
+        criterion.get("operator") == "delta_match"
+        and criterion.get("reference_delta")
+        == {
+            "baseline": "drv_before_6g.DriverTxBytes6g",
+            "verify": "drv_after_6g.DriverTxBytes6g",
+        }
         for criterion in d053["pass_criteria"]
     )
 
@@ -8131,156 +7606,27 @@ def test_d053_txbytes_evaluate_live_examples():
 
     d053_results = {
         "steps": {
-            "step1_5g_sta_ready": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "bssid=2c:59:17:00:19:95",
-                        "freq=5180",
-                        "ssid=testpilot5G",
-                        "key_mgmt=WPA2-PSK",
-                        "wpa_state=COMPLETED",
-                        "StaMac5g=2c:59:17:00:04:85",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step2_5g_assoc_entry": {
-                "success": True,
-                "output": "AssocMac5g=2c:59:17:00:04:85",
-                "timing": 0.01,
-            },
-            "step3_5g_ip_prep": {
-                "success": True,
-                "output": "StaIp5g=192.168.1.3/24",
-                "timing": 0.01,
-            },
-            "step4_5g_ping_trigger": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "PingReturnCode5g=1",
-                        "PingTx5g=8",
-                        "PingRx5g=0",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step5_5g_tight_capture": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "AssocMac5g=2c:59:17:00:04:85",
-                        "AssocTxBytes5g=12944",
-                        "AssocTxPacketCount5g=24",
-                        "TxBytes5g=12944",
-                        "DriverAssocMac5g=2c:59:17:00:04:85",
-                        "DriverTxBytes5g=12944",
-                        "DriverTxPacketCount5g=24",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step6_6g_sta_ready": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "bssid=2c:59:17:00:19:96",
-                        "freq=5955",
-                        "ssid=testpilot6G",
-                        "key_mgmt=SAE",
-                        "wpa_state=COMPLETED",
-                        "StaMac6g=2c:59:17:00:04:86",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step7_6g_assoc_entry": {
-                "success": True,
-                "output": "AssocMac6g=2c:59:17:00:04:86",
-                "timing": 0.01,
-            },
-            "step8_6g_ip_prep": {
-                "success": True,
-                "output": "StaIp6g=192.168.1.3/24",
-                "timing": 0.01,
-            },
-            "step9_6g_ping_trigger": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "PingReturnCode6g=1",
-                        "PingTx6g=8",
-                        "PingRx6g=0",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step10_6g_tight_capture": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "AssocMac6g=2c:59:17:00:04:86",
-                        "AssocTxBytes6g=28270",
-                        "AssocTxPacketCount6g=49",
-                        "TxBytes6g=28270",
-                        "DriverAssocMac6g=2c:59:17:00:04:86",
-                        "DriverTxBytes6g=28270",
-                        "DriverTxPacketCount6g=49",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step11_24g_sta_ready": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "bssid=2c:59:17:00:19:a7",
-                        "freq=2412",
-                        "ssid=testpilot2G",
-                        "key_mgmt=WPA2-PSK",
-                        "wpa_state=COMPLETED",
-                        "StaMac24g=2c:59:17:00:04:97",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step12_24g_assoc_entry": {
-                "success": True,
-                "output": "AssocMac24g=2c:59:17:00:04:97",
-                "timing": 0.01,
-            },
-            "step13_24g_ip_prep": {
-                "success": True,
-                "output": "StaIp24g=192.168.1.3/24",
-                "timing": 0.01,
-            },
-            "step14_24g_ping_trigger": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "PingReturnCode24g=1",
-                        "PingTx24g=8",
-                        "PingRx24g=0",
-                    ]
-                ),
-                "timing": 0.01,
-            },
-            "step15_24g_tight_capture": {
-                "success": True,
-                "output": "\n".join(
-                    [
-                        "AssocMac24g=2c:59:17:00:04:97",
-                        "AssocTxBytes24g=90",
-                        "AssocTxPacketCount24g=10",
-                        "TxBytes24g=90",
-                        "DriverAssocMac24g=2c:59:17:00:04:97",
-                        "DriverTxBytes24g=90",
-                        "DriverTxPacketCount24g=10",
-                    ]
-                ),
-                "timing": 0.01,
-            },
+            "step1_5g_sta_ready": {"success": True, "output": "wpa_state=COMPLETED\nssid=testpilot5G\nStaMac5g=2c:59:17:00:04:85\nStaIp5g=192.168.1.3", "timing": 0.01},
+            "step2_5g_assoc_entry": {"success": True, "output": "AssocMac5g=2c:59:17:00:04:85", "timing": 0.01},
+            "step3_5g_api_baseline": {"success": True, "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes=10", "timing": 0.01},
+            "step4_5g_drv_baseline": {"success": True, "output": "DriverAssocMac5g=2c:59:17:00:04:85\nDriverTxBytes5g=100", "timing": 0.01},
+            "step5_5g_trigger": {"success": True, "output": "TriggerTxPackets5g=8", "timing": 0.01},
+            "step6_5g_api_verify": {"success": True, "output": "WiFi.AccessPoint.1.AssociatedDevice.1.TxBytes=18", "timing": 0.01},
+            "step7_5g_drv_verify": {"success": True, "output": "DriverAssocMac5g=2c:59:17:00:04:85\nDriverTxBytes5g=108", "timing": 0.01},
+            "step8_6g_sta_ready": {"success": True, "output": "wpa_state=COMPLETED\nssid=testpilot6G\nStaMac6g=2c:59:17:00:04:86\nStaIp6g=192.168.1.3", "timing": 0.01},
+            "step9_6g_assoc_entry": {"success": True, "output": "AssocMac6g=2c:59:17:00:04:86", "timing": 0.01},
+            "step10_6g_api_baseline": {"success": True, "output": "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes=20", "timing": 0.01},
+            "step11_6g_drv_baseline": {"success": True, "output": "DriverAssocMac6g=2c:59:17:00:04:86\nDriverTxBytes6g=200", "timing": 0.01},
+            "step12_6g_trigger": {"success": True, "output": "TriggerTxPackets6g=8", "timing": 0.01},
+            "step13_6g_api_verify": {"success": True, "output": "WiFi.AccessPoint.3.AssociatedDevice.1.TxBytes=28", "timing": 0.01},
+            "step14_6g_drv_verify": {"success": True, "output": "DriverAssocMac6g=2c:59:17:00:04:86\nDriverTxBytes6g=208", "timing": 0.01},
+            "step15_24g_sta_ready": {"success": True, "output": "wpa_state=COMPLETED\nssid=testpilot2G\nStaMac24g=2c:59:17:00:04:97\nStaIp24g=192.168.1.3", "timing": 0.01},
+            "step16_24g_assoc_entry": {"success": True, "output": "AssocMac24g=2c:59:17:00:04:97", "timing": 0.01},
+            "step17_24g_api_baseline": {"success": True, "output": "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes=30", "timing": 0.01},
+            "step18_24g_drv_baseline": {"success": True, "output": "DriverAssocMac24g=2c:59:17:00:04:97\nDriverTxBytes24g=300", "timing": 0.01},
+            "step19_24g_trigger": {"success": True, "output": "TriggerTxPackets24g=8", "timing": 0.01},
+            "step20_24g_api_verify": {"success": True, "output": "WiFi.AccessPoint.5.AssociatedDevice.1.TxBytes=38", "timing": 0.01},
+            "step21_24g_drv_verify": {"success": True, "output": "DriverAssocMac24g=2c:59:17:00:04:97\nDriverTxBytes24g=308", "timing": 0.01},
         }
     }
     assert plugin.evaluate(d053, d053_results) is True
@@ -8288,19 +7634,9 @@ def test_d053_txbytes_evaluate_live_examples():
     d053_wrong_6g_driver_results = {
         "steps": {
             **d053_results["steps"],
-            "step10_6g_tight_capture": {
+            "step14_6g_drv_verify": {
                 "success": True,
-                "output": "\n".join(
-                    [
-                        "AssocMac6g=2c:59:17:00:04:86",
-                        "AssocTxBytes6g=28270",
-                        "AssocTxPacketCount6g=49",
-                        "TxBytes6g=28270",
-                        "DriverAssocMac6g=2c:59:17:00:04:86",
-                        "DriverTxBytes6g=11111",
-                        "DriverTxPacketCount6g=49",
-                    ]
-                ),
+                "output": "DriverAssocMac6g=2c:59:17:00:04:86\nDriverTxBytes6g=260",
                 "timing": 0.01,
             },
         }
@@ -17309,8 +16645,9 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
         ("D034_noise_accesspoint_associateddevice.yaml", 2, "DriverNoise="),
         ("D037_retransmissions.yaml", 3, "DriverRetransmissions="),
         ("D038_rx_retransmissions.yaml", 3, "DriverRxRetransmissions="),
-        ("D039_rxbytes.yaml", 2, "DriverRxBytes="),
+        ("D039_rxbytes.yaml", 3, "DriverRxBytes="),
         ("D040_rxmulticastpacketcount.yaml", 3, "DriverRxMulticastPacketCount="),
+        ("D042_rxunicastpacketcount.yaml", 3, "DriverRxUnicastPacketCount="),
         ("D044_signalnoiseratio.yaml", 2, "DriverSignalNoiseRatio="),
         ("D043_securitymodeenabled.yaml", 2, "DriverSecurityModeEnabled="),
         ("D045_signalstrength_accesspoint_associateddevice.yaml", 2, "DriverSignalStrength="),
@@ -17321,7 +16658,7 @@ def test_extract_cli_fragments_ignores_prose_after_ubus_keyword():
         ("D052_tx_retransmissionsfailed.yaml", 2, "DriverTxRetransmissionsFailed="),
         ("D054_txerrors.yaml", 3, "DriverTxErrors="),
         ("D049_supportedmcs.yaml", 2, "DriverMCSSetPresent="),
-        ("D056_txpacketcount.yaml", 2, "DriverTxPacketCount="),
+        ("D056_txpacketcount.yaml", 3, "DriverTxPacketCount="),
         ("D059_uplinkbandwidth.yaml", 3, "DriverUplinkBandwidth="),
         ("D060_uplinkmcs.yaml", 3, "DriverUplinkMCS="),
         ("D061_uplinkshortguard.yaml", 4, "DriverUplinkShortGuardGI="),
@@ -17509,21 +16846,18 @@ def test_d055_txmulticastpacketcount_verification_fragments_preserve_delivery_an
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d055 = load_case(cases_dir / "D055_txmulticastpacketcount.yaml")
 
-    step3_command = d055["steps"][2]["command"]
-    step6_command = d055["steps"][5]["command"]
-    step7_command = d055["steps"][6]["command"]
+    step5_command = d055["steps"][4]["command"]
+    step8_command = d055["steps"][7]["command"]
     verification_commands = plugin._extract_cli_fragments(d055["verification_command"])
 
-    assert "ProbeTxPackets=" in step3_command
-    assert "AssocTxMulticastPacketCount=" in step6_command
-    assert plugin._sanitize_cli_fragment(step7_command) == step7_command
-    assert plugin._extract_cli_fragments(step7_command) == [step7_command]
-    assert step3_command in verification_commands
+    assert "ProbeTxPackets=" in step5_command
+    assert plugin._sanitize_cli_fragment(step8_command) == step8_command
+    assert plugin._extract_cli_fragments(step8_command) == [step8_command]
+    assert len(verification_commands) == 6
     assert any("StaRxPacketsBefore=" in fragment for fragment in verification_commands)
     assert any("StaRxPacketsAfter=" in fragment for fragment in verification_commands)
-    assert 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount?"' in verification_commands
-    assert step6_command in verification_commands
-    assert step7_command in verification_commands
+    assert step5_command in verification_commands
+    assert verification_commands[-1] == step8_command
 
 
 def test_d055_txmulticastpacketcount_macaddress_fragment_normalizes_case():
@@ -17548,34 +16882,13 @@ def test_d055_txmulticastpacketcount_macaddress_fragment_normalizes_case():
     assert proc.stdout.strip() == "MACAddress=2c:59:17:00:04:85"
 
 
-def test_d055_txmulticastpacketcount_snapshot_sed_fragment_executes():
+def test_d055_txmulticastpacketcount_driver_fragment_mentions_counter():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d055 = load_case(cases_dir / "D055_txmulticastpacketcount.yaml")
-    step6_command = d055["steps"][5]["command"]
-    pipeline = step6_command.split("|", 1)[1].strip()
-    sample_output = "\n".join(
-        [
-            'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-            "WiFi.AccessPoint.1.AssociatedDevice.1.TxMulticastPacketCount=0",
-        ]
-    )
+    step8_command = d055["steps"][7]["command"]
 
-    proc = subprocess.run(
-        [
-            "sh",
-            "-lc",
-            f"cat <<'EOF' | {pipeline}\n{sample_output}\nEOF",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip().splitlines() == [
-        "AssocMAC=2c:59:17:00:04:85",
-        "AssocTxMulticastPacketCount=0",
-    ]
+    assert "DriverTxMulticastPacketCount=" in step8_command
+    assert "DriverAssocMac=" in step8_command
 
 
 def test_d057_txunicastpacketcount_verification_fragments_preserve_snapshot_and_driver_checks():
@@ -17583,20 +16896,16 @@ def test_d057_txunicastpacketcount_verification_fragments_preserve_snapshot_and_
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d057 = load_case(cases_dir / "D057_txunicastpacketcount.yaml")
 
-    step3_command = d057["steps"][2]["command"]
-    step4_command = d057["steps"][3]["command"]
     step5_command = d057["steps"][4]["command"]
+    step7_command = d057["steps"][6]["command"]
     verification_commands = plugin._extract_cli_fragments(d057["verification_command"])
 
-    assert step3_command == 'ubus-cli "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount?"'
-    assert "AssocTxPacketCount=" in step4_command
-    assert plugin._sanitize_cli_fragment(step5_command) == step5_command
-    assert plugin._extract_cli_fragments(step5_command) == [step5_command]
+    assert "TriggerTxPackets=" in step5_command
+    assert plugin._sanitize_cli_fragment(step7_command) == step7_command
+    assert plugin._extract_cli_fragments(step7_command) == [step7_command]
     assert len(verification_commands) == 4
-    assert verification_commands[0] == "cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac=/'"
-    assert verification_commands[1] == step3_command
-    assert verification_commands[2] == step4_command
-    assert verification_commands[3] == step5_command
+    assert verification_commands[2] == step5_command
+    assert verification_commands[3] == step7_command
 
 
 def test_d057_txunicastpacketcount_macaddress_fragment_normalizes_case():
@@ -17621,36 +16930,13 @@ def test_d057_txunicastpacketcount_macaddress_fragment_normalizes_case():
     assert proc.stdout.strip() == "MACAddress=2c:59:17:00:04:85"
 
 
-def test_d057_txunicastpacketcount_snapshot_fragment_executes():
+def test_d057_txunicastpacketcount_driver_fragment_mentions_driver_counter():
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d057 = load_case(cases_dir / "D057_txunicastpacketcount.yaml")
-    step4_command = d057["steps"][3]["command"]
-    pipeline = step4_command.split("|", 1)[1].strip()
-    sample_output = "\n".join(
-        [
-            'WiFi.AccessPoint.1.AssociatedDevice.1.MACAddress="2C:59:17:00:04:85"',
-            "WiFi.AccessPoint.1.AssociatedDevice.1.TxUnicastPacketCount=0",
-            "WiFi.AccessPoint.1.AssociatedDevice.1.TxPacketCount=90442",
-        ]
-    )
+    step7_command = d057["steps"][6]["command"]
 
-    proc = subprocess.run(
-        [
-            "sh",
-            "-lc",
-            f"cat <<'EOF' | {pipeline}\n{sample_output}\nEOF",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip().splitlines() == [
-        "AssocMAC=2c:59:17:00:04:85",
-        "AssocTxUnicastPacketCount=0",
-        "AssocTxPacketCount=90442",
-    ]
+    assert "DriverTxUnicastPacketCount=" in step7_command
+    assert "DriverAssocMac=" in step7_command
 
 
 def test_d053_txbytes_verification_fragments_preserve_snapshot_and_driver_checks():
@@ -17658,16 +16944,14 @@ def test_d053_txbytes_verification_fragments_preserve_snapshot_and_driver_checks
     cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
     d053 = load_case(cases_dir / "D053_txbytes.yaml")
 
-    step5_command = d053["steps"][4]["command"]
+    step7_command = d053["steps"][6]["command"]
     verification_commands = plugin._extract_cli_fragments(d053["verification_command"])
 
-    assert "TxBytes5g=" in step5_command
-    assert "AssocTxPacketCount5g=" in step5_command
-    assert "DriverTxBytes5g=" in step5_command
-    assert plugin._sanitize_cli_fragment(step5_command) == step5_command
-    assert plugin._extract_cli_fragments(step5_command) == [step5_command]
-    assert len(verification_commands) == 15
-    assert verification_commands[4] == step5_command
+    assert "DriverTxBytes5g=" in step7_command
+    assert plugin._sanitize_cli_fragment(step7_command) == step7_command
+    assert plugin._extract_cli_fragments(step7_command) == [step7_command]
+    assert len(verification_commands) == 12
+    assert verification_commands[3] == step7_command
 
 
 def test_d053_txbytes_macaddress_fragment_normalizes_case():


### PR DESCRIPTION
## Summary

- migrate the Wave 3 `wave3-associated-device-traffic` counter cases to baseline/trigger/verify delta contracts
- add explicit STA IPv4 preconditions to the uplink Rx delta cases so STA-originated triggers are defensible
- keep `D031 MUMimoTxPktsCount` as a documented holdout because current repo-local evidence still shows it is a stubbed `Not Supported` counter rather than a live traffic delta metric
- mark OpenSpec task `9.1` complete for this sub-PR

## Case scope

- migrated: `D039`, `D040`, `D041`, `D042`, `D053`, `D055`, `D056`, `D057`
- documented holdout: `D031`

## Notes

- `D053 TxBytes` now uses a DUT -> STA trigger instead of the old reversed direction
- `D055 TxMulticastPacketCount` keeps STA-side before/after delivery evidence so flat counters fail honestly instead of hiding behind a zero-shaped oracle
- command-budget guard updated from `949` to `973`

## Validation

- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py -k 'd031 or d039 or d040 or d041 or d042 or d053 or d055 or d056 or d057' plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py -k 'pending_counter_pass_associateddevice_cases or sanitize_cli_fragment_preserves_nested_quotes_for_associateddevice_driver_checks' plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py`
- `openspec validate wifi-llapi-counter-delta-validation --strict`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q`
