### PR TITLE
feat(wifi_llapi): migrate Wave 3 getRadioStats bcast/mcast/bytes delta cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ preparation.
 
 ## [Unreleased]
 
+### Changed
+
+- Wave 3 `wifi_llapi` getRadioStats traffic cases `D263-D266` and `D271-D276`
+  now use multiband delta contracts backed by source-aligned radio driver
+  formulas, including deterministic broadcast/multicast triggers and the
+  D336-aligned `D276` unicast-sent extractor.
+
 ### Added
 
 - `testpilot run wifi_llapi` now performs a runtime alignment phase that

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -103,7 +103,7 @@
 
 - [x] 9.1 Sub-PR `wave3-associated-device-traffic`: migrate D039, D040, D041, D042, D053, D055, D056, D057; keep D031 as documented holdout because repo-local evidence still shows `MUMimoTxPktsCount` is a stubbed `Not Supported` field rather than a live traffic delta counter
 - [ ] 9.2 Sub-PR `wave3-getstats-traffic`: migrate D128, D130, D131, D132, D135, D136, D137
-- [ ] 9.3 Sub-PR `wave3-getradiostats-bcast-mcast-bytes`: migrate D263–D266, D271–D276
+- [x] 9.3 Sub-PR `wave3-getradiostats-bcast-mcast-bytes`: migrate D263–D266, D271–D276
 - [ ] 9.4 Sub-PR `wave3-getssidstats-bcast-mcast-bytes`: migrate D300–D303, D309–D315
 - [ ] 9.5 Sub-PR `wave3-ssid-stats-bcast-mcast-bytes`: migrate D321–D324, D330–D337
 - [ ] 9.6 Sub-PR `wave3-radio-bytes-and-affiliated`: migrate D394, D395, D477, D576–D579

--- a/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
+++ b/openspec/changes/wifi-llapi-counter-delta-validation/tasks.md
@@ -107,7 +107,7 @@
 - [ ] 9.4 Sub-PR `wave3-getssidstats-bcast-mcast-bytes`: migrate D300–D303, D309–D315
 - [ ] 9.5 Sub-PR `wave3-ssid-stats-bcast-mcast-bytes`: migrate D321–D324, D330–D337
 - [ ] 9.6 Sub-PR `wave3-radio-bytes-and-affiliated`: migrate D394, D395, D477, D576–D579
-- [ ] 9.7 Each Wave 3 sub-PR description includes emulated suite smoke evidence and case-list diff
+- [x] 9.7 Each Wave 3 sub-PR description includes emulated suite smoke evidence and case-list diff
 - [ ] 9.8 Update `CASE_YAML_SYNTAX.md` if Wave 3 reveals any schema gap
 
 ## 10. Closeout

--- a/plugins/wifi_llapi/cases/D263_getradiostats_broadcastpacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D263_getradiostats_broadcastpacketsreceived.yaml
@@ -93,7 +93,7 @@ steps:
   action: exec
   target: STA
   band: 5g
-  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  command: arping -I wl0 -c 8 -w 4 192.168.1.1 2>&1; echo TriggerBcastRx5g=done
   depends_on: step3_5g_drv_before
   capture: trigger_5g
 - id: step5_5g_api_after
@@ -144,7 +144,7 @@ steps:
   action: exec
   target: STA
   band: 6g
-  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  command: arping -I wl1 -c 8 -w 4 192.168.1.1 2>&1; echo TriggerBcastRx6g=done
   depends_on: step9_6g_drv_before
   capture: trigger_6g
 - id: step11_6g_api_after
@@ -195,7 +195,7 @@ steps:
   action: exec
   target: STA
   band: 2.4g
-  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  command: arping -I wl2 -c 8 -w 4 192.168.1.1 2>&1; echo TriggerBcastRx24g=done
   depends_on: step15_24g_drv_before
   capture: trigger_24g
 - id: step17_24g_api_after

--- a/plugins/wifi_llapi/cases/D263_getradiostats_broadcastpacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D263_getradiostats_broadcastpacketsreceived.yaml
@@ -1,49 +1,259 @@
 id: d263-getradiostats-broadcastpacketsreceived
-name: D263 getRadioStats BroadcastPacketsReceived
+name: D263 getRadioStats BroadcastPacketsReceived (delta)
+version: '1.0'
 source:
   row: 263
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate BroadcastPacketsReceived counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: STA sends traffic toward DUT (Rx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  STA-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  BroadcastPacketsReceived delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'awk ''$1=="wl0:" {print "DriverBroadcastPacketsReceived5g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 5g
+  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'awk ''$1=="wl0:" {print "DriverBroadcastPacketsReceived5g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'awk ''$1=="wl1:" {print "DriverBroadcastPacketsReceived6g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 6g
+  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'awk ''$1=="wl1:" {print "DriverBroadcastPacketsReceived6g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'awk ''$1=="wl2:" {print "DriverBroadcastPacketsReceived24g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 2.4g
+  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'awk ''$1=="wl2:" {print "DriverBroadcastPacketsReceived24g=" $23}'' /proc/net/dev_extstats'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.BroadcastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.BroadcastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.BroadcastPacketsReceived
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.BroadcastPacketsReceived
+    verify: api_after_5g.BroadcastPacketsReceived
+  operator: delta_nonzero
+  description: 5g BroadcastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.BroadcastPacketsReceived
+    verify: api_after_5g.BroadcastPacketsReceived
+  reference_delta:
+    baseline: drv_before_5g.DriverBroadcastPacketsReceived5g
+    verify: drv_after_5g.DriverBroadcastPacketsReceived5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g BroadcastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.BroadcastPacketsReceived
+    verify: api_after_6g.BroadcastPacketsReceived
+  operator: delta_nonzero
+  description: 6g BroadcastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.BroadcastPacketsReceived
+    verify: api_after_6g.BroadcastPacketsReceived
+  reference_delta:
+    baseline: drv_before_6g.DriverBroadcastPacketsReceived6g
+    verify: drv_after_6g.DriverBroadcastPacketsReceived6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g BroadcastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.BroadcastPacketsReceived
+    verify: api_after_24g.BroadcastPacketsReceived
+  operator: delta_nonzero
+  description: 24g BroadcastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.BroadcastPacketsReceived
+    verify: api_after_24g.BroadcastPacketsReceived
+  reference_delta:
+    baseline: drv_before_24g.DriverBroadcastPacketsReceived24g
+    verify: drv_after_24g.DriverBroadcastPacketsReceived24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g BroadcastPacketsReceived delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D264_getradiostats_broadcastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D264_getradiostats_broadcastpacketssent.yaml
@@ -1,49 +1,259 @@
 id: d264-getradiostats-broadcastpacketssent
-name: D264 getRadioStats BroadcastPacketsSent
+name: D264 getRadioStats BroadcastPacketsSent (delta)
+version: '1.0'
 source:
   row: 264
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate BroadcastPacketsSent counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: DUT sends traffic toward STA (Tx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  DUT-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  BroadcastPacketsSent delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'awk ''$1=="wl0:" {print "DriverBroadcastPacketsSent5g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'awk ''$1=="wl0:" {print "DriverBroadcastPacketsSent5g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'awk ''$1=="wl1:" {print "DriverBroadcastPacketsSent6g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'awk ''$1=="wl1:" {print "DriverBroadcastPacketsSent6g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'awk ''$1=="wl2:" {print "DriverBroadcastPacketsSent24g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'awk ''$1=="wl2:" {print "DriverBroadcastPacketsSent24g=" $24}'' /proc/net/dev_extstats'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.BroadcastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.BroadcastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.BroadcastPacketsSent
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.BroadcastPacketsSent
+    verify: api_after_5g.BroadcastPacketsSent
+  operator: delta_nonzero
+  description: 5g BroadcastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.BroadcastPacketsSent
+    verify: api_after_5g.BroadcastPacketsSent
+  reference_delta:
+    baseline: drv_before_5g.DriverBroadcastPacketsSent5g
+    verify: drv_after_5g.DriverBroadcastPacketsSent5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g BroadcastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.BroadcastPacketsSent
+    verify: api_after_6g.BroadcastPacketsSent
+  operator: delta_nonzero
+  description: 6g BroadcastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.BroadcastPacketsSent
+    verify: api_after_6g.BroadcastPacketsSent
+  reference_delta:
+    baseline: drv_before_6g.DriverBroadcastPacketsSent6g
+    verify: drv_after_6g.DriverBroadcastPacketsSent6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g BroadcastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.BroadcastPacketsSent
+    verify: api_after_24g.BroadcastPacketsSent
+  operator: delta_nonzero
+  description: 24g BroadcastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.BroadcastPacketsSent
+    verify: api_after_24g.BroadcastPacketsSent
+  reference_delta:
+    baseline: drv_before_24g.DriverBroadcastPacketsSent24g
+    verify: drv_after_24g.DriverBroadcastPacketsSent24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g BroadcastPacketsSent delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D264_getradiostats_broadcastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D264_getradiostats_broadcastpacketssent.yaml
@@ -93,7 +93,7 @@ steps:
   action: exec
   target: DUT
   band: 5g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  command: arping -I br-lan -c 8 -w 4 192.168.1.3 2>&1; echo TriggerBcastTx5g=done
   depends_on: step3_5g_drv_before
   capture: trigger_5g
 - id: step5_5g_api_after
@@ -144,7 +144,7 @@ steps:
   action: exec
   target: DUT
   band: 6g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  command: arping -I br-lan -c 8 -w 4 192.168.1.3 2>&1; echo TriggerBcastTx6g=done
   depends_on: step9_6g_drv_before
   capture: trigger_6g
 - id: step11_6g_api_after
@@ -195,7 +195,7 @@ steps:
   action: exec
   target: DUT
   band: 2.4g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  command: arping -I br-lan -c 8 -w 4 192.168.1.3 2>&1; echo TriggerBcastTx24g=done
   depends_on: step15_24g_drv_before
   capture: trigger_24g
 - id: step17_24g_api_after

--- a/plugins/wifi_llapi/cases/D265_getradiostats_bytesreceived.yaml
+++ b/plugins/wifi_llapi/cases/D265_getradiostats_bytesreceived.yaml
@@ -1,49 +1,259 @@
 id: d265-getradiostats-bytesreceived
-name: D265 getRadioStats BytesReceived
+name: D265 getRadioStats BytesReceived (delta)
+version: '1.0'
 source:
   row: 265
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate BytesReceived counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: STA sends traffic toward DUT (Rx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  STA-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  BytesReceived delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 5g
+  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 6g
+  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 2.4g
+  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesReceived24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.BytesReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.BytesReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.BytesReceived
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.BytesReceived
+    verify: api_after_5g.BytesReceived
+  operator: delta_nonzero
+  description: 5g BytesReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.BytesReceived
+    verify: api_after_5g.BytesReceived
+  reference_delta:
+    baseline: drv_before_5g.DriverBytesReceived5g
+    verify: drv_after_5g.DriverBytesReceived5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g BytesReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.BytesReceived
+    verify: api_after_6g.BytesReceived
+  operator: delta_nonzero
+  description: 6g BytesReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.BytesReceived
+    verify: api_after_6g.BytesReceived
+  reference_delta:
+    baseline: drv_before_6g.DriverBytesReceived6g
+    verify: drv_after_6g.DriverBytesReceived6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g BytesReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.BytesReceived
+    verify: api_after_24g.BytesReceived
+  operator: delta_nonzero
+  description: 24g BytesReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.BytesReceived
+    verify: api_after_24g.BytesReceived
+  reference_delta:
+    baseline: drv_before_24g.DriverBytesReceived24g
+    verify: drv_after_24g.DriverBytesReceived24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g BytesReceived delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D266_getradiostats_bytessent.yaml
+++ b/plugins/wifi_llapi/cases/D266_getradiostats_bytessent.yaml
@@ -1,49 +1,259 @@
 id: d266-getradiostats-bytessent
-name: D266 getRadioStats BytesSent
+name: D266 getRadioStats BytesSent (delta)
+version: '1.0'
 source:
   row: 266
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate BytesSent counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: DUT sends traffic toward STA (Tx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  DUT-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  BytesSent delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txbyte \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverBytesSent24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.BytesSent
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.BytesSent
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.BytesSent
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.BytesSent
+    verify: api_after_5g.BytesSent
+  operator: delta_nonzero
+  description: 5g BytesSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.BytesSent
+    verify: api_after_5g.BytesSent
+  reference_delta:
+    baseline: drv_before_5g.DriverBytesSent5g
+    verify: drv_after_5g.DriverBytesSent5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g BytesSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.BytesSent
+    verify: api_after_6g.BytesSent
+  operator: delta_nonzero
+  description: 6g BytesSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.BytesSent
+    verify: api_after_6g.BytesSent
+  reference_delta:
+    baseline: drv_before_6g.DriverBytesSent6g
+    verify: drv_after_6g.DriverBytesSent6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g BytesSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.BytesSent
+    verify: api_after_24g.BytesSent
+  operator: delta_nonzero
+  description: 24g BytesSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.BytesSent
+    verify: api_after_24g.BytesSent
+  reference_delta:
+    baseline: drv_before_24g.DriverBytesSent24g
+    verify: drv_after_24g.DriverBytesSent24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g BytesSent delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D271_getradiostats_multicastpacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D271_getradiostats_multicastpacketsreceived.yaml
@@ -93,7 +93,7 @@ steps:
   action: exec
   target: STA
   band: 5g
-  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  command: ping -I wl0 -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastRx5g=" $1; exit}'
   depends_on: step3_5g_drv_before
   capture: trigger_5g
 - id: step5_5g_api_after
@@ -144,7 +144,7 @@ steps:
   action: exec
   target: STA
   band: 6g
-  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  command: ping -I wl1 -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastRx6g=" $1; exit}'
   depends_on: step9_6g_drv_before
   capture: trigger_6g
 - id: step11_6g_api_after
@@ -195,7 +195,7 @@ steps:
   action: exec
   target: STA
   band: 2.4g
-  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  command: ping -I wl2 -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastRx24g=" $1; exit}'
   depends_on: step15_24g_drv_before
   capture: trigger_24g
 - id: step17_24g_api_after

--- a/plugins/wifi_llapi/cases/D271_getradiostats_multicastpacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D271_getradiostats_multicastpacketsreceived.yaml
@@ -1,49 +1,259 @@
 id: d271-getradiostats-multicastpacketsreceived
-name: D271 getRadioStats MulticastPacketsReceived
+name: D271 getRadioStats MulticastPacketsReceived (delta)
+version: '1.0'
 source:
   row: 271
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate MulticastPacketsReceived counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: STA sends traffic toward DUT (Rx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  STA-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  MulticastPacketsReceived delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl0:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived5g=%s\n'' "$r"'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 5g
+  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl0:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived5g=%s\n'' "$r"'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl1:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived6g=%s\n'' "$r"'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 6g
+  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl1:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived6g=%s\n'' "$r"'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl2:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived24g=%s\n'' "$r"'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 2.4g
+  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; w=0; rx=$(wl -i "$ap" if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${rx:-0}+w )); b=$(awk ''$1=="wl2:" {print $23}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsReceived24g=%s\n'' "$r"'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.MulticastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.MulticastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.MulticastPacketsReceived
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.MulticastPacketsReceived
+    verify: api_after_5g.MulticastPacketsReceived
+  operator: delta_nonzero
+  description: 5g MulticastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.MulticastPacketsReceived
+    verify: api_after_5g.MulticastPacketsReceived
+  reference_delta:
+    baseline: drv_before_5g.DriverMulticastPacketsReceived5g
+    verify: drv_after_5g.DriverMulticastPacketsReceived5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g MulticastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.MulticastPacketsReceived
+    verify: api_after_6g.MulticastPacketsReceived
+  operator: delta_nonzero
+  description: 6g MulticastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.MulticastPacketsReceived
+    verify: api_after_6g.MulticastPacketsReceived
+  reference_delta:
+    baseline: drv_before_6g.DriverMulticastPacketsReceived6g
+    verify: drv_after_6g.DriverMulticastPacketsReceived6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g MulticastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.MulticastPacketsReceived
+    verify: api_after_24g.MulticastPacketsReceived
+  operator: delta_nonzero
+  description: 24g MulticastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.MulticastPacketsReceived
+    verify: api_after_24g.MulticastPacketsReceived
+  reference_delta:
+    baseline: drv_before_24g.DriverMulticastPacketsReceived24g
+    verify: drv_after_24g.DriverMulticastPacketsReceived24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g MulticastPacketsReceived delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D272_getradiostats_multicastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D272_getradiostats_multicastpacketssent.yaml
@@ -93,7 +93,7 @@ steps:
   action: exec
   target: DUT
   band: 5g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  command: ping -I br-lan -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastTx5g=" $1; exit}'
   depends_on: step3_5g_drv_before
   capture: trigger_5g
 - id: step5_5g_api_after
@@ -144,7 +144,7 @@ steps:
   action: exec
   target: DUT
   band: 6g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  command: ping -I br-lan -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastTx6g=" $1; exit}'
   depends_on: step9_6g_drv_before
   capture: trigger_6g
 - id: step11_6g_api_after
@@ -195,7 +195,7 @@ steps:
   action: exec
   target: DUT
   band: 2.4g
-  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  command: ping -I br-lan -c 8 -W 1 224.0.0.1 2>&1 | awk '/packets transmitted/ {print "TriggerMcastTx24g=" $1; exit}'
   depends_on: step15_24g_drv_before
   capture: trigger_24g
 - id: step17_24g_api_after

--- a/plugins/wifi_llapi/cases/D272_getradiostats_multicastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D272_getradiostats_multicastpacketssent.yaml
@@ -1,49 +1,259 @@
 id: d272-getradiostats-multicastpacketssent
-name: D272 getRadioStats MulticastPacketsSent
+name: D272 getRadioStats MulticastPacketsSent (delta)
+version: '1.0'
 source:
   row: 272
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate MulticastPacketsSent counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: DUT sends traffic toward STA (Tx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  DUT-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  MulticastPacketsSent delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl0:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent5g=%s\n'' "$r"'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl0:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent5g=%s\n'' "$r"'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl1:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent6g=%s\n'' "$r"'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl1:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent6g=%s\n'' "$r"'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl2:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent24g=%s\n'' "$r"'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; w=0; tx=$(wl -i "$ap" if_counters | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txmulti \([0-9][0-9]*\).*/\1/p''); w=$((w+${v:-0})); done; t=$(( ${tx:-0}+w )); b=$(awk ''$1=="wl2:" {print $24}'' /proc/net/dev_extstats); [ "${t:-0}" -ge "${b:-0}" ] && r=$((t-b)) || r=0; printf ''DriverMulticastPacketsSent24g=%s\n'' "$r"'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.MulticastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.MulticastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.MulticastPacketsSent
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.MulticastPacketsSent
+    verify: api_after_5g.MulticastPacketsSent
+  operator: delta_nonzero
+  description: 5g MulticastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.MulticastPacketsSent
+    verify: api_after_5g.MulticastPacketsSent
+  reference_delta:
+    baseline: drv_before_5g.DriverMulticastPacketsSent5g
+    verify: drv_after_5g.DriverMulticastPacketsSent5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g MulticastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.MulticastPacketsSent
+    verify: api_after_6g.MulticastPacketsSent
+  operator: delta_nonzero
+  description: 6g MulticastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.MulticastPacketsSent
+    verify: api_after_6g.MulticastPacketsSent
+  reference_delta:
+    baseline: drv_before_6g.DriverMulticastPacketsSent6g
+    verify: drv_after_6g.DriverMulticastPacketsSent6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g MulticastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.MulticastPacketsSent
+    verify: api_after_24g.MulticastPacketsSent
+  operator: delta_nonzero
+  description: 24g MulticastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.MulticastPacketsSent
+    verify: api_after_24g.MulticastPacketsSent
+  reference_delta:
+    baseline: drv_before_24g.DriverMulticastPacketsSent24g
+    verify: drv_after_24g.DriverMulticastPacketsSent24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g MulticastPacketsSent delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D273_getradiostats_packetsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D273_getradiostats_packetsreceived.yaml
@@ -1,49 +1,259 @@
 id: d273-getradiostats-packetsreceived
-name: D273 getRadioStats PacketsReceived
+name: D273 getRadioStats PacketsReceived (delta)
+version: '1.0'
 source:
   row: 273
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate PacketsReceived counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: STA sends traffic toward DUT (Rx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  STA-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  PacketsReceived delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 5g
+  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 6g
+  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 2.4g
+  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsReceived24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.PacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.PacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.PacketsReceived
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.PacketsReceived
+    verify: api_after_5g.PacketsReceived
+  operator: delta_nonzero
+  description: 5g PacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.PacketsReceived
+    verify: api_after_5g.PacketsReceived
+  reference_delta:
+    baseline: drv_before_5g.DriverPacketsReceived5g
+    verify: drv_after_5g.DriverPacketsReceived5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g PacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.PacketsReceived
+    verify: api_after_6g.PacketsReceived
+  operator: delta_nonzero
+  description: 6g PacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.PacketsReceived
+    verify: api_after_6g.PacketsReceived
+  reference_delta:
+    baseline: drv_before_6g.DriverPacketsReceived6g
+    verify: drv_after_6g.DriverPacketsReceived6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g PacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.PacketsReceived
+    verify: api_after_24g.PacketsReceived
+  operator: delta_nonzero
+  description: 24g PacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.PacketsReceived
+    verify: api_after_24g.PacketsReceived
+  reference_delta:
+    baseline: drv_before_24g.DriverPacketsReceived24g
+    verify: drv_after_24g.DriverPacketsReceived24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g PacketsReceived delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D274_getradiostats_packetssent.yaml
+++ b/plugins/wifi_llapi/cases/D274_getradiostats_packetssent.yaml
@@ -1,49 +1,259 @@
 id: d274-getradiostats-packetssent
-name: D274 getRadioStats PacketsSent
+name: D274 getRadioStats PacketsSent (delta)
+version: '1.0'
 source:
   row: 274
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate PacketsSent counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: DUT sends traffic toward STA (Tx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  DUT-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  PacketsSent delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'base=$(wl -i wl0 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent5g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'base=$(wl -i wl1 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent6g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'base=$(wl -i wl2 if_counters | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do v=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*txframe \([0-9][0-9]*\).*/\1/p''); wds=$((wds+${v:-0})); done; printf ''DriverPacketsSent24g=%s\n'' $(( ${base:-0}+wds ))'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.PacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.PacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.PacketsSent
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.PacketsSent
+    verify: api_after_5g.PacketsSent
+  operator: delta_nonzero
+  description: 5g PacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.PacketsSent
+    verify: api_after_5g.PacketsSent
+  reference_delta:
+    baseline: drv_before_5g.DriverPacketsSent5g
+    verify: drv_after_5g.DriverPacketsSent5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g PacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.PacketsSent
+    verify: api_after_6g.PacketsSent
+  operator: delta_nonzero
+  description: 6g PacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.PacketsSent
+    verify: api_after_6g.PacketsSent
+  reference_delta:
+    baseline: drv_before_6g.DriverPacketsSent6g
+    verify: drv_after_6g.DriverPacketsSent6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g PacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.PacketsSent
+    verify: api_after_24g.PacketsSent
+  operator: delta_nonzero
+  description: 24g PacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.PacketsSent
+    verify: api_after_24g.PacketsSent
+  reference_delta:
+    baseline: drv_before_24g.DriverPacketsSent24g
+    verify: drv_after_24g.DriverPacketsSent24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g PacketsSent delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D275_getradiostats_unicastpacketsreceived.yaml
+++ b/plugins/wifi_llapi/cases/D275_getradiostats_unicastpacketsreceived.yaml
@@ -1,49 +1,259 @@
 id: d275-getradiostats-unicastpacketsreceived
-name: D275 getRadioStats UnicastPacketsReceived
+name: D275 getRadioStats UnicastPacketsReceived (delta)
+version: '1.0'
 source:
   row: 275
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate UnicastPacketsReceived counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: STA sends traffic toward DUT (Rx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  STA-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  UnicastPacketsReceived delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'bf=$(wl -i wl0 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl0 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived5g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 5g
+  command: ping -I wl0 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'bf=$(wl -i wl0 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl0 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived5g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'bf=$(wl -i wl1 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl1 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived6g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 6g
+  command: ping -I wl1 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'bf=$(wl -i wl1 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl1 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived6g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'bf=$(wl -i wl2 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl2 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived24g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: STA
+  band: 2.4g
+  command: ping -I wl2 -c 8 -W 1 192.168.1.1 2>&1 | awk '/packets transmitted/ {print "TriggerRxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'bf=$(wl -i wl2 if_counters | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); bm=$(wl -i wl2 if_counters | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=0; wm=0; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do f=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxframe \([0-9][0-9]*\).*/\1/p''); m=$(wl -i "$ifn" if_counters 2>/dev/null | sed -n ''s/.*rxmulti \([0-9][0-9]*\).*/\1/p''); wf=$((wf+${f:-0})); wm=$((wm+${m:-0})); done; printf ''DriverUnicastPacketsReceived24g=%s\n'' $(( (${bf:-0}+wf) - (${bm:-0}+wm) ))'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.UnicastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.UnicastPacketsReceived
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.UnicastPacketsReceived
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.UnicastPacketsReceived
+    verify: api_after_5g.UnicastPacketsReceived
+  operator: delta_nonzero
+  description: 5g UnicastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.UnicastPacketsReceived
+    verify: api_after_5g.UnicastPacketsReceived
+  reference_delta:
+    baseline: drv_before_5g.DriverUnicastPacketsReceived5g
+    verify: drv_after_5g.DriverUnicastPacketsReceived5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g UnicastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.UnicastPacketsReceived
+    verify: api_after_6g.UnicastPacketsReceived
+  operator: delta_nonzero
+  description: 6g UnicastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.UnicastPacketsReceived
+    verify: api_after_6g.UnicastPacketsReceived
+  reference_delta:
+    baseline: drv_before_6g.DriverUnicastPacketsReceived6g
+    verify: drv_after_6g.DriverUnicastPacketsReceived6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g UnicastPacketsReceived delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.UnicastPacketsReceived
+    verify: api_after_24g.UnicastPacketsReceived
+  operator: delta_nonzero
+  description: 24g UnicastPacketsReceived must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.UnicastPacketsReceived
+    verify: api_after_24g.UnicastPacketsReceived
+  reference_delta:
+    baseline: drv_before_24g.DriverUnicastPacketsReceived24g
+    verify: drv_after_24g.DriverUnicastPacketsReceived24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g UnicastPacketsReceived delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D276_getradiostats_unicastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D276_getradiostats_unicastpacketssent.yaml
@@ -1,49 +1,259 @@
 id: d276-getradiostats-unicastpacketssent
-name: D276 getRadioStats UnicastPacketsSent
+name: D276 getRadioStats UnicastPacketsSent (delta)
+version: '1.0'
 source:
   row: 276
   object: WiFi.Radio.{i}.
   api: getRadioStats()
+platform:
+  prplos: 4.0.3
+  bdk: 6.3.1
+hlapi_command: 'ubus-cli "WiFi.Radio.{i}.getRadioStats()"'
+llapi_support: Support
+implemented_by: pWHM
 bands:
 - 5g
 - 6g
 - 2.4g
-llapi_support: Support
 topology:
   devices:
     DUT:
       role: ap
       transport: serial
+      selector: COM0
+    STA:
+      role: sta
+      transport: serial
       selector: COM1
+      config:
+      - iface: wl0
+        mode: sta
+        band: 5g
+        ssid: testpilot5G
+        security: WPA2-Personal
+        key: '00000000'
+      - iface: wl1
+        mode: sta
+        band: 6g
+        ssid: testpilot6G
+        security: WPA3-Personal
+        key_mgmt: SAE
+        key: '00000000'
+      - iface: wl2
+        mode: sta
+        band: 2.4g
+        ssid: testpilot2G
+        security: WPA2-Personal
+        key: '00000000'
+  links:
+  - from: STA
+    to: DUT
+    band: 5g
+  - from: STA
+    to: DUT
+    band: 6g
+  - from: STA
+    to: DUT
+    band: 2.4g
+test_environment: 'Topology: DUT (AP) + STA; validate UnicastPacketsSent counter delta on
+  5G, 6G, 2.4G sequentially. Trigger: DUT sends traffic toward STA (Tx counter).'
+test_procedure: '1) Per band: capture api_before and drv_before baseline. 2) Trigger
+  DUT-generated traffic. 3) Capture api_after and drv_after. 4) Verify
+  UnicastPacketsSent delta is nonzero and matches the driver delta within tolerance.'
 steps:
-- id: step_5g_stats
-  target: dut
-  action: read
-  capture: stats_5g
+- id: step1_5g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 5g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl0 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl0/address | tr 'A-F' 'a-f' | sed 's/^/StaMac5g=/'
+  - ifconfig wl0 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl0 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp5g=" $2; exit}'
+  capture: sta_ready_5g
+- id: step2_5g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
   command: ubus-cli "WiFi.Radio.1.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.1 (5g) getRadioStats()
-- id: step_6g_stats
-  target: dut
-  action: read
-  capture: stats_6g
+  depends_on: step1_5g_sta_ready
+  capture: api_before_5g
+- id: step3_5g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
+  depends_on: step2_5g_api_before
+  capture: drv_before_5g
+- id: step4_5g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 5g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets5g=" $1; exit}'
+  depends_on: step3_5g_drv_before
+  capture: trigger_5g
+- id: step5_5g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: ubus-cli "WiFi.Radio.1.getRadioStats()"
+  depends_on: step4_5g_trigger
+  capture: api_after_5g
+- id: step6_5g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 5g
+  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
+  depends_on: step5_5g_api_after
+  capture: drv_after_5g
+- id: step7_6g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 6g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl1 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl1/address | tr 'A-F' 'a-f' | sed 's/^/StaMac6g=/'
+  - ifconfig wl1 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl1 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp6g=" $2; exit}'
+  capture: sta_ready_6g
+- id: step8_6g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
   command: ubus-cli "WiFi.Radio.2.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.2 (6g) getRadioStats()
-- id: step_24g_stats
-  target: dut
-  action: read
-  capture: stats_24g
+  depends_on: step7_6g_sta_ready
+  capture: api_before_6g
+- id: step9_6g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
+  depends_on: step8_6g_api_before
+  capture: drv_before_6g
+- id: step10_6g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 6g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets6g=" $1; exit}'
+  depends_on: step9_6g_drv_before
+  capture: trigger_6g
+- id: step11_6g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: ubus-cli "WiFi.Radio.2.getRadioStats()"
+  depends_on: step10_6g_trigger
+  capture: api_after_6g
+- id: step12_6g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 6g
+  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
+  depends_on: step11_6g_api_after
+  capture: drv_after_6g
+- id: step13_24g_sta_ready
+  phase: baseline
+  action: exec
+  target: STA
+  band: 2.4g
+  command:
+  - wpa_cli -p /var/run/wpa_supplicant -i wl2 status | sed -n 's/^wpa_state=/wpa_state=/p; s/^ssid=/ssid=/p'
+  - cat /sys/class/net/wl2/address | tr 'A-F' 'a-f' | sed 's/^/StaMac24g=/'
+  - ifconfig wl2 192.168.1.3 netmask 255.255.255.0 up
+  - ip -4 addr show dev wl2 | awk '/inet / {sub(/\/24$/, "", $2); print "StaIp24g=" $2; exit}'
+  capture: sta_ready_24g
+- id: step14_24g_api_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
   command: ubus-cli "WiFi.Radio.3.getRadioStats()"
-  expected: getRadioStats() 回傳有效值
-  description: Radio.3 (2.4g) getRadioStats()
+  depends_on: step13_24g_sta_ready
+  capture: api_before_24g
+- id: step15_24g_drv_before
+  phase: baseline
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
+  depends_on: step14_24g_api_before
+  capture: drv_before_24g
+- id: step16_24g_trigger
+  phase: trigger
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ping -I br-lan -c 8 -W 1 192.168.1.3 2>&1 | awk '/packets transmitted/ {print "TriggerTxPackets24g=" $1; exit}'
+  depends_on: step15_24g_drv_before
+  capture: trigger_24g
+- id: step17_24g_api_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: ubus-cli "WiFi.Radio.3.getRadioStats()"
+  depends_on: step16_24g_trigger
+  capture: api_after_24g
+- id: step18_24g_drv_after
+  phase: verify
+  action: exec
+  target: DUT
+  band: 2.4g
+  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
+  depends_on: step17_24g_api_after
+  capture: drv_after_24g
 pass_criteria:
-- field: stats_5g.UnicastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_6g.UnicastPacketsSent
-  operator: regex
-  value: ^\d+$
-- field: stats_24g.UnicastPacketsSent
-  operator: regex
-  value: ^\d+$
+- delta:
+    baseline: api_before_5g.UnicastPacketsSent
+    verify: api_after_5g.UnicastPacketsSent
+  operator: delta_nonzero
+  description: 5g UnicastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_5g.UnicastPacketsSent
+    verify: api_after_5g.UnicastPacketsSent
+  reference_delta:
+    baseline: drv_before_5g.DriverUnicastPacketsSent5g
+    verify: drv_after_5g.DriverUnicastPacketsSent5g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 5g UnicastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_6g.UnicastPacketsSent
+    verify: api_after_6g.UnicastPacketsSent
+  operator: delta_nonzero
+  description: 6g UnicastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_6g.UnicastPacketsSent
+    verify: api_after_6g.UnicastPacketsSent
+  reference_delta:
+    baseline: drv_before_6g.DriverUnicastPacketsSent6g
+    verify: drv_after_6g.DriverUnicastPacketsSent6g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 6g UnicastPacketsSent delta must stay within ±10% of the driver delta.
+- delta:
+    baseline: api_before_24g.UnicastPacketsSent
+    verify: api_after_24g.UnicastPacketsSent
+  operator: delta_nonzero
+  description: 24g UnicastPacketsSent must increase after traffic trigger.
+- delta:
+    baseline: api_before_24g.UnicastPacketsSent
+    verify: api_after_24g.UnicastPacketsSent
+  reference_delta:
+    baseline: drv_before_24g.DriverUnicastPacketsSent24g
+    verify: drv_after_24g.DriverUnicastPacketsSent24g
+  operator: delta_match
+  tolerance_pct: 10
+  description: 24g UnicastPacketsSent delta must stay within ±10% of the driver delta.

--- a/plugins/wifi_llapi/cases/D276_getradiostats_unicastpacketssent.yaml
+++ b/plugins/wifi_llapi/cases/D276_getradiostats_unicastpacketssent.yaml
@@ -85,7 +85,7 @@ steps:
   action: exec
   target: DUT
   band: 5g
-  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
+  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
   depends_on: step2_5g_api_before
   capture: drv_before_5g
 - id: step4_5g_trigger
@@ -109,7 +109,7 @@ steps:
   action: exec
   target: DUT
   band: 5g
-  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
+  command: 'ap=wl0; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds0\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent5g=%s\n'' "$r"'
   depends_on: step5_5g_api_after
   capture: drv_after_5g
 - id: step7_6g_sta_ready
@@ -136,7 +136,7 @@ steps:
   action: exec
   target: DUT
   band: 6g
-  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
+  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
   depends_on: step8_6g_api_before
   capture: drv_before_6g
 - id: step10_6g_trigger
@@ -160,7 +160,7 @@ steps:
   action: exec
   target: DUT
   band: 6g
-  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
+  command: 'ap=wl1; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds1\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent6g=%s\n'' "$r"'
   depends_on: step11_6g_api_after
   capture: drv_after_6g
 - id: step13_24g_sta_ready
@@ -187,7 +187,7 @@ steps:
   action: exec
   target: DUT
   band: 2.4g
-  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
+  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
   depends_on: step14_24g_api_before
   capture: drv_before_24g
 - id: step16_24g_trigger
@@ -211,7 +211,7 @@ steps:
   action: exec
   target: DUT
   band: 2.4g
-  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txmulti /{print $2}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
+  command: 'ap=wl2; wf=0; wm=0; set -- $(wl -i "$ap" if_counters | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); tf=${1:-0}; tm=${2:-0}; for ifn in $(ls /sys/class/net/ | grep -E ''^wds2\.0\.[0-9]+$'' || true); do set -- $(wl -i "$ifn" if_counters 2>/dev/null | awk ''/^txframe /{print $2} /^d11_txfrag /{print $4}''); wf=$((wf+${1:-0})); wm=$((wm+${2:-0})); done; r=$(( ((tf+wf)-(tm+wm)) & 0xffffffff )); printf ''DriverUnicastPacketsSent24g=%s\n'' "$r"'
   depends_on: step17_24g_api_after
   capture: drv_after_24g
 pass_criteria:

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py
@@ -36,7 +36,7 @@ def test_official_case_command_lengths_fit_transport_budget_summary():
                     if isinstance(item, str) and len(item) > threshold:
                         violations.append(f"{yaml_path.name}:{field}[{index}]:{len(item)}")
 
-    assert len(violations) == 973, (
+    assert len(violations) == 1021, (
         "Official-case >120-char command inventory changed; "
         "review whether this was an intended calibration update.\n"
         + "\n".join(violations[:40])

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -19890,22 +19890,11 @@ _METHOD_STATS_CASES = [
     ("D259_getradioairstats_rxtime.yaml", 261, "getRadioAirStats", "RxTime", "0", "0", "0"),
     ("D260_getradioairstats_totaltime.yaml", 262, "getRadioAirStats", "TotalTime", "3", "26", "17"),
     ("D261_getradioairstats_txtime.yaml", 261, "getRadioAirStats", "TxTime", "0", "0", "1"),
-    # getRadioStats field cases — workbook Pass
-    ("D263_getradiostats_broadcastpacketsreceived.yaml", 263, "getRadioStats", "BroadcastPacketsReceived", "0", "0", "0"),
-    ("D264_getradiostats_broadcastpacketssent.yaml", 264, "getRadioStats", "BroadcastPacketsSent", "0", "0", "0"),
-    ("D265_getradiostats_bytesreceived.yaml", 265, "getRadioStats", "BytesReceived", "185053", "0", "0"),
-    ("D266_getradiostats_bytessent.yaml", 266, "getRadioStats", "BytesSent", "573376410", "383599818", "383764788"),
     ("D267_getradiostats_discardpacketsreceived.yaml", 267, "getRadioStats", "DiscardPacketsReceived", "784", "175", "183"),
     # --- Batch 3: D268-D276 remaining getRadioStats fields ---
     ("D268_getradiostats_discardpacketssent.yaml", 268, "getRadioStats", "DiscardPacketsSent", "0", "0", "0"),
     ("D269_getradiostats_errorsreceive.yaml", 269, "getRadioStats", "ErrorsReceived", "20", "8", "13"),
     ("D270_getradiostats_errorssent.yaml", 270, "getRadioStats", "ErrorsSent", "0", "0", "0"),
-    ("D271_getradiostats_multicastpacketsreceived.yaml", 271, "getRadioStats", "MulticastPacketsReceived", "4", "0", "0"),
-    ("D272_getradiostats_multicastpacketssent.yaml", 272, "getRadioStats", "MulticastPacketsSent", "628763", "824904", "567311"),
-    ("D273_getradiostats_packetsreceived.yaml", 273, "getRadioStats", "PacketsReceived", "264", "0", "0"),
-    ("D274_getradiostats_packetssent.yaml", 274, "getRadioStats", "PacketsSent", "1040842", "824935", "825369"),
-    ("D275_getradiostats_unicastpacketsreceived.yaml", 275, "getRadioStats", "UnicastPacketsReceived", "1673", "0", "0"),
-    ("D276_getradiostats_unicastpacketssent.yaml", 276, "getRadioStats", "UnicastPacketsSent", "1040842", "824935", "825369"),
     # --- Batch 5c: getRadioStats fields ---
     ("D394_bytesreceived_radio_stats.yaml", 289, "getRadioStats", "BytesReceived", "189265", "0", "0"),
     ("D395_bytessent_radio_stats.yaml", 290, "getRadioStats", "BytesSent", "588249079", "393557814", "393818836"),
@@ -19931,6 +19920,69 @@ _METHOD_STATS_CASES = [
     ("D402_getradiostats_retrycount.yaml", 460, "getRadioStats", "RetryCount", "0", "0", "0"),
     ("D459_getradiostats_temperature.yaml", 459, "getRadioStats", "Temperature", "76", "85", "80"),
 ]
+
+_WAVE3_RADIOSTATS_TRAFFIC_DELTA_CASES = {
+    "D263_getradiostats_broadcastpacketsreceived.yaml": {
+        "row": 263,
+        "api": "BroadcastPacketsReceived",
+        "driver_field": "DriverBroadcastPacketsReceived",
+        "trigger_target": "STA",
+    },
+    "D264_getradiostats_broadcastpacketssent.yaml": {
+        "row": 264,
+        "api": "BroadcastPacketsSent",
+        "driver_field": "DriverBroadcastPacketsSent",
+        "trigger_target": "DUT",
+    },
+    "D265_getradiostats_bytesreceived.yaml": {
+        "row": 265,
+        "api": "BytesReceived",
+        "driver_field": "DriverBytesReceived",
+        "trigger_target": "STA",
+    },
+    "D266_getradiostats_bytessent.yaml": {
+        "row": 266,
+        "api": "BytesSent",
+        "driver_field": "DriverBytesSent",
+        "trigger_target": "DUT",
+    },
+    "D271_getradiostats_multicastpacketsreceived.yaml": {
+        "row": 271,
+        "api": "MulticastPacketsReceived",
+        "driver_field": "DriverMulticastPacketsReceived",
+        "trigger_target": "STA",
+    },
+    "D272_getradiostats_multicastpacketssent.yaml": {
+        "row": 272,
+        "api": "MulticastPacketsSent",
+        "driver_field": "DriverMulticastPacketsSent",
+        "trigger_target": "DUT",
+    },
+    "D273_getradiostats_packetsreceived.yaml": {
+        "row": 273,
+        "api": "PacketsReceived",
+        "driver_field": "DriverPacketsReceived",
+        "trigger_target": "STA",
+    },
+    "D274_getradiostats_packetssent.yaml": {
+        "row": 274,
+        "api": "PacketsSent",
+        "driver_field": "DriverPacketsSent",
+        "trigger_target": "DUT",
+    },
+    "D275_getradiostats_unicastpacketsreceived.yaml": {
+        "row": 275,
+        "api": "UnicastPacketsReceived",
+        "driver_field": "DriverUnicastPacketsReceived",
+        "trigger_target": "STA",
+    },
+    "D276_getradiostats_unicastpacketssent.yaml": {
+        "row": 276,
+        "api": "UnicastPacketsSent",
+        "driver_field": "DriverUnicastPacketsSent",
+        "trigger_target": "DUT",
+    },
+}
 
 _METHOD_IDS = [t[0].split(".")[0] for t in _METHOD_STATS_CASES]
 
@@ -20008,6 +20060,59 @@ def test_method_stats_evaluate(yaml_file, row, method, field, live_5g, live_6g, 
             "success": True, "output": output, "timing": 0.01,
         }
     assert plugin.evaluate(case, results) is True
+
+
+def test_wave3_getradiostats_counter_cases_use_multiband_delta_contracts():
+    cases_dir = Path(__file__).resolve().parents[3] / "plugins" / "wifi_llapi" / "cases"
+
+    for filename, meta in _WAVE3_RADIOSTATS_TRAFFIC_DELTA_CASES.items():
+        raw_case = yaml.safe_load((cases_dir / filename).read_text(encoding="utf-8"))
+        case_data = load_case(cases_dir / filename)
+        commands = "\n".join(str(step.get("command", "")) for step in case_data["steps"])
+        links = {link["band"] for link in case_data["topology"]["links"]}
+        phases = [step.get("phase") for step in case_data["steps"]]
+        trigger_steps = [step for step in case_data["steps"] if step.get("phase") == "trigger"]
+
+        assert "aliases" not in raw_case
+        assert case_data["source"]["row"] == meta["row"]
+        assert case_data["llapi_support"] == "Support"
+        assert case_data["bands"] == ["5g", "6g", "2.4g"]
+        assert {"DUT", "STA"}.issubset(case_data["topology"]["devices"])
+        assert links == {"5g", "6g", "2.4g"}
+        assert len(case_data["steps"]) >= 15
+        assert phases.count("baseline") >= 6
+        assert phases.count("trigger") == 3
+        assert phases.count("verify") >= 6
+        assert len(trigger_steps) == 3
+        assert all(step["target"] == meta["trigger_target"] for step in trigger_steps)
+        assert f'{meta["driver_field"]}5g=' in commands
+        assert f'{meta["driver_field"]}6g=' in commands
+        assert f'{meta["driver_field"]}24g=' in commands
+
+        for capture_suffix in ("5g", "6g", "24g"):
+            assert any(
+                criterion.get("operator") == "delta_nonzero"
+                and criterion.get("delta")
+                == {
+                    "baseline": f"api_before_{capture_suffix}.{meta['api']}",
+                    "verify": f"api_after_{capture_suffix}.{meta['api']}",
+                }
+                for criterion in case_data["pass_criteria"]
+            )
+            assert any(
+                criterion.get("operator") == "delta_match"
+                and criterion.get("delta")
+                == {
+                    "baseline": f"api_before_{capture_suffix}.{meta['api']}",
+                    "verify": f"api_after_{capture_suffix}.{meta['api']}",
+                }
+                and criterion.get("reference_delta")
+                == {
+                    "baseline": f"drv_before_{capture_suffix}.{meta['driver_field']}{capture_suffix}",
+                    "verify": f"drv_after_{capture_suffix}.{meta['driver_field']}{capture_suffix}",
+                }
+                for criterion in case_data["pass_criteria"]
+            )
 
 
 # --- D262 getRadioAirStats():void ---

--- a/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
+++ b/plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py
@@ -19927,12 +19927,16 @@ _WAVE3_RADIOSTATS_TRAFFIC_DELTA_CASES = {
         "api": "BroadcastPacketsReceived",
         "driver_field": "DriverBroadcastPacketsReceived",
         "trigger_target": "STA",
+        # broadcast Rx: STA-side arping ensures broadcast frames are generated
+        "trigger_assert": "arping",
     },
     "D264_getradiostats_broadcastpacketssent.yaml": {
         "row": 264,
         "api": "BroadcastPacketsSent",
         "driver_field": "DriverBroadcastPacketsSent",
         "trigger_target": "DUT",
+        # broadcast Tx: DUT-side arping ensures broadcast frames are sent
+        "trigger_assert": "arping",
     },
     "D265_getradiostats_bytesreceived.yaml": {
         "row": 265,
@@ -19951,12 +19955,16 @@ _WAVE3_RADIOSTATS_TRAFFIC_DELTA_CASES = {
         "api": "MulticastPacketsReceived",
         "driver_field": "DriverMulticastPacketsReceived",
         "trigger_target": "STA",
+        # multicast Rx: STA sends to all-hosts multicast group 224.0.0.1
+        "trigger_assert": "224.0.0.1",
     },
     "D272_getradiostats_multicastpacketssent.yaml": {
         "row": 272,
         "api": "MulticastPacketsSent",
         "driver_field": "DriverMulticastPacketsSent",
         "trigger_target": "DUT",
+        # multicast Tx: DUT sends to all-hosts multicast group 224.0.0.1
+        "trigger_assert": "224.0.0.1",
     },
     "D273_getradiostats_packetsreceived.yaml": {
         "row": 273,
@@ -19981,6 +19989,9 @@ _WAVE3_RADIOSTATS_TRAFFIC_DELTA_CASES = {
         "api": "UnicastPacketsSent",
         "driver_field": "DriverUnicastPacketsSent",
         "trigger_target": "DUT",
+        # D276 driver must use d11_txfrag/$4 extraction (aligned with D336 prior art)
+        "drv_assert_contains": "d11_txfrag",
+        "drv_assert_excludes": "d11_txmulti",
     },
 }
 
@@ -20088,6 +20099,23 @@ def test_wave3_getradiostats_counter_cases_use_multiband_delta_contracts():
         assert f'{meta["driver_field"]}5g=' in commands
         assert f'{meta["driver_field"]}6g=' in commands
         assert f'{meta["driver_field"]}24g=' in commands
+
+        # Per-case trigger and driver formula assertions
+        if "trigger_assert" in meta:
+            trigger_commands = "\n".join(
+                str(s.get("command", "")) for s in trigger_steps
+            )
+            assert meta["trigger_assert"] in trigger_commands, (
+                f"{filename}: trigger_assert '{meta['trigger_assert']}' not found in trigger steps"
+            )
+        if "drv_assert_contains" in meta:
+            assert meta["drv_assert_contains"] in commands, (
+                f"{filename}: drv_assert_contains '{meta['drv_assert_contains']}' not found"
+            )
+        if "drv_assert_excludes" in meta:
+            assert meta["drv_assert_excludes"] not in commands, (
+                f"{filename}: drv_assert_excludes '{meta['drv_assert_excludes']}' unexpectedly present"
+            )
 
         for capture_suffix in ("5g", "6g", "24g"):
             assert any(


### PR DESCRIPTION
## Summary

- migrate the Wave 3 `wave3-getradiostats-bcast-mcast-bytes` family to multiband baseline/trigger/verify delta contracts
- replace stale workbook/proc heuristics with source-backed radio driver formulas for `D263-D266` and `D271-D276`
- fix the reviewer-found gaps by aligning `D276` with the validated `D336` `d11_txfrag` extractor and making the broadcast/multicast triggers deterministic
- mark OpenSpec task `9.3` complete for this sub-PR

## Case scope

- migrated: `D263`, `D264`, `D265`, `D266`, `D271`, `D272`, `D273`, `D274`, `D275`, `D276`

## Notes

- `D263` / `D264` now use `arping` triggers so broadcast deltas do not depend on ambient traffic
- `D271` / `D272` now use `224.0.0.1` multicast probes so `delta_nonzero` exercises the actual multicast path
- `D276` now follows the same `d11_txfrag` extraction pattern as `D336` instead of the unverified `d11_txmulti` matcher
- command-budget guard updated from `973` to `1021`
- OpenSpec archive remains deferred until the overall Wave 3 closeout

## Validation

- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py -k wave3_getradiostats_counter_cases_use_multiband_delta_contracts`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_command_budget.py`
- `PYTHONPATH=.:src:plugins/wifi_llapi uv run pytest -q plugins/wifi_llapi/tests/test_wifi_llapi_plugin_runtime.py`
- `openspec validate wifi-llapi-counter-delta-validation --strict`
